### PR TITLE
Fix cmdline tests and use correct transport at `send-ack`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Make sure ack port parameter is converted to integer for command line nREPL initialization.
 * When starting the REPL, make sure the transport option is used correctly.
+* Make sure calling `send-ack` at `cmdline` ns works with the correct transport.
 
 #### Changes
 

--- a/project.clj
+++ b/project.clj
@@ -31,6 +31,7 @@
                                     :sign-releases false}]]
 
   :profiles {:fastlane {:dependencies [[nrepl/fastlane "0.1.0-SNAPSHOT"]]}
+             :test {:dependencies [[com.hypirion/io "0.3.1"]]}
              ;; Clojure versions matrix
              :provided {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
@@ -53,4 +54,5 @@
                                          merge-meta [[:inner 0]]}}}
 
              :eastwood {:plugins [[jonase/eastwood "0.2.6"]]
-                        :eastwood {:config-files ["eastwood.clj"]}}})
+                        :eastwood {:config-files ["eastwood.clj"]}
+                        :dependencies [[com.hypirion/io "0.3.1"]]}})

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -274,7 +274,7 @@
           (binding [*out* *err*]
             (println (format "ack'ing my port %d to other server running on port %d"
                              (:port server) ack-port)
-                     (:status (send-ack (:port server) ack-port)))))
+                     (:status (send-ack (:port server) ack-port transport)))))
         (let [port (:port server)
               ^java.net.ServerSocket ssocket (:server-socket server)
               host (.getHostName (.getInetAddress ssocket))]

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -2,38 +2,89 @@
   {:author "Chas Emerick"}
   (:require
    [clojure.test :refer :all]
+   [nrepl.ack :as ack]
    [nrepl.core :as nrepl]
-   [nrepl.core-test :refer [def-repl-test repl-server-fixture *server*]]))
+   [nrepl.core-test :refer [*server* *transport-fn* transport-fns]]
+   [nrepl.server :as server])
+  (:import (com.hypirion.io Pipe ClosingPipe)))
 
-(use-fixtures :once repl-server-fixture)
+(defn- start-server-for-transport-fn
+  [transport-fn f]
+  (with-open [server (server/start-server
+                      :transport-fn transport-fn
+                      :handler (ack/handle-ack (server/default-handler)))]
+    (binding [*server* server
+              *transport-fn* transport-fn]
+      (testing (str (-> transport-fn meta :name) " transport\n")
+        (ack/reset-ack-port!)
+        (f))
+      (set! *print-length* nil)
+      (set! *print-level* nil))))
 
