### PR TITLE
Fixed some messages not resulting in status :done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+* Bugfix for `clojure.tools.nrepl.middleware.session` for `:unknown-session`
+  error and `clojure.tools.nrepl.middleware.interruptible-eval` for `:no-code`
+  error, the correct response of `:status :done` is now being returned.
+
 [`0.3.0`](https://github.com/nrepl/nREPL/milestone/2?closed=1):
 
 * Materially identical to `[org.clojure/tools.nrepl "0.2.13"]`, but released under

--- a/src/clojure/clojure/tools/nrepl/bencode.clj
+++ b/src/clojure/clojure/tools/nrepl/bencode.clj
@@ -13,11 +13,11 @@
   (:require [clojure.java.io :as io])
   (:import clojure.lang.RT
            [java.io ByteArrayOutputStream
-                    EOFException
-                    InputStream
-                    IOException
-                    OutputStream
-                    PushbackInputStream]))
+            EOFException
+            InputStream
+            IOException
+            OutputStream
+            PushbackInputStream]))
 
 ;; # Motivation
 ;;

--- a/src/clojure/clojure/tools/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/clojure/tools/nrepl/middleware/interruptible_eval.clj
@@ -210,7 +210,7 @@
       (case op
         "eval"
         (if-not (:code msg)
-          (t/send transport (response-for msg :status #{:error :no-code}))
+          (t/send transport (response-for msg :status #{:error :no-code :done}))
           (queue-eval session executor
                       (fn []
                         (alter-meta! session assoc

--- a/src/clojure/clojure/tools/nrepl/middleware/session.clj
+++ b/src/clojure/clojure/tools/nrepl/middleware/session.clj
@@ -176,7 +176,7 @@
                         (@sessions session)
                         (create-session transport))]
       (if-not the-session
-        (t/send transport (response-for msg :status #{:error :unknown-session}))
+        (t/send transport (response-for msg :status #{:error :unknown-session :done}))
         (let [msg (assoc msg :session the-session)]
           ;; TODO yak, this is ugly; need to cleanly thread out-limit through to
           ;; session-out without abusing a dynamic var

--- a/test/clojure/clojure/tools/nrepl_test.clj
+++ b/test/clojure/clojure/tools/nrepl_test.clj
@@ -107,7 +107,7 @@
          (-> (message timeout-client {:op :abc}) combine-responses (select-keys [:op :status])))))
 
 (def-repl-test session-lifecycle
-  (is (= #{"error" "unknown-session"}
+  (is (= #{"error" "unknown-session" "done"}
          (-> (message timeout-client {:session "abc"}) combine-responses :status)))
   (let [session-id (new-session timeout-client)
         session-alive? #(contains? (-> (message timeout-client {:op :ls-sessions})

--- a/test/clojure/clojure/tools/nrepl_test.clj
+++ b/test/clojure/clojure/tools/nrepl_test.clj
@@ -102,6 +102,10 @@
     (is (= (:line meta) 42))
     (is (= (:column meta) (if (< (:minor *clojure-version*) 5) nil 10)))))
 
+(def-repl-test no-code
+  (is (= {:status #{"error" "no-code" "done"}}
+         (-> (message timeout-client {:op "eval"}) combine-responses (select-keys [:status])))))
+
 (def-repl-test unknown-op
   (is (= {:op "abc" :status #{"error" "unknown-op" "done"}}
          (-> (message timeout-client {:op :abc}) combine-responses (select-keys [:op :status])))))


### PR DESCRIPTION
Fix for :status :done, issue https://github.com/nrepl/nREPL/issues/15

The fix for it was created over 3 years ago, I'm just applying it here.

The original patch was submitted by
@Dirklectisch on 30/Mar/15 10:26 AM

His description of the problem:

According to the documentation:

"Once a handler has completely processed a message, a response
containing a `:status` of `:done` must be sent."

I am assuming this includes messages that have resulted in an
error. Some messages to an nREPL server never respond with such a
status possibly leaving some clients waiting for follow up messages
forever.

So far I have found two instances of this problem.

1. The interruptible-eval middleware may result in a :no-code error
that does not include the :done status.

2. The session middleware may result in a :unknown-session error that
does not include the :done status.

I'm including a patch for the above two which are just one word
fixes. There might be other situations in which the problem arises.