### PR TITLE
[Fix #13] Catch ThreadDeath exception thrown by interrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#33](https://github.com/nrepl/nREPL/issues/33): Add ability to change value of `*print-namespace-maps*`.
 * [#68](https://github.com/nrepl/nREPL/issues/68): Avoid illegal access warning on JDK 9+ caused by `nrepl.middleware.interruptible-eval/set-line!`.
 * [#77](https://github.com/nrepl/nREPL/issues/77): Exit cleanly after pressing `ctrl-d` in an interactive REPL.
+* [#13](https://github.com/nrepl/nREPL/issues/13): Catch ThreadDeath exception thrown by interrupt.
 
 #### Changes
 

--- a/load-file-test/nrepl/load_file_sample2.clj
+++ b/load-file-test/nrepl/load_file_sample2.clj
@@ -1,0 +1,3 @@
+(ns nrepl.load-file-sample2)
+
+(Thread/sleep 10000)

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -123,6 +123,11 @@
            :caught (fn [e]
                      (let [root-ex (#'clojure.main/root-cause e)
                            previous-cause (.getCause e)]
+                       ;; Check if the root cause or previous cause of the exception
+                       ;; is a ThreadDeath exception. In case the exception is a
+                       ;; CompilerException, the root cause is not returned by
+                       ;; the root-cause function, so we check the previous cause
+                       ;; instead.
                        (when-not (or (instance? ThreadDeath root-ex)
                                      (instance? ThreadDeath previous-cause))
                          (reset! bindings (assoc (capture-thread-bindings) #'*e e))

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -121,8 +121,10 @@
                                                      :ns (-> *ns* ns-name str)})))
            ;; TODO: customizable exception prints
            :caught (fn [e]
-                     (let [root-ex (#'clojure.main/root-cause e)]
-                       (when-not (instance? ThreadDeath root-ex)
+                     (let [root-ex (#'clojure.main/root-cause e)
+                           previous-cause (.getCause e)]
+                       (when-not (or (instance? ThreadDeath root-ex)
+                                     (instance? ThreadDeath previous-cause))
                          (reset! bindings (assoc (capture-thread-bindings) #'*e e))
                          (reset! session (maybe-restore-original-ns @bindings))
                          (t/send transport (response-for msg {:status :eval-error

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -522,7 +522,7 @@
       (is (= true true-val))
       (is (= false false-val)))))
 
-(def-repl-test interrupt-load-file-with-thread-sleep
+(def-repl-test interrupt-load-file
   (let [resp (message session {:op "load-file"
                                :file (slurp (File. project-base-dir "load-file-test/nrepl/load_file_sample2.clj"))
                                :file-path "nrepl/load_file_sample2.clj"

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -521,3 +521,12 @@
           false-val (first (repl-values session "*print-namespace-maps*"))]
       (is (= true true-val))
       (is (= false false-val)))))
+
+(def-repl-test interrupt-load-file-with-thread-sleep
+  (let [resp (message session {:op "load-file"
+                               :file (slurp (File. project-base-dir "load-file-test/nrepl/load_file_sample2.clj"))
+                               :file-path "nrepl/load_file_sample2.clj"
+                               :file-name "load_file_sample2.clj"})]
+    (Thread/sleep 100)
+    (is (= #{"done"} (-> session (message {:op :interrupt}) first :status set)))
+    (is (= #{"done" "interrupted"} (-> resp combine-responses :status)))))


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

This PR adds handling of ThreadDeath exceptions that can be thrown by an interrupt.