### PR TITLE
[Fix #62] Capture output of background threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#68](https://github.com/nrepl/nREPL/issues/68): Avoid illegal access warning on JDK 9+ caused by `nrepl.middleware.interruptible-eval/set-line!`.
 * [#77](https://github.com/nrepl/nREPL/issues/77): Exit cleanly after pressing `ctrl-d` in an interactive REPL.
 * [#13](https://github.com/nrepl/nREPL/issues/13): Catch ThreadDeath exception thrown by interrupt.
+* [#62](https://github.com/nrepl/nREPL/issues/62): Capture output of background threads.
 
 #### Changes
 

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -100,7 +100,7 @@
                       (set! *e (@bindings #'*e))
                       (when (resolve '*print-namespace-maps*)
                         (set! *print-namespace-maps* (@bindings #'*print-namespace-maps*)))
-                      (alter-var-root #'*out* (constantly *out*))
+                      (alter-var-root #'*out* (constantly (@bindings #'*out*)))
                       (alter-var-root #'*msg* (constantly *msg*)))
            :read (if (string? code)
                    (let [reader (source-logging-pushback-reader code line column)]

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -99,7 +99,9 @@
                       (set! *3 (@bindings #'*3))
                       (set! *e (@bindings #'*e))
                       (when (resolve '*print-namespace-maps*)
-                        (set! *print-namespace-maps* (@bindings #'*print-namespace-maps*))))
+                        (set! *print-namespace-maps* (@bindings #'*print-namespace-maps*)))
+                      (alter-var-root #'*out* (constantly *out*))
+                      (alter-var-root #'*msg* (constantly *msg*)))
            :read (if (string? code)
                    (let [reader (source-logging-pushback-reader code line column)]
                      #(read {:read-cond :allow :eof %2} reader))

--- a/test/clojure/nrepl/sanity_test.clj
+++ b/test/clojure/nrepl/sanity_test.clj
@@ -83,7 +83,8 @@
 
 (deftest repl-out-writer
   (let [[local remote] (piped-transports)
-        w (#'session/session-out :out :dummy-session-id remote)]
+        w (#'session/session-out :out :dummy-session-id remote)
+        alter-msg (alter-var-root #'eval/*msg* (constantly nil))]
     (doto w
       .flush
       (.println "println")


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

This PR alters the root binding of *out* and *msg* to be able to capture the output of background threads in responses and keep the :id of the original message.
