### PR TITLE
Custom rendering logic for pr-values middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### New features
 
-* [#12](https://github.com/nrepl/nREPL/issues/10): Support custom rendering
+* [#12](https://github.com/nrepl/nREPL/issues/12): Support custom rendering
   function in `pr-values`, enabling pretty-printed REPL results.
 
 #### Bugs fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### master (unreleased)
 
+#### New features
+
+* [#12](https://github.com/nrepl/nREPL/issues/10): Support custom rendering
+  function in `pr-values`, enabling pretty-printed REPL results.
+
 #### Bugs fixed
 
 * [#10](https://github.com/nrepl/nREPL/issues/10): Bind *1, *2, *3 and *e in cloned session.

--- a/doc/modules/ROOT/pages/design/middleware.adoc
+++ b/doc/modules/ROOT/pages/design/middleware.adoc
@@ -166,3 +166,11 @@ value instead.
 
 This enables using libraries like link:https://github.com/greglook/puget[puget]
 to pretty-print the evaluation results automatically.
+
+[source,clojure]
+----
+{:op :eval
+ :code "(+ 1 1)"
+ :renderer 'my.custom/print-value
+ :render-options {:print-width 120}}
+----

--- a/doc/modules/ROOT/pages/design/middleware.adoc
+++ b/doc/modules/ROOT/pages/design/middleware.adoc
@@ -154,3 +154,15 @@ fundamental to allowing simultaneous activities in the same nREPL.
 For instance - if you want to evaluate two expressions simultaneously
 you'll have to do this in separate session, as all requests within the
 same session are serialized.
+
+== Pretty Printing
+
+nREPL includes a `pr-values` middleware to render the results of evaluated
+forms as strings for returning to the client. By default, this will use either
+`print-dup` or `print-method` to match the standard Clojure `print` behavior.
+To customize this you can pass a custom `:renderer` as a symbol along with the
+message. If present, this will be resolved to a function and used to render the
+value instead.
+
+This enables using libraries like link:https://github.com/greglook/puget[puget]
+to pretty-print the evaluation results automatically.

--- a/src/clojure/nrepl/middleware/pr_values.clj
+++ b/src/clojure/nrepl/middleware/pr_values.clj
@@ -2,7 +2,7 @@
   {:author "Chas Emerick"}
   (:require
    [clojure.string :as str]
-   [nrepl.middleware :as middleware])
+   [nrepl.middleware :refer [set-descriptor!]])
   (:import
    nrepl.transport.Transport))
 
@@ -66,8 +66,7 @@
           transport (rendering-transport transport render-fn)]
       (handler (assoc msg :transport transport)))))
 
-(middleware/set-descriptor!
- #'pr-values
- {:requires #{}
-  :expects #{}
-  :handles {}})
+(set-descriptor! #'pr-values
+                 {:requires #{}
+                  :expects #{}
+                  :handles {}})

--- a/src/clojure/nrepl/middleware/pr_values.clj
+++ b/src/clojure/nrepl/middleware/pr_values.clj
@@ -16,6 +16,19 @@
     (str writer)))
 
 
+(defn- resolve-renderer
+  "Resolve a namespaced symbol to a rendering function var. Returns the default
+  renderer if the argument is nil or not resolvable."
+  [renderer]
+  (if renderer
+    (let [var-sym (symbol renderer)]
+      (or (find-var var-sym)
+          (do (require (symbol (namespace var-sym)))
+              (resolve var-sym))
+          default-renderer))
+    default-renderer))
+
+
 (defn- rendering-transport
   "Wraps a `Transport` with code which renders the value of messages sent to
   it using the provided function."
@@ -53,9 +66,7 @@
   and opt out of the printing here."
   [handler]
   (fn [{:keys [op ^Transport transport renderer] :as msg}]
-    (let [render-fn (if renderer
-                      (find-var (symbol renderer))
-                      default-renderer)
+    (let [render-fn (resolve-renderer renderer)
           transport (rendering-transport transport render-fn)]
       (handler (assoc msg :transport transport)))))
 

--- a/src/clojure/nrepl/middleware/pr_values.clj
+++ b/src/clojure/nrepl/middleware/pr_values.clj
@@ -6,7 +6,6 @@
   (:import
    nrepl.transport.Transport))
 
-
 (defn- default-renderer
   "Uses print-dup or print-method to render a value to a string."
   [v]
@@ -14,7 +13,6 @@
         writer (java.io.StringWriter.)]
     (printer v writer)
     (str writer)))
