### PR TITLE
Fixes nREPL initialization with `:ack` port at cmd line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### master (unreleased)
 
-### Changes
+#### Bugs fixed
+
+* Make sure ack port parameter is converted to integer for command line nREPL initialization.
+
+#### Changes
 
 * [#16](https://github.com/nrepl/nrepl/issues/16): Use a single session thread per evaluation.
 

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -269,7 +269,7 @@
             greeting-fn (if (= transport #'transport/tty) #'transport/tty-greeting)
             server (start-server :port port :bind bind :handler handler
                                  :transport-fn transport :greeting-fn greeting-fn)]
-        (when-let [ack-port (:ack options)]
+        (when-let [ack-port (some-> (:ack options) ->int)]
           (binding [*out* *err*]
             (println (format "ack'ing my port %d to other server running on port %d"
                              (:port server) ack-port)


### PR DESCRIPTION
Start nREPL with a ack port from the command line
raises a "java.util.IllegalFormatConversionException"
exception because the `format` expects a integer.

This fixes it by converting to int if `:ack` field
is given.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

Thanks!
