### PR TITLE
[Fix #111] Fix return-on-incomplete-expr test for clojure 1.10

### DIFF
--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -299,7 +299,8 @@
   (let [{:keys [out status value]} (combine-responses (repl-eval session "(missing paren"))]
     (is (nil? value))
     (is (= #{"done" "eval-error"} status))
-    (is (re-seq #"EOF while reading" (first (repl-values session "(.getMessage *e)"))))))
+    (is (re-seq #"EOF while reading" (first (repl-values session "(or (.getMessage *e)
+                                                                      (-> *e Throwable->map .toString))"))))))
 
 (def-repl-test switch-ns
   (is (= "otherns" (-> (repl-eval session "(ns otherns) (defn function [] 12)")


### PR DESCRIPTION
This PR fixes the return-on-incomplete-expr test for clojure 1.10.

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)
