### PR TITLE
[Fix #77] Exit interactive session when input is control-d, exit or quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#10](https://github.com/nrepl/nREPL/issues/10): Bind *1, *2, *3 and *e in cloned session.
 * [#33](https://github.com/nrepl/nREPL/issues/33): Add ability to change value of `*print-namespace-maps*`.
 * [#68](https://github.com/nrepl/nREPL/issues/68): Avoid illegal access warning caused by set-line!.
+* [#77](https://github.com/nrepl/nREPL/issues/77): Exit when entering ctrl-d in interactive session.
 
 #### Changes
 


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

This PR makes an interactive session exit when control-d is pressed, or exit or quit is entered as input.