### PR TITLE
Fix link to manual in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ code in remote environments.
 ### How is this different from the "contrib" [tools.nrepl](https://github.com/clojure/tools.nrepl/) project?
 
 Check the brief history of nREPL, available
-[here](https://docs.nrepl.xyz/en/latest/about/history/).
+[here](https://nrepl.xyz/nrepl/0.4.5/about/history.html).
 
 ### Status
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ the needs of the essential tools of the Clojure(Script) ecosystem
 
 ## Usage
 
-See the [manual](https://docs.nrepl.xyz).
+See the [manual](https://nrepl.xyz).
 
 ## License
 


### PR DESCRIPTION
This PR fixes the link to the manual.

The link to the history should be changed as well, but I'm not sure if there is a link available with "latest" to avoid having to specify the version number?
