### PR TITLE
Handle interrupt in interactive session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#76](https://github.com/nrepl/nrepl/pull/76): Move version-related logic to a dedicated namespace (`nrepl.version`).
 * Deprecate `nrepl.core/version`.
 * Deprecate `nrepl.core/version-string`.
+* [#81](https://github.com/nrepl/nrepl/pull/81): Handle interrupt in interactive session.
 
 ### 0.4.5 (2018-09-02)
 

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -57,10 +57,9 @@
    (let [transport (nrepl/connect :host host :port port)
          client (nrepl/client-session (nrepl/client transport Long/MAX_VALUE))
          ns (atom "user")]
-     (println (format "nREPL %s" (:version-string version/version)))
      (swap! running-repl assoc :transport transport)
      (swap! running-repl assoc :client client)
-     (println (format "nREPL %s" nrepl/version-string))
+     (println (format "nREPL %s" (:version-string version/version)))
      (println (str "Clojure " (clojure-version)))
      (println (System/getProperty "java.vm.name") (System/getProperty "java.runtime.version"))
      (loop []

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -62,6 +62,8 @@
      (println (format "nREPL %s" (:version-string version/version)))
      (println (str "Clojure " (clojure-version)))
      (println (System/getProperty "java.vm.name") (System/getProperty "java.runtime.version"))
+     (println (str "Interrupt: Control+C"))
+     (println (str "Exit:      Control+D or (exit) or (quit)"))
      (loop []
        (prompt @ns)
        (flush)


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

This PR adds handling of an interrupt signal in an interactive session.
