### PR TITLE
Add ops.adoc generation script behind `lein docs`

### DIFF
--- a/doc/modules/ROOT/pages/design/middleware.adoc
+++ b/doc/modules/ROOT/pages/design/middleware.adoc
@@ -97,8 +97,8 @@ the handled `:op` and a value that contains any of four entries:
 The values in the `:handles` map are used to support the `"describe"` operation,
 which provides "a machine- and human-readable directory and documentation for
 the operations supported by an nREPL endpoint" (see
-`nrepl.impl.docs/-main` and the results of
-`"describe"` (via `lein with-profile +maint run nrepl.impl.docs`) <<ops.adoc,here>>).
+`nrepl.impl.docs/generate-ops-info` and the results of
+`lein with-profile +maint run nrepl.impl.docs` <<ops.adoc,here>>).
 
 NOTE: There's also `lein with-profile +maint run nrepl.impl.docs --output md` if you'd like to
 generate an ops listing in Markdown format.

--- a/doc/modules/ROOT/pages/design/middleware.adoc
+++ b/doc/modules/ROOT/pages/design/middleware.adoc
@@ -94,13 +94,13 @@ the handled `:op` and a value that contains any of four entries:
 ** `:returns`, a map of slots that may be found in messages sent in response
     to handling the indicated `:op`
 
-The values in the `:handles` map is used to support the `"describe"` operation,
+The values in the `:handles` map are used to support the `"describe"` operation,
 which provides "a machine- and human-readable directory and documentation for
 the operations supported by an nREPL endpoint" (see
-`nrepl.middleware/describe-adoc`, and the results of
-`"describe"` and `describe-doc` <<ops.adoc,here>>).
+`nrepl.impl.docs/-main` and the results of
+`"describe"` (via `lein with-profile +maint run nrepl.impl.docs`) <<ops.adoc,here>>).
 
-NOTE: There's also `nrepl.middleware/describe-markdown` if you'd like to
+NOTE: There's also `lein with-profile +maint run nrepl.impl.docs --output md` if you'd like to
 generate an ops listing in Markdown format.
 
 The `:requires` and `:expects` entries control the order in which

--- a/doc/modules/ROOT/pages/ops.adoc
+++ b/doc/modules/ROOT/pages/ops.adoc
@@ -1,10 +1,10 @@
 ////
-This file is _generated_ by #'nrepl.describe-test/update-op-docs
+This file is _generated_ by #'nrepl.impl.docs/-main
    *Do not edit!*
 ////
 = Supported nREPL operations
 
-[small]#generated from a verbose 'describe' response (nREPL v0.4.5)#
+[small]#generated from a verbose 'describe' response (nREPL v0.6.0-SNAPSHOT)#
 
 == Operations
 

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,8 @@
   :dependencies [[nrepl/bencode "1.0.0"]]
 
   :aliases {"bump-version" ["change" "version" "leiningen.release/bump-version"]
-            "test-all" ["with-profile" "+1.7:+1.8:+1.9:+fastlane" "test"]}
+            "test-all" ["with-profile" "+1.7:+1.8:+1.9:+fastlane" "test"]
+            "docs" ["with-profile" "+maint" "run" "-m" "nrepl.impl.docs"]}
 
   :release-tasks [["vcs" "assert-committed"]
                   ["bump-version" "release"]
@@ -38,6 +39,7 @@
                       :dependencies [[org.clojure/clojure "1.10.0-master-SNAPSHOT"]]}
 
              :sysutils {:plugins [[lein-sysutils "0.2.0"]]}
+             :maint {:source-paths ["src/maint"]}
 
              ;; CI tools
              :cloverage {:plugins [[lein-cloverage "1.0.13"]]}

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
 
   :aliases {"bump-version" ["change" "version" "leiningen.release/bump-version"]
             "test-all" ["with-profile" "+1.7:+1.8:+1.9:+fastlane" "test"]
-            "docs" ["with-profile" "+maint" "run" "-m" "nrepl.impl.docs"]}
+            "docs" ["with-profile" "+maint" "run" "-m" "nrepl.impl.docs" "--lein"]}
 
   :release-tasks [["vcs" "assert-committed"]
                   ["bump-version" "release"]
@@ -39,7 +39,8 @@
                       :dependencies [[org.clojure/clojure "1.10.0-master-SNAPSHOT"]]}
 
              :sysutils {:plugins [[lein-sysutils "0.2.0"]]}