-
 
 (defn- resolve-renderer
   "Resolve a namespaced symbol to a rendering function var. Returns the default
@@ -28,7 +26,6 @@
           default-renderer))
     default-renderer))
 
-
 (defn- rendering-transport
   "Wraps a `Transport` with code which renders the value of messages sent to
   it using the provided function."
@@ -40,13 +37,12 @@
       (.recv transport timeout))
     (send [this resp]
       (.send transport
-        (if (and (string? (:value resp)) (:printed-value resp))
-          (dissoc resp :printed-value)
-          (if-let [[_ v] (find resp :value)]
-            (assoc resp :value (str/trim-newline (render-fn v)))
-            resp)))
+             (if (and (string? (:value resp)) (:printed-value resp))
+               (dissoc resp :printed-value)
+               (if-let [[_ v] (find resp :value)]
+                 (assoc resp :value (str/trim-newline (render-fn v)))
+                 resp)))
       this)))
-
 
 (defn pr-values
   "Middleware that returns a handler which transforms any `:value` slots in
@@ -70,9 +66,8 @@
           transport (rendering-transport transport render-fn)]
       (handler (assoc msg :transport transport)))))
 
-
 (middleware/set-descriptor!
-  #'pr-values
-  {:requires #{}
-   :expects #{}
-   :handles {}})
+ #'pr-values
+ {:requires #{}
+  :expects #{}
+  :handles {}})

--- a/src/clojure/nrepl/middleware/pr_values.clj
+++ b/src/clojure/nrepl/middleware/pr_values.clj
@@ -19,10 +19,12 @@
   the argument is nil or not resolvable."
   [var-sym]
   (when-let [var-sym (and var-sym (symbol var-sym))]
-    ; TODO: log a warning if we were given a symbol but couldn't find it?
-    (or (find-var var-sym)
-        (do (require (symbol (namespace var-sym)))
-            (resolve var-sym)))))
+    (try
+      (require (symbol (namespace var-sym)))
+      (resolve var-sym)
+      (catch Exception ex
+        ; TODO: emit a warning here?
+        nil))))
 
 (defn- rendering-transport
   "Wraps a `Transport` with code which renders the value of messages sent to

--- a/src/clojure/nrepl/middleware/pr_values.clj
+++ b/src/clojure/nrepl/middleware/pr_values.clj
@@ -1,43 +1,67 @@
 (ns nrepl.middleware.pr-values
   {:author "Chas Emerick"}
   (:require
-   [nrepl.middleware :refer [set-descriptor!]])
+    [clojure.string :as str]
+    [nrepl.middleware :as middleware])
   (:import
-   nrepl.transport.Transport))
+    nrepl.transport.Transport))
+
+
+(defn- print-renderer
+  "Uses print-dup or print-method to render a value to a string."
+  [v]
+  (let [printer (if *print-dup* print-dup print-method)
+        writer (java.io.StringWriter.)]
+    (printer v writer)
+    (str writer)))
+
+
+(defn- wrap-renderer
+  "Wraps a `Transport` with code which renders the value of messages sent to
+  it using the provided function."
+  [^Transport transport render-fn]
+  (reify Transport
+    (recv [this]
+      (.recv transport))
+    (recv [this timeout]
+      (.recv transport timeout))
+    (send [this resp]
+      (.send transport
+        (if (and (string? (:value resp)) (:printed-value resp))
+          (dissoc resp :printed-value)
+          (if-let [[_ v] (find resp :value)]
+            (assoc resp :value (str/trim-newline (render-fn v)))
+            resp)))
+      this)))
+
 
 (defn pr-values
-  "Middleware that returns a handler which transforms any :value slots
-   in messages sent via the request's Transport to strings via `pr`,
-   delegating all actual message handling to the provided handler.
+  "Middleware that returns a handler which transforms any `:value` slots in
+  messages sent via the request's `Transport` to strings via the provided
+  `:renderer` function, delegating all actual message handling to the provided
+  handler.
 
-   Requires that results of eval operations are sent in messages in a
-   :value slot.
+  If no custom renderer is set, this falls back to using `print-dup` or
+  `print-method`.
 
-   If :value is already a string, and a sent message's :printed-value
-   slot contains any truthy value, then :value will not be re-printed.
-   This allows evaluation contexts to produce printed results in :value
-   if they so choose, and opt out of the printing here."
-  [h]
-  (fn [{:keys [op ^Transport transport] :as msg}]
-    (h (assoc msg
-              :transport (reify Transport
-                           (recv [this] (.recv transport))
-                           (recv [this timeout] (.recv transport timeout))
-                           (send [this {:keys [printed-value value] :as resp}]
-                             (.send transport
-                                    (if (and printed-value (string? value))
-                                      (dissoc resp :printed-value)
-                                      (if-let [[_ v] (find resp :value)]
-                                        (assoc resp
-                                               :value (let [repr (java.io.StringWriter.)]
-                                                        (if *print-dup*
-                                                          (print-dup v repr)
-                                                          (print-method v repr))
-                                                        (str repr)))
-                                        resp)))
-                             this))))))
+  Requires that results of eval operations are sent in messages in a
+  `:value` slot.
 
