### PR TITLE
Remove extra newline in output

### DIFF
--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -25,8 +25,8 @@
    (run-repl host port nil))
   ([host port {:keys [prompt err out value]
                :or {prompt #(print (str % "=> "))
-                    err println
-                    out println
+                    err print
+                    out print
                     value println}}]
    (let [transport (repl/connect :host host :port port)
          client (repl/client-session (repl/client transport Long/MAX_VALUE))


### PR DESCRIPTION
`:out` is now printed as it is, purely based on the user print statement (i.e., as opposed to `:value`, where a newline is added for convenience). AFAICT, the `:error` string also comes with a newline character in the end, so I changed that too.

This should fix #38.
