### PR TITLE
Stop reading and evaluating code on first read error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### Changes
 
 * [#16](https://github.com/nrepl/nrepl/issues/16): Use a single session thread per evaluation.
+* [#107](https://github.com/nrepl/nrepl/issues/107): Stop reading and evaluating code on first read error.
 * Support single-arity printer functions.
 * Restore the `nrepl.bencode` namespace.
 

--- a/doc/modules/ROOT/pages/ops.adoc
+++ b/doc/modules/ROOT/pages/ops.adoc
@@ -59,7 +59,7 @@ Returns::
 
 === `:eval`
 
-Evaluates code.
+Evaluates code. Note that unlike regular stream-based Clojure REPLs, nREPL's ``:eval`` short-circuits on first read error and will not try to read and execute the remaining code in the message.
 
 Required parameters::
 * `:code` The code to be evaluated.


### PR DESCRIPTION
This has bothered me for a long long time.

Consider this example (default Clojure REPL):

```clj
user=> (comment {:a} (println "BOOM!"))
Syntax error reading source at (REPL:1:14).
Map literal must contain an even number of forms
BOOM!
nil
Syntax error reading source at (REPL:1:33).
Unmatched delimiter: )
```

Or this one:

```clj
user=> (defn foo [] (println {:a}) (println "BOOM!"))
Syntax error reading source at (REPL:8:27).
Map literal must contain an even number of forms
Syntax error reading source at (REPL:8:28).
Unmatched delimiter: )
BOOM!
nil
Syntax error reading source at (REPL:8:47).
Unmatched delimiter: )
```

Observe how because of a *syntactic error* (odd number of elements in a map) the println form gets executed, even though it shouldn't (since it's in `comment` and `defn` form respectively).

Besides this potentially dangerous but rare behavior, there is also an much more common inconvenience when you have to debug such errors. What should be the result of evaluating a single form triggers multiple exceptions, all but one of which don't make any sense. They obscure the original problem and make life harder, especially to the beginners. This is even more jarring in CIDER since it only displays the last exception in its stacktrace popup buffer, and that stacktrace is completely unrelated to the actual problem. The only thing to do is to remember that `Unmatched delimiter: )` means you probably have an odd-arg map somewhere. Bleh.

While in default Clojure REPL there isn't much to be done because it is stream based, in nREPL (which is message-based) it is sensible to skip over the whole message if a read error occurs. This is exactly what this patch does – on read error, it discards the remaining content of the StringReader which is passed to the `clojure.main/repl`. Only one (primary) error remains, and the rest of the broken code is not executed.