### PR TITLE
[Fix #10] Bind *1, *2, *3 and *e in cloned session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### master (unreleased)
 
+#### Bugs fixed
+
+* [#10](https://github.com/nrepl/nREPL/issues/10): Bind *1, *2, *3 and *e in cloned session.
+
 ### 0.4.5 (2018-09-02)
 
 #### New features
@@ -19,7 +23,6 @@ with the built-in client to an already running nREPL server.
 #### Bugs fixed
 
 * [#38](https://github.com/nrepl/nREPL/issues/38): Remove extra newline in REPL output.
-* [#10](https://github.com/nrepl/nREPL/issues/10): Bind *1, *2, *3 and *e in cloned session.
 
 ### 0.4.4 (2018-07-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ with the built-in client to an already running nREPL server.
 #### Bugs fixed
 
 * [#38](https://github.com/nrepl/nREPL/issues/38): Remove extra newline in REPL output.
+* [#10](https://github.com/nrepl/nREPL/issues/10): Bind *1, *2, *3 and *e in cloned session.
 
 ### 0.4.4 (2018-07-31)
 

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -121,6 +121,10 @@
                  *in* stdin-reader
                  *ns* (create-ns 'user)
                  *out-limit* (or (baseline-bindings #'*out-limit*) 1024)
+                 *1 (baseline-bindings #'*1)
+                 *2 (baseline-bindings #'*2)
+                 *3 (baseline-bindings #'*3)
+                 *e (baseline-bindings #'*e)
                  ;; clojure.test captures *out* at load-time, so we need to make sure
                  ;; runtime output of test status/results is redirected properly
                  ;; TODO: is this something we need to consider in general, or is this


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings

This PR copies the bindings of *1, *2, *3 and *e to the new session when cloning a session. 
