### PR TITLE
Introduce external server configuration

### DIFF
--- a/doc/modules/ROOT/pages/design/transports.adoc
+++ b/doc/modules/ROOT/pages/design/transports.adoc
@@ -46,6 +46,14 @@ $ nc localhost 12345
 user=>
 ----
 
+Starting with nREPL 0.5 you can also start an nREPL with a TTY transport using `clj`:
+
+[source,shell]
+----
+$ clj -R:nrepl -m nrepl.cmdline -t nrepl.transport/tty
+nREPL server started on port 63266 on host localhost - telnet://localhost:63266
+----
+
 == Bencode Transport
 
 There's nothing special you have to do to use the bencode transport,

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -157,19 +157,21 @@
       (println nrepl/version-string)
       (System/exit 0))
     ;; then we check for --connect
-    (let [port (Integer/parseInt (or (options "--port") "0"))
+    (let [port (if (options "--port")
+                 (Integer/parseInt (options "--port"))
+                 (or (config/port) 0))
           host (options "--host")]
       (when (options "--connect")
         (run-repl host port)
         (System/exit 0))
       ;; otherwise we assume we have to start an nREPL server
-      (let [bind (options "--bind")
+      (let [bind (or (options "--bind") (config/bind-address))
             ;; if some handler was explicitly passed we'll use it, otherwise we'll build one
             ;; from whatever was passed via --middleware
             handler (and (options "--handler") (read-string (options "--handler")))
             middleware (and (options "--middleware") (read-string (options "--middleware")))
             handler (if handler (handler) (build-handler middleware))
-            transport (if (options "--transport") (require-and-resolve (options "--transport")))
+            transport (if (or (options "--transport") (config/transport)) (require-and-resolve (options "--transport")))
             greeting-fn (if (= transport #'transport/tty) #'transport/tty-greeting)
             server (start-server :port port :bind bind :handler handler
                                  :transport-fn transport :greeting-fn greeting-fn)

--- a/src/clojure/nrepl/config.clj
+++ b/src/clojure/nrepl/config.clj
@@ -1,0 +1,56 @@
+(ns nrepl.config
+  "Server configuration utilities.
+  Some server defaults can be configured via
+  a configuration file or env variables.
+  This namespace provides convenient API to work
+  with them."
+  {:author "Bozhidar Batsov"}
+  (:require
+   [clojure.java.io :as io]
+   [clojure.edn :as edn]))
+
+(def ^:private home-dir
+  "The user's home directory."
+  (System/getProperty "user.home"))
+
+(def config-dir
+  "nREPL's configuration directory.
+  By default it's ~/.nrepl, but this can be overridden
+  with the NREPL_CONFIG_DIR env variable."
+  (or (System/getenv "NREPL_CONFIG_DIR")
+      (str home-dir java.io.File/separator ".nrepl")))
+
+(def config-file
+  "nREPL's config file."
+  (str config-dir java.io.File/separator "config.edn"))
+
+(defn load-edn
+  "Load edn from an io/reader source (filename or io/resource)."
+  [source]
+  (try
+    (with-open [r (io/reader source)]
+      (edn/read (java.io.PushbackReader. r)))
+
+    (catch java.io.IOException e
+      (printf "Couldn't open '%s': %s\n" source (.getMessage e)))
+    (catch RuntimeException e
+      (printf "Error parsing edn file '%s': %s\n" source (.getMessage e)))))
+
+(defn load-config []
+  (let [config-file (io/file config-file)]
+    (if (.exists config-file)
+      (load-edn config-file)
+      {})))
+
+(def config
+  "Configuration map."
+  (load-config))
+
+(defn bind-address []
+  (or (System/getenv "NREPL_BIND_ADDRESS") (:bind config)))
+
+(defn port []
+  (or (System/getenv "NREPL_PORT") (:port config)))
+
+(defn transport []
+  (or (System/getenv "NREPL_TRANSPORT") (:transport config)))

--- a/src/clojure/nrepl/config.clj
+++ b/src/clojure/nrepl/config.clj
@@ -36,21 +36,37 @@
     (catch RuntimeException e
       (printf "Error parsing edn file '%s': %s\n" source (.getMessage e)))))
 
-(defn load-config []
+(defn load-config [file]
   (let [config-file (io/file config-file)]
     (if (.exists config-file)
       (load-edn config-file)
       {})))
 
 (def config
-  "Configuration map."
-  (load-config))
+  "Configuration map.
+  It's created by merging the global configuration file
+  with a local configuration file that would normally
+  the placed in the directory in which you're running
+  nREPL."
+  (merge
+   (load-config config-file)
+   (load-config ".nrepl-config.edn")))
 
 (defn bind-address []
-  (or (System/getenv "NREPL_BIND_ADDRESS") (:bind config)))
+  (or
+   (System/getenv "NREPL_BIND_ADDRESS")
+   (:bind config)))
 
-(defn port []
-  (or (System/getenv "NREPL_PORT") (:port config)))
+(defn port
+  "The default port for the server to listen on.
+  First we check the env variable NREPL_PORT,
+  then `config`."
+  []
+  (if-let [env-port (System/getenv "NREPL_PORT")]
+    (Integer/parseInt env-port)
+    (:port config)))
 
 (defn transport []
-  (or (System/getenv "NREPL_TRANSPORT") (:transport config)))
+  (or
+   (System/getenv "NREPL_TRANSPORT")
+   (:transport config)))


### PR DESCRIPTION
That's something I've been thinking about for a long time and it's finally coming in 0.5 (after a polish it and add some docs). 

Basically the idea is to make it easier to have host-wide and project-specific configs, so you can have stable bind-addresses, ports, transports, middleware, etc. 

Obviously that's also going to require a bit of changes to tools like `boot` and `lein`, but those are going to be trivial. Feedback is welcome!

I also plan to follow this up with `clj` writing in `.nrepl/` some information about each running server, so it's easy for something like CIDER to just go check this dir and suggest all the local running instances as something you can connect to. That's going to be a massive improvement over the `ps` grepping we do right now and will finally work on Windows as well. :-) 