-(set-descriptor! #'pr-values
-                 {:requires #{}
-                  :expects #{}
-                  :handles {}})
+  If `:value` is already a string, and a sent message's `:printed-value` slot
+  contains any truthy value, then `:value` will not be re-printed.  This allows
+  evaluation contexts to produce printed results in `:value` if they so choose,
+  and opt out of the printing here."
+  [handler]
+  (fn [{:keys [op ^Transport transport renderer] :as msg}]
+    (let [render-fn (if renderer
+                      (find-var (symbol renderer))
+                      print-renderer)
+          transport (wrap-renderer transport render-fn)]
+      (handler (assoc msg :transport transport)))))
+
+
+(middleware/set-descriptor!
+  #'pr-values
+  {:requires #{}
+   :expects #{}
+   :handles {}})

--- a/src/clojure/nrepl/middleware/pr_values.clj
+++ b/src/clojure/nrepl/middleware/pr_values.clj
@@ -19,6 +19,7 @@
   the argument is nil or not resolvable."
   [var-sym]
   (when-let [var-sym (and var-sym (symbol var-sym))]
+    ; TODO: log a warning if we were given a symbol but couldn't find it?
     (or (find-var var-sym)
         (do (require (symbol (namespace var-sym)))
             (resolve var-sym)))))
@@ -60,7 +61,7 @@
   and opt out of the printing here."
   [handler]
   (fn [{:keys [op ^Transport transport renderer render-options] :as msg}]
-    (let [render-fn (or (resolve-symbol renderer) default-renderer)
+    (let [render-fn (or (resolve-renderer renderer) default-renderer)
           transport (rendering-transport transport render-fn render-options)]
       (handler (assoc msg :transport transport)))))
 

--- a/src/clojure/nrepl/middleware/pr_values.clj
+++ b/src/clojure/nrepl/middleware/pr_values.clj
@@ -2,6 +2,7 @@
   {:author "Chas Emerick"}
   (:require
    [clojure.string :as str]
+   [clojure.tools.logging :as log]
    [nrepl.middleware :refer [set-descriptor!]])
   (:import
    nrepl.transport.Transport))
