### PR TITLE
Refactored cmdline for reusability nrepl/nrepl#108 (first cut)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * [#16](https://github.com/nrepl/nrepl/issues/16): Use a single session thread per evaluation.
 * [#107](https://github.com/nrepl/nrepl/issues/107): Stop reading and evaluating code on first read error.
+* [#108](https://github.com/nrepl/nrepl/issues/108): Refactor cmdline functions into a public, reusable API.
 * Restore the `nrepl.bencode` namespace.
 * [#117](https://github.com/nrepl/nrepl/issues/117): Replace
   `nrepl.middleware.pr-values` with `nrepl.middleware.print`.

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -1,11 +1,14 @@
 (ns nrepl.cmdline-test
+  ^:test-refresh/focus
   {:author "Chas Emerick"}
   (:require
    [clojure.test :refer :all]
    [nrepl.ack :as ack]
+   [nrepl.cmdline :as cmd]
    [nrepl.core :as nrepl]
    [nrepl.core-test :refer [*server* *transport-fn* transport-fns]]
-   [nrepl.server :as server])
+   [nrepl.server :as server]
+   [nrepl.transport :as transport])
   (:import (com.hypirion.io Pipe ClosingPipe)))
 
 (defn- start-server-for-transport-fn
@@ -46,6 +49,79 @@
             pump-err (doto (Pipe. err System/err) .start)
             pump-in (ClosingPipe. System/in in)]
         proc))))
+
+(defmacro with-err-str
+  "Evaluates exprs in a context in which *err* is bound to a fresh
+  StringWriter.  Returns the string created by any nested printing
+  calls."
+  [& body]
+  `(let [s# (new java.io.StringWriter)]
+     (binding [*err* s#]
+       ~@body
+       (str s#))))
+
+(deftest repl-intro
+  (is (re-find #"nREPL" (cmd/repl-intro))))
+
+(deftest help
+  (is (re-find #"Usage:" (cmd/help))))
+
+(deftest parse-cli-values
+  (is (= {:other "string"
+          :middleware :middleware
+          :handler :handler
+          :transport :transport}
+         (cmd/parse-cli-values {:other "string"
+                                :middleware ":middleware"
+                                :handler ":handler"
+                                :transport ":transport"}))))
+
+(deftest args->cli-options
+  (is (= [{:middleware :middleware :repl "true"} ["extra" "args"]]
+         (cmd/args->cli-options ["-m" ":middleware" "-r" "true" "extra" "args"]))))
+
+(deftest connection-opts
+  (is (= {:port 5000
+          :host "0.0.0.0"
+          :transport #'transport/bencode
+          :repl-fn #'nrepl.cmdline/run-repl}
+         (cmd/connection-opts {:port "5000"
+                               :host "0.0.0.0"
+                               :transport nil}))))
+
+(deftest server-opts
+  (is (= {:bind "0.0.0.0"
+          :port 5000
+          :transport #'transport/bencode
+          :handler #'clojure.core/identity
+          :repl-fn #'clojure.core/identity
+          :greeting nil
+          :ack-port 2000}
+         (select-keys
+          (cmd/server-opts {:bind "0.0.0.0"
+                            :port 5000
+                            :ack 2000
+                            :handler 'clojure.core/identity
+                            :repl-fn 'clojure.core/identity})
+          [:bind :port :transport :greeting :handler :ack-port :repl-fn]))))
+
+(deftest ack-server
+  (with-redefs [ack/send-ack (fn [_ _ _] true)]
+    (let [output (with-err-str
+                   (cmd/ack-server {:port 6000}
+                                   {:ack-port 8000
+                                    :transport #'transport/bencode}))]
+      (is (= "ack'ing my port 6000 to other server running on port 8000 true\n"
+             output)))))
+
+(deftest server-started-message
+  (with-open [server (server/start-server
+                      :transport-fn #'transport/bencode
+                      :handler server/default-handler)]
+    (is (re-find #"nREPL server started on port \d+ on host .* - .*//.*:\d+"
+                 (cmd/server-started-message
+                  server
+                  {:transport #'transport/bencode})))))
 
 (deftest ack
   (let [ack-port (:port *server*)


### PR DESCRIPTION
## Features
- Addresses issue nrepl/nrepl#108
- Splitting up large cmdline functions into a smaller, reusable API

## API Functions
| name                        | Description                                                                                          |
| --------------------------- | ---------------------------------------------------------------------------------------------------- |
| `args->cli-functions`       | Processes CLI args into options map with keywordized keys.                                           |
| `help-command`              | Displays help copy to user and exits program                                                         |
| `version-command`           | Displays version info and exists program                                                             |
| `get-conn-options`          | Return map of resolved options specific to connecting to a running nREPL server.                     |
| `get-server-options`        | Return map of resolved options specific to starting an nREPL server. Also reuses `get-conn-options`. |
| `connect-command`           | Connects to a running nREPL server                                                                   |
| `ack-server`                | Acknowledges an existing nREPL server running on another port (not a command)                        |
| `print-connection-header`   | Prints the nREPL server connection string that clients like cider parse                              |
| `save-port-file!`           | Writes the server port to a file and deletes it when the program closes                              |
| `interactive-repl-or-sleep` | Runs an nREPL client against the created nREPL server. Corresponds to --interactive CLI flag.        |
| `server-command`            | Server pipeline to create an nREPL server and optionally start an interactive repl.                  |
| `dispatch-commands`         | Simple function to dispatch major commands.                                                          |
| `print-repl-intro`          | Displays interactive repl help content.                                                              |

## Checklist

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
> **NOTE:** _Since we decided to discuss the API shape first it's subject to change therefore writing tests at this point would be creating more work for myself. Second, I'm not adding functionality to the cmdline ns so it is still covered by the functional tests that exist for it._
- [X] All tests are passing
- [X] The new code is not generating reflection warnings
- [X] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)
- [X] Ran cljformat
- [X] Ran eastwood
- [X] Generated docs

## Next Steps
Let's discuss the flow, signatures, and names of the proposed API functions and decide what would be best suited for a consistent API across time. After, I'm willing to write tests for all the functions I've created but would like some advice on resolution. I'm also willing to write tests for related functions I did not write, within reason, and perhaps some insight as to the priority.