-(comment  ;TODO
-  (def-repl-test ack
-    (nrepl/reset-ack-port!)
-    (let [server-process (.exec (Runtime/getRuntime)
-                                (into-array ["java" "-Dnreplacktest=y" "-cp" (System/getProperty "java.class.path")
-                                             "nrepl.main" "--ack" (str (:port *server*))]))
-          acked-port (nrepl/wait-for-ack 20000)]
-      (try
-        (is acked-port "Timed out waiting for ack")
-        (when acked-port
-          (with-open [c2 (nrepl/connect acked-port)]
-          ;; just a sanity check
-            (is (= "y" (-> (((:send c2) "(System/getProperty \"nreplacktest\")")) nrepl/read-response-value :value)))))
-        (finally
-          (.destroy server-process)))))
+(defn- server-cmdline-fixture
+  [f]
+  (doseq [transport-fn transport-fns]
+    (start-server-for-transport-fn transport-fn f)))
 
-  (def-repl-test explicit-port-argument
-    (nrepl/reset-ack-port!)
-    (let [free-port (with-open [ss (java.net.ServerSocket.)]
-                      (.bind ss nil)
-                      (.getLocalPort ss))
-          server-process (.exec (Runtime/getRuntime)
-                                (into-array ["java" "-Dnreplacktest=y" "-cp" (System/getProperty "java.class.path")
-                                             "nrepl.main" "--port" (str free-port) "--ack" (str (:port *server*))]))
-          acked-port (nrepl/wait-for-ack 20000)]
-      (try
-        (is acked-port "Timed out waiting for ack")
-        (is (= acked-port free-port))
-        (finally
-          (.destroy server-process))))))
+(use-fixtures :each server-cmdline-fixture)
+
+(defn- var->str
+  [sym]
+  (subs (str sym) 2))
+
+(defn- sh
+  "A version of clojure.java.shell/sh that streams in/out/err.
+  Taken and edited from https://github.com/technomancy/leiningen/blob/f7e1adad6ff5137d6ea56bc429c3b620c6f84128/leiningen-core/src/leiningen/core/eval.clj"
+  [& cmd]
+  (let [proc (.exec (Runtime/getRuntime) (into-array String cmd))]
+    (.addShutdownHook (Runtime/getRuntime)
+                      (Thread. (fn [] (.destroy proc))))
+    (with-open [out (.getInputStream proc)
+                err (.getErrorStream proc)
+                in (.getOutputStream proc)]
+      (let [pump-out (doto (Pipe. out System/out) .start)
+            pump-err (doto (Pipe. err System/err) .start)
+            pump-in (ClosingPipe. System/in in)]
+        proc))))
+
+(deftest ack
+  (let [ack-port (:port *server*)
+        server-process (apply sh ["java" "-Dnreplacktest=y"
+                                  "-cp" (System/getProperty "java.class.path")
+                                  "nrepl.main"
+                                  "--ack" (str ack-port)
+                                  "--transport" (var->str *transport-fn*)])
+        acked-port (ack/wait-for-ack 10000)]
+    (try
+      (is acked-port "Timed out waiting for ack")
+      (when acked-port
+        (with-open [transport-2 (nrepl/connect :port acked-port
+                                               :transport-fn *transport-fn*)]
+          (let [client (nrepl/client transport-2 1000)]
+            ;; just a sanity check
+            (is (= "y"
+                   (-> (nrepl/message client {:op :eval
+                                              :code "(System/getProperty \"nreplacktest\")"})
+                       first
+                       nrepl/read-response-value
+                       :value))))))
+      (finally
+        (.destroy server-process)))))
+
+(deftest explicit-port-argument
+  (let [ack-port (:port *server*)
+        free-port (with-open [ss (java.net.ServerSocket.)]
+                    (.bind ss nil)
+                    (.getLocalPort ss))
+        server-process (apply sh ["java" "-Dnreplacktest=y"
+                                  "-cp" (System/getProperty "java.class.path")
+                                  "nrepl.main"
+                                  "--port" (str free-port)
+                                  "--ack" (str ack-port)
+                                  "--transport" (var->str *transport-fn*)])
+        acked-port (ack/wait-for-ack 10000)]
+    (try
+      (is (= acked-port free-port))
+      (finally
+        (Thread/sleep 2000)
+        (.destroy server-process)))))

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -447,6 +447,16 @@
       (Thread/sleep 100)
       (is (thrown? SocketException (transport/send transport {"op" "eval" "code" "(+ 5 1)"}))))))
 
+(deftest server-starts-with-minimal-configuration
+  (testing "Ensure server starts with minimal configuration"
+    (let [server (server/start-server)
+          transport (connect :port (:port server))
+          client (client transport Long/MAX_VALUE)]
+      (is (= ["3"]
+             (-> (message client {:op :eval :code "(- 4 1)"})
+                 combine-responses
+                 :value))))))
+
 (def-repl-test clients-fail-on-disconnects
   (testing "Ensure that clients fail ASAP when the server they're connected to goes down."
     (let [resp (repl-eval client "1 2 3 4 5 6 7 8 9 10")]


### PR DESCRIPTION
`cmdline` ns  was not being test anymore, it starts to
add some tests so we can have more confidence in how
nREPL UI works.

Also fixes `send-ack` at `cmdline` ns with the correct
transport.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

Thanks!