-             :maint {:source-paths ["src/maint"]}
+             :maint {:source-paths ["src/maint"]
+                     :dependencies [[org.clojure/tools.cli "0.4.1"]]}
 
              ;; CI tools
              :cloverage {:plugins [[lein-cloverage "1.0.13"]]}

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,9 @@
 
   :aliases {"bump-version" ["change" "version" "leiningen.release/bump-version"]
             "test-all" ["with-profile" "+1.7:+1.8:+1.9:+fastlane" "test"]
-            "docs" ["with-profile" "+maint" "run" "-m" "nrepl.impl.docs" "--lein"]}
+            "docs" ["with-profile" "+maint" "run" "-m" "nrepl.impl.docs" "--file"
+                    ~(clojure.java.io/as-relative-path
+                      (clojure.java.io/file "doc" "modules" "ROOT" "pages" "ops.adoc"))]}
 
   :release-tasks [["vcs" "assert-committed"]
                   ["bump-version" "release"]

--- a/src/clojure/nrepl/middleware.clj
+++ b/src/clojure/nrepl/middleware.clj
@@ -2,7 +2,6 @@
   (:refer-clojure :exclude [comparator])
   (:require
    [clojure.set :as set]
-   [clojure.string :as string]
    [nrepl.misc :as misc]
    [nrepl.transport :as transport]
    [nrepl.version :as version]))
@@ -183,76 +182,3 @@
        extend-deps
        (topologically-sort comparator)
        (map :implemented-by)))
