### PR TITLE
fix some issues with hiccup style syntax in cljdoc.edn

### DIFF
--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -4,14 +4,14 @@
   ["Home" {:file "doc/modules/ROOT/pages/index.adoc"}]
   ["Installation" {:file "doc/modules/ROOT/pages/installation.adoc"}]
   ["Usage" {}
-   ["Server" {:file "doc/modules/ROOT/pages/usage/server.adoc"}
-    "Client" {:file "doc/modules/ROOT/pages/usage/clients.adoc"}
-    "Misc" {:file "doc/modules/ROOT/pages/usage/misc.adoc"}]]
+   ["Server" {:file "doc/modules/ROOT/pages/usage/server.adoc"}]
+   ["Client" {:file "doc/modules/ROOT/pages/usage/clients.adoc"}]
+   ["Misc" {:file "doc/modules/ROOT/pages/usage/misc.adoc"}]]
   ["Design" {}
-   "Overview" {:file "doc/modules/ROOT/pages/design/overview.adoc"}
-   "Handlers" {:file "doc/modules/ROOT/pages/design/handlers.adoc"}
-   "Transports" {:file "doc/modules/ROOT/pages/design/transports.adoc"}
-   "Middleware" {:file "doc/modules/ROOT/pages/design/middleware.adoc"}]
+   ["Overview" {:file "doc/modules/ROOT/pages/design/overview.adoc"}]
+   ["Handlers" {:file "doc/modules/ROOT/pages/design/handlers.adoc"}]
+   ["Transports" {:file "doc/modules/ROOT/pages/design/transports.adoc"}]
+   ["Middleware" {:file "doc/modules/ROOT/pages/design/middleware.adoc"}]]
   ["Built-in Ops" {:file "doc/modules/ROOT/pages/ops.adoc"}]
   ["FAQ" {:file "doc/modules/ROOT/pages/faq.adoc"}]
   ["Third-party Middleware" {:file "doc/modules/ROOT/pages/third_party_middleware.adoc"}]


### PR DESCRIPTION
Unfortunately the `verify-cljdoc-edn` step that's part of your CI doesn't yet catch syntax issues.

I thought just checking that the `:file` exists is sufficient but looks like we should expand this and ensure the value conforms to the spec. 