### PR TITLE
[Fix #68] Avoid illegal access warning in set-line! of interruptible-eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#10](https://github.com/nrepl/nREPL/issues/10): Bind *1, *2, *3 and *e in cloned session.
 * [#33](https://github.com/nrepl/nREPL/issues/33): Add ability to change value of `*print-namespace-maps*`.
+* [#68](https://github.com/nrepl/nREPL/issues/68): Avoid illegal access warning caused by set-line!.
 
 #### Changes
 

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -38,11 +38,7 @@
 
 (defn- set-line!
   [^LineNumberingPushbackReader reader line]
-  (-> FilterReader
-      ^Field (.getDeclaredField "in")
-      (doto (.setAccessible true))
-      ^LineNumberReader (.get reader)
-      (.setLineNumber line)))
+  (-> reader (.setLineNumber line)))
 
 (defn- set-column!
   [^LineNumberingPushbackReader reader column]
@@ -57,7 +53,7 @@
 (defn- source-logging-pushback-reader
   [code line column]
   (let [reader (LineNumberingPushbackReader. (StringReader. code))]
-    (when line (set-line! reader (int (dec line))))
+    (when line (set-line! reader (int line)))
     (when column (set-column! reader (int column)))
     reader))
 


### PR DESCRIPTION
This PR fixes the illegal access warning caused by the set-line! function of interruptible-eval. Since [this commit](https://github.com/clojure/clojure/commit/3d216d45b63781586bb79144268bb2fb88dd6f28) a `setLineNumber` method is available on the `LineNumberingPushbackReader` (added in clojure v1.7.0). 

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