-
-;;; documentation utilities ;;;
-
-;; oh, kill me now
-(defn- markdown-escape
-  [^String s]
-  (.replaceAll s "([*_])" "\\\\$1"))
-
-(defn- message-slot-markdown
-  [msg-slot-docs]
-  (apply str (for [[k v] msg-slot-docs]
-               (format "* `%s` %s\n" (pr-str k) (markdown-escape v)))))
-
-(defn- describe-markdown
-  "Given a message containing the response to a verbose :describe message,
-generates a markdown string conveying the information therein, suitable for
-use in e.g. wiki pages, github, etc.
-
-(This is currently private because markdown conversion surely shouldn't
-be part of the API here...?)"
-  [{:keys [ops versions]}]
-  (apply str "# Supported nREPL operations
-
-<small>generated from a verbose 'describe' response (nREPL v"
-         (:version-string version/version)
-         ")</small>\n\n## Operations"
-         (for [[op {:keys [doc optional requires returns]}] ops]
-           (str "\n\n### `" (pr-str op) "`\n\n"
-                (markdown-escape doc) "\n\n"
-                "###### Required parameters\n\n"
-                (message-slot-markdown requires)
-                "\n\n###### Optional parameters\n\n"
-                (message-slot-markdown optional)
-                "\n\n###### Returns\n\n"
-                (message-slot-markdown returns)))))
-
-;; because `` is expected to work, this only escapes certain characters. As opposed to using + to properly escape everything.
-(defn- adoc-escape
-  [s]
-  (-> s
-      (string/replace #"\*(.+?)\*" "\\\\*$1*")
-      (string/replace #"\_(.+?)\_" "\\\\_$1_")
-      (string/escape {\` "``"})))
-
-(defn- message-slot-adoc
-  [msg-slot-docs]
-  (if (seq msg-slot-docs)
-    (apply str (for [[k v] msg-slot-docs]
-                 (format "* `%s` %s\n" (pr-str k) (adoc-escape v))))
-    "{blank}"))
-
-(defn- describe-adoc
-  "Given a message containing the response to a verbose :describe message,
-generates a asciidoc string conveying the information therein, suitable for
-use in e.g. wiki pages, github, etc.
-
-(This is currently private because asciidoc conversion surely shouldn't
-be part of the API here...?)"
-  [{:keys [ops versions]}]
-  (apply str "= Supported nREPL operations\n\n"
-         "[small]#generated from a verbose 'describe' response (nREPL v"
-         (:version-string version/version)
-         ")#\n\n== Operations"
-         (for [[op {:keys [doc optional requires returns]}] ops]
-           (str "\n\n=== `" (pr-str op) "`\n\n"
-                (adoc-escape doc) "\n\n"
-                "Required parameters::\n"
-                (message-slot-adoc requires)
-                "\n\nOptional parameters::\n"
-                (message-slot-adoc optional)
-                "\n\nReturns::\n"
-                (message-slot-adoc returns)
-                "\n"))))

--- a/src/maint/nrepl/impl/docs.clj
+++ b/src/maint/nrepl/impl/docs.clj
@@ -103,7 +103,7 @@ use in e.g. wiki pages, github, etc."
                 "\n"))))
 
 (defn- format-response [format resp]
-  (cond (= format "raw") (pr-str (select-keys resp [:ops :versions]))
+  (cond (= format "raw") (pr-str (select-keys resp [:ops]))
         (= format "md") (str "<!-- This file is *generated* by " #'-main
                              "\n   **Do not edit!** -->\n"
                              (describe-markdown resp))
@@ -139,3 +139,5 @@ use in e.g. wiki pages, github, etc."
         (if (= *out* file) (println docs)
             (do (spit file docs)
                 (println (str "Regenerated " (.getAbsolutePath file)))))))))
+
+(defn pwd [] (println (.getAbsolutePath (File. "."))))

--- a/src/maint/nrepl/impl/docs.clj
+++ b/src/maint/nrepl/impl/docs.clj
@@ -1,0 +1,98 @@
+(ns nrepl.impl.docs
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as string]
+   [nrepl.core :as nrepl]
+   [nrepl.server :as server]
+   [nrepl.transport :as transport]
+   [nrepl.version :as version])
+  (:import
+   (java.io File)))
+
+;; oh, kill me now
+(defn- markdown-escape
+  [^String s]
+  (.replaceAll s "([*_])" "\\\\$1"))
+
+(defn- message-slot-markdown
+  [msg-slot-docs]
+  (apply str (for [[k v] msg-slot-docs]
+               (format "* `%s` %s\n" (pr-str k) (markdown-escape v)))))
+
+(defn- describe-markdown
+  "Given a message containing the response to a verbose :describe message,
+generates a markdown string conveying the information therein, suitable for
+use in e.g. wiki pages, github, etc."
+  [{:keys [ops versions]}]
+  (apply str "# Supported nREPL operations
+
+<small>generated from a verbose 'describe' response (nREPL v"
+         (:version-string version/version)
+         ")</small>\n\n## Operations"
+         (for [[op {:keys [doc optional requires returns]}] ops]
+           (str "\n\n### `" (pr-str op) "`\n\n"
+                (markdown-escape doc) "\n\n"
+                "###### Required parameters\n\n"
+                (message-slot-markdown requires)
+                "\n\n###### Optional parameters\n\n"
+                (message-slot-markdown optional)
+                "\n\n###### Returns\n\n"
+                (message-slot-markdown returns)))))
+
+;; because `` is expected to work, this only escapes certain characters. As opposed to using + to properly escape everything.
+(defn- adoc-escape
+  [s]
+  (-> s
+      (string/replace #"\*(.+?)\*" "\\\\*$1*")
+      (string/replace #"\_(.+?)\_" "\\\\_$1_")
+      (string/escape {\` "``"})))
+
+(defn- message-slot-adoc
+  [msg-slot-docs]
+  (if (seq msg-slot-docs)
+    (apply str (for [[k v] msg-slot-docs]
+                 (format "* `%s` %s\n" (pr-str k) (adoc-escape v))))
+    "{blank}"))
+
+(defn- describe-adoc
+  "Given a message containing the response to a verbose :describe message,
+  generates a asciidoc string conveying the information therein, suitable for
+  use in e.g. wiki pages, github, etc."
+  [{:keys [ops versions]}]
+  (apply str "= Supported nREPL operations\n\n"
+         "[small]#generated from a verbose 'describe' response (nREPL v"
+         (:version-string version/version)
+         ")#\n\n== Operations"
+         (for [[op {:keys [doc optional requires returns]}] (sort ops)]
+           (str "\n\n=== `" (pr-str op) "`\n\n"
+                (adoc-escape doc) "\n\n"
+                "Required parameters::\n"
+                (message-slot-adoc (sort requires))
+                "\n\nOptional parameters::\n"
+                (message-slot-adoc (sort optional))
+                "\n\nReturns::\n"
+                (message-slot-adoc (sort returns))
+                "\n"))))
+
+(defn -main
+  "Regenerate the ops documentation in ops.adoc"
+  [& args]
+  (let [project-base-dir (File. (System/getProperty "nrepl.basedir" "."))
+        ops-adoc (io/file project-base-dir "doc" "modules" "ROOT" "pages" "ops.adoc")]
+    (spit ops-adoc
+          (str
+           "////\n"
+           "This file is _generated_ by " #'-main
+           "\n   *Do not edit!*\n"
+           "////\n"
+           (let [[local remote] (transport/piped-transports)
+                 handler (server/default-handler)
+                 msg {:op "describe"
+                      :verbose? "true"
+                      :id "1"}]
+             (handler (assoc msg :transport remote))
+             (-> (nrepl/response-seq local 500)
+                 first
+                 clojure.walk/keywordize-keys
+                 describe-adoc))))
+    (println (str "Regenerated " (.getPath ops-adoc)))))

--- a/src/maint/nrepl/impl/docs.clj
+++ b/src/maint/nrepl/impl/docs.clj
@@ -19,11 +19,11 @@
     :validate [#(contains? #{"raw" "adoc" "md"} %)]]])
 ;; io/file (File. (System/getProperty "nrepl.basedir" ".")) "doc" "modules" "ROOT" "pages" "ops.adoc")
 
-(defn exit [status msg]
+(defn- exit [status msg]
   (println msg)
   (System/exit status))
 
-(defn usage [options-summary]
+(defn- usage [options-summary]
   (->> ["Regenerate and output the ops documentation to the specified destination in the specified format."
         ""
         "Usage: lein -m +maint run nrepl.impl.docs [options]"
@@ -32,13 +32,9 @@
         options-summary]
        (string/join \newline)))
 
-(defn error-msg [errors]
+(defn- error-msg [errors]
   (str "The following errors occurred while parsing your command:\n\n"
        (string/join \newline errors)))
-
-(defn exit [status msg]
-  (println msg)
-  (System/exit status))
 
 ;; oh, kill me now
 (defn- markdown-escape

--- a/test/clojure/nrepl/describe_test.clj
+++ b/test/clojure/nrepl/describe_test.clj
@@ -1,7 +1,6 @@
 (ns nrepl.describe-test
   {:author "Chas Emerick"}
   (:require
-   [clojure.java.io :as io]
    [clojure.test :refer :all]
    [nrepl.core :as nrepl]
    [nrepl.core-test :refer [def-repl-test repl-server-fixture project-base-dir]]
@@ -37,16 +36,3 @@
     (is (= op-names (set (keys ops))))
     (is (every? seq (map (comp :doc val) ops)))
     (is (= {:current-ns "user"} aux))))
-
-;; quite misplaced, but this'll do for now...
-(def-repl-test update-op-docs
-  (let [describe-response (nrepl/combine-responses
-                           (nrepl/message timeout-client
-                                          {:op "describe" :verbose? "true"}))]
-    (spit (io/file project-base-dir "doc" "modules" "ROOT" "pages" "ops.adoc")
-          (str
-           "////\n"
-           "This file is _generated_ by " #'update-op-docs
-           "\n   *Do not edit!*\n"
-           "////\n"
-           (#'middleware/describe-adoc describe-response)))))


### PR DESCRIPTION
Putting this up here in the hopes that someone else will point out my mistake before I find it myself or offer guidance (on approach, etc.). This adds an nrepl.-private/-main routine to regenerate ops.adoc. The docs helper functions were moved verbatim from middleware.clj into the new namespace, and the new -main sends a verbose "describe" request through the default handler via a simple transport.

The issue I'm currently debugging: when wrap-describe is executed on the verbose "describe" message the -main is sending, :descriptors isn't set on the message. It looks like the handler function is supposed to be composed with wrap-conj-descriptor (which sets :descriptors for describe messages) in set-descriptor!, but for some reason that doesn't appear to be happening. Maybe I set something up wrong in the handler, but I'm still trying to figure out what. Let me know if any pointers.

The result is an ops.adoc without ops 😢 :
```
bnran at dca90496b22a in ~/dev/clj/nREPL on master*
$ lein run -m nrepl.-private.docs && cat doc/modules/ROOT/pages/ops.adoc
done
////
This file is _generated_ by #'nrepl.-private.docs/-main
   *Do not edit!*
////
= Supported nREPL operations

[small]#generated from a verbose 'describe' response (nREPL v0.6.0-SNAPSHOT)#

== Operationsbnran at dca90496b22a in ~/dev/clj/nREPL on master*
$ 
```

As for the general approach, it would be nice to avoid including this in the released jar used to run other projects' repls. I guess that's what a lein task is (still new to clojure) but I'm having trouble finding docs on how to create one. Thoughts on how important this actually is would be welcome.

P.S. also wondering who sets system prop 'nrepl.basedir'.

Issue: https://github.com/nrepl/nrepl/issues/37