### PR TITLE
Make sure that we assign zero when port is nil

### DIFF
--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -136,8 +136,9 @@
    either via `stop-server`, (.close server), or automatically via `with-open`.
    The port that the server is open on is available in the :port slot of the
    server map (useful if the :port option is 0 or was left unspecified."
-  [& {:keys [port bind transport-fn handler ack-port greeting-fn] :or {port 0}}]
-  (let [addr (fn [^String bind ^Integer port] (InetSocketAddress. bind port))
+  [& {:keys [port bind transport-fn handler ack-port greeting-fn]}]
+  (let [port (or port 0)
+        addr (fn [^String bind ^Integer port] (InetSocketAddress. bind port))
         make-ss #(doto (ServerSocket.)
                    (.setReuseAddress true)
                    (.bind %))


### PR DESCRIPTION
This is required when the `:port` key is passed in but the value is `nil`:

```clojure
cider-nrepl.main> (let [{:keys [port bind] :or {port 0}}
                        {:bind nil
                         :port nil}]
                    port)
nil
```