### PR TITLE
Add more servers and more clients to their respective lists

### DIFF
--- a/doc/modules/ROOT/pages/beyond_clojure.adoc
+++ b/doc/modules/ROOT/pages/beyond_clojure.adoc
@@ -1,13 +1,23 @@
 = Beyond Clojure
 
 As mentioned earlier the nREPL protocol is language-agnostic and can
-be leveraged for many languages that have similar semantics to Clojure
-(in particular the ability to evaluate code at runtime).
+be leveraged for many languages that have the ability to evaluate code
+at runtime.
 
-Here's a listing of alternative nREPL implementations.
+Note than certain clients may make Clojure-specific assumptions which
+will cause bugs when used with other servers while other clients are
+designed with language-agnosticism in mind.
 
-== Alternative Implementations
+== Alternative Server Implementations
 
 * link:https://github.com/Foxboron/HyREPL[HyREPL] - an nREPL for the link:http://hylang.org/[Hy programming language]
 
 * link:https://gitlab.com/technomancy/jeejah[JeeJah] - an nREPL server for link:https://fennel-lang.org/[Fennel] and link:https://www.lua.org/[Lua]
+
+* link:https://gitlab.com/technomancy/ogion[Ogion] - an nREPL server for link:https://racket-lang.org/[Racket]
+
+* link:http://wiki.call-cc.org/eggref/5/nrepl[Chicken NREPL] - an nREPL server for link:https://call-cc.org/[Chicken Scheme]
+
+* link:https://github.com/sjl/cl-nrepl[cl-nrepl] - an nREPL server for Common Lisp
+
+* link:https://github.com/bodil/cljs-noderepl[cljs-noderepl] - an nREPL server for ClojureScript running on Node.js

--- a/doc/modules/ROOT/pages/usage/clients.adoc
+++ b/doc/modules/ROOT/pages/usage/clients.adoc
@@ -8,14 +8,22 @@ client/tool.  Tools that support nREPL include:
 * link:https://cursiveclojure.com[Cursive] (Clojure IDE/plugin for IntelliJ Idea)
 * link:https://github.com/ccw-ide/ccw[Counterclockwise] (Clojure IDE/plugin
   for Eclipse)
-* link:https://github.com/sanel/monroe[monroe] (nREPL client for Emacs)
+* link:https://github.com/sanel/monroe[monroe] (nREPL client for Emacs, works with non-Clojure servers)
 * link:https://github.com/tpope/vim-fireplace[fireplace.vim] (Clojure + nREPL
   support for vim)
+* link:https://leiningen.org/grench[grenchman] (command-line nREPL client written in OCaml, works with non-Clojure servers)
 * link:https://github.com/liquidz/vim-iced[vim-iced] (Clojure Interactive Development Environment for Vim8/Neovim)
 * link:https://github.com/jasongilman/proto-repl[Proto REPL] (Clojure development environment and REPL for Atom)
 * link:https://github.com/BetterThanTomorrow/calva[Calva] (Clojure & ClojureScript support for VS Code)
 * link:https://github.com/trptcolin/reply/[REPL-y] (command-line client for nREPL)
-* link:https://github.com/eraserhd/rep[rep] - A single-shot nREPL client designed for shell invocation.
+* link:https://github.com/eraserhd/rep[rep] (A single-shot nREPL client designed for shell invocation.)
+* link:https://git.sr.ht/~technomancy/shevek/[shevek] (A command-line nREPL client written in link:https://fennel-lang.org/[Fennel], works with non-Clojure servers)
+* link:https://github.com/rksm/node-nrepl-client[node-nrepl-client] (An nREPL client for programmatic use from node.js written in Javascript)
+* link:https://github.com/kanej/parle[Parle] (A command-line nREPL client using node.js written in ClojureScript)
+
+Some of these clients will only work with Clojure nREPL servers, while
+others are built with language-agnosticism and can connect to nREPL
+servers written in any language.
 
 NOTE: Both Leiningen and Boot use internally REPL-y, as their command-line nREPL client.
 


### PR DESCRIPTION
Here's a bunch more implementations I was able to find.

I haven't tried them all, but they should probably be listed anyway.

Also I noticed on the clients page it tells you how to connect to an nREPL server on a remote host but doesn't mention anything about adding encryption or authentication; I think that section of the docs should probably be removed as it is misleading and potentially dangerous.