### PR TITLE
Remove unused function (#37)

### DIFF
--- a/src/maint/nrepl/impl/docs.clj
+++ b/src/maint/nrepl/impl/docs.clj
@@ -139,5 +139,3 @@ use in e.g. wiki pages, github, etc."
         (if (= *out* file) (println docs)
             (do (spit file docs)
                 (println (str "Regenerated " (.getAbsolutePath file)))))))))
-
-(defn pwd [] (println (.getAbsolutePath (File. "."))))


### PR DESCRIPTION
Removing an unused function which was accidentally included in https://github.com/nrepl/nrepl/pull/94.