### PR TITLE
[WIP] #12: Value rendering function eval parameter

### DIFF
--- a/src/clojure/nrepl/middleware/pr_values.clj
+++ b/src/clojure/nrepl/middleware/pr_values.clj
@@ -16,7 +16,7 @@
    This allows evaluation contexts to produce printed results in :value
    if they so choose, and opt out of the printing here."
   [h]
-  (fn [{:keys [op ^Transport transport] :as msg}]
+  (fn [{:keys [op ^Transport transport renderf] :as msg}]
     (h (assoc msg
               :transport (reify Transport
                            (recv [this] (.recv transport))
@@ -27,6 +27,13 @@
                                       (dissoc resp :printed-value)
                                       (if-let [[_ v] (find resp :value)]
                                         (assoc resp
+                                               :value2 (let [repr (java.io.StringWriter.)]
+                                                         (apply
+                                                          (if renderf
+                                                            (eval (read-string renderf))
+                                                            #((if *print-dup* print-dup print-method)
+                                                              % repr))
+                                                          [v]))
                                                :value (let [repr (java.io.StringWriter.)]
                                                         (if *print-dup*
                                                           (print-dup v repr)


### PR DESCRIPTION
This is not ready to be merged, but the core of the change for #12 is here (I think--feedback welcome). I'll record my thoughts/questions here as I go.

Some questions:

Should a client be able to add multiple separate rendering functions?
=> No, b/c composition of functions can just be done inside a single :renderf string

(How) should symbols from the nrepl session be isolated from the rendering function?
=> I think the rendering function should be isolated from the nrepl session; that way the rendering function can't cause side effects on the nrepl session state and the nrepl session state can't influence the behavior of the rendering function. TODO: figure out if eval already does this or how to add it.

Sample nrepl-messages log (rendered values in value2):
```
   (-->
     id         "78"
     op         "eval"
     session    "dfcbdd42-eace-497e-8e6f-cb1c79f648c4"
     time-stamp "2018-10-13 23:02:07.091198000"
     code       "(zipmap [:a :b :c :d :e] (repeat (zipmap [:a :b :c :d :e] (take 5 (range)))))"
     renderf    "(fn [v] (let [repr (java.io.StringWriter.)] (clojure.pprint/pprint v repr) (str repr)))"
   )
   (<--
     id         "78"
     session    "dfcbdd42-eace-497e-8e6f-cb1c79f648c4"
     time-stamp "2018-10-13 23:02:07.222323000"
     ns         "user"
     value      "{:a {:a 0, :b 1, :c 2, :d 3, :e 4}, :b {:a 0, :b 1, :c 2, :d 3, :e 4}, :c {:a 0, :b 1, :c 2, :d 3, :e 4}, :d {:a 0, :b 1, :c 2, :d 3, :e 4}, :e {:a 0, :b 1, :c 2, :d 3, :e 4}}"
     value2     "{:a {:a 0, :b 1, :c 2, :d 3, :e 4},
    :b {:a 0, :b 1, :c 2, :d 3, :e 4},
    :c {:a 0, :b 1, :c 2, :d 3, :e 4},
    :d {:a 0, :b 1, :c 2, :d 3, :e 4},
    :e {:a 0, :b 1, :c 2, :d 3, :e 4}}
   "
   )
   (<--
     id         "78"
     session    "dfcbdd42-eace-497e-8e6f-cb1c79f648c4"
     time-stamp "2018-10-13 23:02:07.224126000"
     status     ("done")
   )
   (<--
     id                 "78"
     session            "dfcbdd42-eace-497e-8e6f-cb1c79f648c4"
     time-stamp         "2018-10-13 23:02:07.225471000"
     changed-namespaces (dict)
     repl-type          "clj"
     status             ("state")
   )
```
