### PR TITLE
Session thread

### DIFF
--- a/doc/modules/ROOT/pages/design/middleware.adoc
+++ b/doc/modules/ROOT/pages/design/middleware.adoc
@@ -135,12 +135,21 @@ should do the same, or use a similar alternative base handler.
 
 == Sessions
 
-Sessions persist link:https://clojure.org/reference/vars[dynamic vars]
-(collected by `get-thread-bindings`) against a unique lookup. This is
-allows you to have a different value for `*e` from different REPL
-clients (e.g. two separate REPL-y instances). An existing session can
-be cloned to create a new one, which then can be modified. This allows
-for copying of existing preferences into new environments.
+There are two types of sessions: ephemeral sessions and long-lived sessions
+(or registered sessions).
+
+When a message arrives without a session id, an ephemeral session is created
+and assigned to it. Ephemeral sessions are bound to the processing of a single message.
+
+The only way to create a long-lived session is to clone an existing session (even an
+ephemeral one). Cloning a session creates a new session that initially shares the link:https://clojure.org/reference/vars[dynamic bindings] of the original session.
+
+Sessions (long-lived ones since they are the useful ones) serialize evaluations
+and make dynamic bindings available for inspection to other ops.
+
+All other ops have no serialization guarantee (they are serialized in the current
+implementation since they run on the server IO thread). However evals run on a
+dedicated thread so a running eval can't block another op.
 
 Sessions become even more useful when different nREPL extensions start
 taking advantage of
@@ -150,14 +159,6 @@ debugging of two things
 separately. link:https://github.com/nrepl/piggieback[piggieback] uses
 sessions to allow host a ClojureScript REPL alongside an existing
 Clojure one.
-
-An easy mistake is to confuse a `session` with an `id`. The difference
-between a session and id, is that an `id` is for tracking a single
-message, and sessions are for tracking remote state. They're
-fundamental to allowing simultaneous activities in the same nREPL.
-For instance - if you want to evaluate two expressions simultaneously
-you'll have to do this in separate session, as all requests within the
-same session are serialized.
 
 == Pretty Printing
 

--- a/doc/modules/ROOT/pages/ops.adoc
+++ b/doc/modules/ROOT/pages/ops.adoc
@@ -84,7 +84,8 @@ Returns::
 
 === `:interrupt`
 
-Attempts to interrupt some code evaluation.
+Attempts to interrupt some code evaluation. When interruption succeeds, the thread used by for
+code evaluation changes, while Clojure dynamic bindings are preserved, other `ThreadLocals` are not. So when running code intimately tied to the current thread identity, best avoid interruptions.
 
 Required parameters::
 * `:session` The ID of the session used to start the evaluation to be interrupted.

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -135,6 +135,8 @@
 
 ;; A little mini-agent implementation. Needed because agents cannot be used to host REPL
 ;; evaluation: http://dev.clojure.org/jira/browse/NREPL-17
+
+
 (defn- prep-session
   [session]
   (locking session
@@ -183,11 +185,11 @@
         "eval"
         (if-not (:code msg)
           (t/send transport (response-for msg :status #{:error :no-code :done}))
-          (exec id 
-            #(binding [*msg* msg]
-               (evaluate @session msg))
-            #(t/send transport (response-for msg :status :done))))
-        
+          (exec id
+                #(binding [*msg* msg]
+                   (evaluate @session msg))
+                #(t/send transport (response-for msg :status :done))))
+
         "interrupt"
         (let [interrupted-id (when interrupt (interrupt interrupt-id))]
           (case interrupted-id
@@ -200,7 +202,7 @@
                                  :id interrupted-id
                                  :session session-id})
               (t/send transport (response-for msg :status #{:done})))))
-        
+
         (h msg)))))
 
 (set-descriptor! #'interruptible-eval

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -201,7 +201,7 @@
                     (cond
                       (nil? current) :idle
                       (and (or (nil? exec-id) (= current exec-id)) ; cas only checks identity, so check equality first 
-                        (compare-and-set! running current nil))
+                           (compare-and-set! running current nil))
                       (do
                         (doto ^Thread @thread .interrupt .stop)
                         (reset! thread (spawn-thread))

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -358,7 +358,7 @@
                                                        (def halted? false)))})]
     (Thread/sleep 100)
     (is (= #{"done"} (-> session (message {:op :interrupt}) first :status set)))
-    (is (= #{"done" "interrupted"} (-> resp combine-responses :status)))
+    (is (= #{} (reduce disj #{"done" "interrupted"} (-> resp combine-responses :status))))
     (is (= [true] (repl-values session "halted?")))))
 
 ;; NREPL-66: ensure that bindings of implementation vars aren't captured by user sessions


### PR DESCRIPTION
Fix for #16:
Each registered session now has its own thread for `:eval`. Upon successful `interrupt` this thread is replaced. So don't interrupt when you care about thread identity.