@@ -23,7 +24,7 @@
       (require (symbol (namespace var-sym)))
       (resolve var-sym)
       (catch Exception ex
-        ; TODO: emit a warning here?
+        (log/warn "Couldn't resolve rendering function" var-sym)
         nil))))
 
 (defn- rendering-transport

--- a/src/clojure/nrepl/middleware/pr_values.clj
+++ b/src/clojure/nrepl/middleware/pr_values.clj
@@ -1,13 +1,13 @@
 (ns nrepl.middleware.pr-values
   {:author "Chas Emerick"}
   (:require
-    [clojure.string :as str]
-    [nrepl.middleware :as middleware])
+   [clojure.string :as str]
+   [nrepl.middleware :as middleware])
   (:import
-    nrepl.transport.Transport))
+   nrepl.transport.Transport))
 
 
-(defn- print-renderer
+(defn- default-renderer
   "Uses print-dup or print-method to render a value to a string."
   [v]
   (let [printer (if *print-dup* print-dup print-method)
@@ -16,7 +16,7 @@
     (str writer)))
 
 
-(defn- wrap-renderer
+(defn- rendering-transport
   "Wraps a `Transport` with code which renders the value of messages sent to
   it using the provided function."
   [^Transport transport render-fn]
@@ -55,8 +55,8 @@
   (fn [{:keys [op ^Transport transport renderer] :as msg}]
     (let [render-fn (if renderer
                       (find-var (symbol renderer))
-                      print-renderer)
-          transport (wrap-renderer transport render-fn)]
+                      default-renderer)
+          transport (rendering-transport transport render-fn)]
       (handler (assoc msg :transport transport)))))
 
 

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -201,6 +201,34 @@
                              combine-responses
                              :out))))
 
+(defn custom-renderer
+  [value opts]
+  (format "<foo %s %s>" value (or (:sub opts) "...")))
+
+(def-repl-test value-printing
+  (is (= ["42"]
+         (-> (message client {:op :eval
+                              :code "(+ 34 8)"
+                              :renderer 'my.missing.ns/renderer})
+             (combine-responses)
+             (:value)))
+      "bad symbol should fall back to default printer")
+  (is (= ["<foo true ...>"]
+         (-> (message client {:op :eval
+                              :code "true"
+                              :renderer `custom-renderer})
+             (combine-responses)
+             (:value)))
+      "custom rendering function symbol should be used")
+  (is (= ["<foo 3 bar>"]
+         (-> (message client {:op :eval
+                              :code "3"
+                              :renderer `custom-renderer
+                              :render-options {:sub "bar"}})
+             (combine-responses)
+             (:value)))
+      "options should be passed to renderer"))
+
 (def-repl-test session-return-recall
   (testing "sessions persist across connections"
     (repl-values session (code

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -206,28 +206,28 @@
   (format "<foo %s %s>" value (or (:sub opts) "...")))
 
 (def-repl-test value-printing
-  (is (= ["42"]
-         (-> (message client {:op :eval
-                              :code "(+ 34 8)"
-                              :renderer 'my.missing.ns/renderer})
-             (combine-responses)
-             (:value)))
-      "bad symbol should fall back to default printer")
-  (is (= ["<foo true ...>"]
-         (-> (message client {:op :eval
-                              :code "true"
-                              :renderer `custom-renderer})
-             (combine-responses)
-             (:value)))
-      "custom rendering function symbol should be used")
-  (is (= ["<foo 3 bar>"]
-         (-> (message client {:op :eval
-                              :code "3"
-                              :renderer `custom-renderer
-                              :render-options {:sub "bar"}})
-             (combine-responses)
-             (:value)))
-      "options should be passed to renderer"))
+  (testing "bad symbol should fall back to default printer"
+    (is (= ["42"]
+           (-> (message client {:op :eval
+                                :code "(+ 34 8)"
+                                :renderer 'my.missing.ns/renderer})
+               (combine-responses)
+               (:value)))))
+  (testing "custom rendering function symbol should be used"
+    (is (= ["<foo true ...>"]
+           (-> (message client {:op :eval
+                                :code "true"
+                                :renderer `custom-renderer})
+               (combine-responses)
+               (:value)))))
+  (testing "options should be passed to renderer"
+    (is (= ["<foo 3 bar>"]
+           (-> (message client {:op :eval
+                                :code "3"
+                                :renderer `custom-renderer
+                                :render-options {:sub "bar"}})
+               (combine-responses)
+               (:value))))))
 
 (def-repl-test session-return-recall
   (testing "sessions persist across connections"


### PR DESCRIPTION
Address #12 by porting some code I wrote to do this in https://github.com/greglook/whidbey but merged into the main `pr-values` middleware instead of a separately-installed hack.

Somewhat a WIP - it appears that there are 2-3 tests that are not passing on master, so I don't think I've broken anything. The code does get exercised by the existing test suite (since it's an extension to `pr-values`, but I haven't explicitly tested the custom rendering functionality. Any pointers there would be helpful.

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)
