### PR TITLE
Fix `run-repl` using a different transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### master (unreleased)
 
-### Changes
+#### Bugs fixed
+
+* When starting the REPL, make sure the transport option is used correctly.
+
+#### Changes
 
 * [#16](https://github.com/nrepl/nrepl/issues/16): Use a single session thread per evaluation.
 


### PR DESCRIPTION
When testing with fastlane transports, the REPL was being
started using bencode and was giving an "The transport's socket
appears to have lost its connection to the nREPL server" error.

We add a `transport` key to `run-repl` args so it can be
connect to the server using the right transport.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

Thanks!
