### PR TITLE
[Fix #33] Add ability to change value of *print-namespace-maps*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Bugs fixed
 
 * [#10](https://github.com/nrepl/nREPL/issues/10): Bind *1, *2, *3 and *e in cloned session.
+* [#33](https://github.com/nrepl/nREPL/issues/33): Add ability to change value of `*print-namespace-maps*`.
 
 #### Changes
 

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -21,6 +21,13 @@
   "Function returning the evaluation of its argument."
   nil)
 
+(defmacro ^{:private true} def-dynamic-when-not-resolved
+  [sym value]
+  (when-not (resolve sym)
+    `(def ~(vary-meta sym assoc :dynamic true) ~value)))
+
+(def-dynamic-when-not-resolved *print-namespace-maps* nil)
+
 (defn- capture-thread-bindings
   "Capture thread bindings, excluding nrepl implementation vars."
   []
@@ -91,7 +98,9 @@
                       (set! *1 (@bindings #'*1))
                       (set! *2 (@bindings #'*2))
                       (set! *3 (@bindings #'*3))
-                      (set! *e (@bindings #'*e)))
+                      (set! *e (@bindings #'*e))
+                      (when (resolve '*print-namespace-maps*)
+                        (set! *print-namespace-maps* (@bindings #'*print-namespace-maps*))))
            :read (if (string? code)
                    (let [reader (source-logging-pushback-reader code line column)]
                      #(read {:read-cond :allow :eof %2} reader))

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -512,3 +512,12 @@
                             first
                             :value)]
     (is (= cloned-sess-*1 "5"))))
+
+(def-repl-test print-namespace-maps-binding
+  (when (resolve '*print-namespace-maps*)
+    (let [set-true (repl-eval session "(set! *print-namespace-maps* true)")
+          true-val (first (repl-values session "*print-namespace-maps*"))
+          set-false (repl-eval session "(set! *print-namespace-maps* false)")
+          false-val (first (repl-values session "*print-namespace-maps*"))]
+      (is (= true true-val))
+      (is (= false false-val)))))


### PR DESCRIPTION
This PR adds the ability for nREPL clients to change the value of `*print-namespace-maps*`.

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [X] All tests are passing
- [X] The new code is not generating reflection warnings
- [X] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)