### PR TITLE
Add middleware for handling evaluation errors

### DIFF
--- a/doc/modules/ROOT/pages/design/middleware.adoc
+++ b/doc/modules/ROOT/pages/design/middleware.adoc
@@ -275,3 +275,40 @@ a middleware descriptor's `:requires` set contains
 * Any requests it handles will contain the key `:nrepl.middleware.print/print-fn`,
   whose value is a function that calls the given printer function with the given
   options – i.e. its signature is `[value writer]`.
+
+== Evaluation Errors
+
+nREPL includes a `caught` middleware which provides a configurable hook for any
+`java.lang.Throwable` that should be conveyed interactively (generally by
+printing to `\*err*`). Like the `print` middleware, any options may be provided
+in either requests or responses (the former taking precedence over the latter if
+any options are specified in both). The following options are supported:
+
+* `:nrepl.middleware.caught/caught`: a fully-qualified symbol naming a var whose
+  function to use to convey interactive errors. Must point to a function that
+  takes a `java.lang.Throwable` as its sole argument. Defaults to
+  `clojure.main/repl-caught`.
+
+* `:nrepl.middleware.caught/print?`: if logical true, the printed value of any
+  interactive errors will be returned in the response (otherwise they will be
+  elided). Delegates to `nrepl.middleware.print` to perform the printing.
+  Defaults to false.
+
+[source,clojure]
+----
+{:op :eval
+ :code "(/ 1 0)"
+ :nrepl.middleware.caught/caught 'my.custom/print-stacktrace
+ :nrepl.middleware.caught/print? true}
+----
+
+The functionality of the `caught` middleware is reusable by other middlewares.
+If a middleware descriptor's `:requires` set contains
+`#'nrepl.middleware.caught/wrap-caught`, then it can expect:
+
+* Any returned responses containing the key `:nrepl.middleware.caught/throwable`
+  will have that key's corresponding value passed to the hook.
+
+* Any handled requests will contain the key
+  `:nrepl.middleware.caught/caught-fn`, whose value is a function that can be
+  called on a `java.lang.Throwable` to convey errors interactively.

--- a/doc/modules/ROOT/pages/ops.adoc
+++ b/doc/modules/ROOT/pages/ops.adoc
@@ -72,6 +72,14 @@ Optional parameters::
 * `:file` The path to the file containing [code]. ``clojure.core/\*file*`` will be bound to this.
 * `:id` An opaque message ID that will be included in responses related to the evaluation, and which may be used to restrict the scope of a later "interrupt" operation.
 * `:line` The line number in [file] at which [code] starts.
+* `:nrepl.middleware.caught/caught` A fully-qualified symbol naming a var whose function to use to convey interactive errors. Must point to a function that takes a ``java.lang.Throwable`` as its sole argument.
+* `:nrepl.middleware.caught/print?` If logical true, the printed value of any interactive errors will be returned in the response (otherwise they will be elided). Delegates to ``nrepl.middleware.print`` to perform the printing. Defaults to false.
+* `:nrepl.middleware.print/buffer-size` The size of the buffer to use when streaming results. Defaults to 1024.
+* `:nrepl.middleware.print/keys` A seq of the keys in the response whose values should be printed.
+* `:nrepl.middleware.print/options` A map of options to pass to the printing function. Defaults to ``nil``.
+* `:nrepl.middleware.print/print` A fully-qualified symbol naming a var whose function to use for printing. Must point to a function with signature [value writer options].
+* `:nrepl.middleware.print/quota` A hard limit on the number of bytes printed for each value.
+* `:nrepl.middleware.print/stream?` If logical true, the result of printing each value will be streamed to the client over one or more messages.
 
 
 Returns::
@@ -113,6 +121,14 @@ Required parameters::
 Optional parameters::
 * `:file-name` Name of source file, e.g. io.clj
 * `:file-path` Source-path-relative path of the source file, e.g. clojure/java/io.clj
+* `:nrepl.middleware.caught/caught` A fully-qualified symbol naming a var whose function to use to convey interactive errors. Must point to a function that takes a ``java.lang.Throwable`` as its sole argument.
+* `:nrepl.middleware.caught/print?` If logical true, the printed value of any interactive errors will be returned in the response (otherwise they will be elided). Delegates to ``nrepl.middleware.print`` to perform the printing. Defaults to false.
+* `:nrepl.middleware.print/buffer-size` The size of the buffer to use when streaming results. Defaults to 1024.
+* `:nrepl.middleware.print/keys` A seq of the keys in the response whose values should be printed.
+* `:nrepl.middleware.print/options` A map of options to pass to the printing function. Defaults to ``nil``.
+* `:nrepl.middleware.print/print` A fully-qualified symbol naming a var whose function to use for printing. Must point to a function with signature [value writer options].
+* `:nrepl.middleware.print/quota` A hard limit on the number of bytes printed for each value.
+* `:nrepl.middleware.print/stream?` If logical true, the result of printing each value will be streamed to the client over one or more messages.
 
 
 Returns::

--- a/doc/modules/ROOT/pages/usage/misc.adoc
+++ b/doc/modules/ROOT/pages/usage/misc.adoc
@@ -72,6 +72,56 @@ intermingled in the result. See the
 <<../design/middleware#_pretty_printing,print middleware documentation>> for a
 more detailed explanation.
 
+== Evaluation Errors
+
+The dynamic var `nrepl.middleware.caught/\*caught-fn*` can be `set!` at the REPL
+to alter how evaluation errors will be handled. Like the `:caught` option to
+`clojure.main/repl`, this is a function that takes a `java.lang.Throwable`
+(default `clojure.main/repl-caught`) and is called when either read, eval, or
+print throws an exception or error.
+
+For example, to automatically print the stacktrace of each error:
+
+[source,clojure]
+----
+user> (set! nrepl.middleware.caught/*caught-fn* clojure.repl/pst)
+#function[clojure.repl/pst]
+user> (first 1)
+IllegalArgumentException Don't know how to create ISeq from: java.lang.Long
+	clojure.lang.RT.seqFrom (RT.java:542)
+	clojure.lang.RT.seq (RT.java:523)
+	clojure.lang.RT.first (RT.java:668)
+	clojure.core/first--4339 (core.clj:55)
+	clojure.core/first--4339 (core.clj:55)
+	user/eval11339 (form-init6612168545889071220.clj:12)
+	user/eval11339 (form-init6612168545889071220.clj:12)
+	clojure.lang.Compiler.eval (Compiler.java:6927)
+	clojure.lang.Compiler.eval (Compiler.java:6890)
+	clojure.core/eval (core.clj:3105)
+	clojure.core/eval (core.clj:3101)
+	clojure.main/repl/read-eval-print--7408/fn--7411 (main.clj:240)
+
+user=>
+----
+
+Or to use the link:https://github.com/AvisoNovate/pretty[pretty] stacktrace
+printing library to print stacktraces:
+
+[source,clojure]
+----
+user=> (set! nrepl.middleware.caught/*caught-fn* io.aviso.repl/pretty-pst)
+#function[io.aviso.repl/pretty-pst]
+user=> (first 1)
+ clojure.core/eval   core.clj: 3214
+               ...
+     user/eval5945  REPL Input
+clojure.core/first   core.clj:   55
+               ...
+java.lang.IllegalArgumentException: Don't know how to create ISeq from: java.lang.Long
+
+user=>
+----
+
 == Hot-loading dependencies
 
 From time to time you'd want to experiment with some library without

--- a/src/clojure/nrepl/middleware/caught.clj
+++ b/src/clojure/nrepl/middleware/caught.clj
@@ -1,0 +1,101 @@
+(ns nrepl.middleware.caught
+  "Support for a hook for conveying errors interactively, akin to the `:caught`
+  option of `clojure.main/repl`. See the docstring of `wrap-caught` and the
+  Evaluation Errors section of the Middleware documentation for more
+  information."
+  {:author "Michael Griffiths"
+   :added  "0.6.0"}
+  (:require
+   [clojure.main]
+   [nrepl.middleware :refer [set-descriptor!]]
+   [nrepl.middleware.print :as print]
+   [nrepl.misc :as misc]
+   [nrepl.transport :as transport])
+  (:import
+   (nrepl.transport Transport)))
+
+(def ^:dynamic *caught-fn*
+  "Function to use to convey interactive errors (generally by printing to
+  `*err*`). Takes one argument, a `java.lang.Throwable`."
+  clojure.main/repl-caught)
+
+(def default-bindings
+  {#'*caught-fn* *caught-fn*})
+
+(defn- bound-configuration
+  []
+  {::caught-fn *caught-fn*})
+
+(def configuration-keys
+  [::caught-fn ::print?])
+
+(defn- resolve-caught
+  [{:keys [::caught transport] :as msg}]
+  (when-let [var-sym (some-> caught (symbol))]
+    (let [caught-var (misc/requiring-resolve var-sym)]
+      (when-not caught-var
+        (let [resp {:status ::error
+                    ::error (str "Couldn't resolve var " var-sym)}]
+          (transport/send transport (misc/response-for msg resp))))
+      caught-var)))
+
+(defn- caught-transport
+  [{:keys [transport] :as msg} opts]
+  (reify Transport
+    (recv [this]
+      (transport/recv transport))
+    (recv [this timeout]
+      (transport/recv transport timeout))
+    (send [this {:keys [::throwable] :as resp}]
+      (let [{:keys [::caught-fn ::print?]} (-> (merge msg (bound-configuration) resp opts)
+                                               (select-keys configuration-keys))]
+        (when throwable
+          (caught-fn throwable))
+        (transport/send transport (cond-> (apply dissoc resp configuration-keys)
+                                    (and throwable print?)
+                                    (update ::print/keys (fnil conj []) ::throwable)
+                                    (not print?)
+                                    (dissoc ::throwable))))
+      this)))
+
+(defn wrap-caught
+  "Middleware that provides a hook for any `java.lang.Throwable` that should be
+  conveyed interactively (generally by printing to `*err*`).
+
+  Returns a handler which calls said hook on the `::caught/throwable` slot of
+  messages sent via the request's transport.
+
+  Supports the following options:
+
+  * `::caught` – a fully-qualified symbol naming a var whose function to use to
+  convey interactive errors. Must point to a function that takes a
+  `java.lang.Throwable` as its sole argument.
+
+  * `::caught-fn` – the function to use to convey interactive errors. Will be
+  resolved from the above option if provided. Defaults to
+  `clojure.main/repl-caught`. Must take a `java.lang.Throwable` as its sole
+  argument.
+
+  * `::print?` – if logical true, the printed value of any interactive errors
+  will be returned in the response (otherwise they will be elided). Delegates to
+  `nrepl.middleware.print` to perform the printing. Defaults to false.
+
+  The options may be specified in either the request or the responses sent on
+  its transport. If any options are specified in both, those in the request will
+  be preferred."
+  [handler]
+  (fn [msg]
+    (let [caught-var (resolve-caught msg)
+          msg (assoc msg ::caught-fn (or caught-var *caught-fn*))
+          opts (cond-> (select-keys msg configuration-keys)
+                 ;; no caught-fn provided in the request, so defer to the response
+                 (nil? caught-var)
+                 (dissoc ::caught-fn)
+                 ;; in bencode empty list is logical false
+                 (contains? msg ::print?)
+                 (update ::print? #(if (= [] %) false (boolean %))))]
+      (handler (assoc msg :transport (caught-transport msg opts))))))
+
+(set-descriptor! #'wrap-caught {:requires #{#'print/wrap-print}
+                                :expects #{}
+                                :handles {}})

--- a/src/clojure/nrepl/middleware/caught.clj
+++ b/src/clojure/nrepl/middleware/caught.clj
@@ -99,3 +99,7 @@
 (set-descriptor! #'wrap-caught {:requires #{#'print/wrap-print}
                                 :expects #{}
                                 :handles {}})
+
+(def wrap-caught-optional-arguments
+  {"nrepl.middleware.caught/caught" "A fully-qualified symbol naming a var whose function to use to convey interactive errors. Must point to a function that takes a `java.lang.Throwable` as its sole argument."
+   "nrepl.middleware.caught/print?" "If logical true, the printed value of any interactive errors will be returned in the response (otherwise they will be elided). Delegates to `nrepl.middleware.print` to perform the printing. Defaults to false."})

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -150,11 +150,13 @@
                             {:doc "Evaluates code. Note that unlike regular stream-based Clojure REPLs, nREPL's `:eval` short-circuits on first read error and will not try to read and execute the remaining code in the message."
                              :requires {"code" "The code to be evaluated."
                                         "session" "The ID of the session within which to evaluate the code."}
-                             :optional {"id" "An opaque message ID that will be included in responses related to the evaluation, and which may be used to restrict the scope of a later \"interrupt\" operation."
-                                        "eval" "A fully-qualified symbol naming a var whose function value will be used to evaluate [code], instead of `clojure.core/eval` (the default)."
-                                        "file" "The path to the file containing [code]. `clojure.core/*file*` will be bound to this."
-                                        "line" "The line number in [file] at which [code] starts."
-                                        "column" "The column number in [file] at which [code] starts."}
+                             :optional (merge caught/wrap-caught-optional-arguments
+                                              print/wrap-print-optional-arguments
+                                              {"id" "An opaque message ID that will be included in responses related to the evaluation, and which may be used to restrict the scope of a later \"interrupt\" operation."
+                                               "eval" "A fully-qualified symbol naming a var whose function value will be used to evaluate [code], instead of `clojure.core/eval` (the default)."
+                                               "file" "The path to the file containing [code]. `clojure.core/*file*` will be bound to this."
+                                               "line" "The line number in [file] at which [code] starts."
+                                               "column" "The column number in [file] at which [code] starts."})
                              :returns {"ns" "*ns*, after successful evaluation of `code`."
                                        "values" "The result of evaluating `code`, often `read`able. This printing is provided by the `print` middleware. Superseded by `ex` and `root-ex` if an exception occurs during evaluation."
                                        "ex" "The type of exception thrown, if any. If present, then `values` will be absent."

--- a/src/clojure/nrepl/middleware/print.clj
+++ b/src/clojure/nrepl/middleware/print.clj
@@ -236,3 +236,11 @@
 (set-descriptor! #'wrap-print {:requires #{}
                                :expects #{}
                                :handles {}})
+
+(def wrap-print-optional-arguments
+  {"nrepl.middleware.print/print" "A fully-qualified symbol naming a var whose function to use for printing. Must point to a function with signature [value writer options]."
+   "nrepl.middleware.print/options" "A map of options to pass to the printing function. Defaults to `nil`."
+   "nrepl.middleware.print/stream?" "If logical true, the result of printing each value will be streamed to the client over one or more messages."
+   "nrepl.middleware.print/buffer-size" "The size of the buffer to use when streaming results. Defaults to 1024."
+   "nrepl.middleware.print/quota" "A hard limit on the number of bytes printed for each value."
+   "nrepl.middleware.print/keys" "A seq of the keys in the response whose values should be printed."})

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -8,7 +8,7 @@
    [nrepl.misc :refer [uuid response-for]]
    [nrepl.transport :as t])
   (:import
-   (clojure.lang LineNumberingPushbackReader)
+   (clojure.lang Compiler$CompilerException LineNumberingPushbackReader)
    (java.io Reader)
    (java.util.concurrent.atomic AtomicLong)
    (java.util.concurrent BlockingQueue LinkedBlockingQueue SynchronousQueue
@@ -142,6 +142,13 @@
      (binding [*msg* msg]
        (evaluate msg))
      the-session)))
+
+(defn interrupted?
+  "Returns true if the given throwable was ultimately caused by an interrupt."
+  [^Throwable e]
+  (or (instance? ThreadDeath (clojure.main/root-cause e))
+      (and (instance? Compiler$CompilerException e)
+           (instance? ThreadDeath (.getCause e)))))
 
 (defn session-exec
   "Takes a session id and returns a maps of three functions meant for interruptible-eval:

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -1,7 +1,8 @@
 (ns nrepl.misc
   "Misc utilities used in nREPL's implementation (potentially also
   useful for anyone extending it)."
-  {:author "Chas Emerick"})
+  {:author "Chas Emerick"}
+  (:refer-clojure :exclude [requiring-resolve]))
 
 (defn log
   [ex & msgs]
@@ -48,3 +49,14 @@
                                                (-> session meta :id)
                                                session)}))]
     (merge basis response)))
+
+(defn requiring-resolve
+  "Resolves namespace-qualified sym per 'resolve'. If initial resolve fails,
+  attempts to require sym's namespace and retries. Returns nil if sym could not
+  be resolved."
+  [sym]
+  (or (resolve sym)
+      (try
+        (require (symbol (namespace sym)))
+        (resolve sym)
+        (catch Exception _))))


### PR DESCRIPTION
Since #101 we only update the session atom in the `:prompt` REPL phase. This means any middlewares using `(get @session #'*e)` during the `:caught` phase to access the thrown error will no longer work (`cider.nrepl.middleware.inspect` is the case that I have found). Arguably that was relying on an implementation detail of nREPL – I think a better way is to simply convey the thrown error as a value in the response, and handle it elsewhere.

For now we just call `clojure.main/repl-caught` on the error as before, and still return `ex` / `root-ex` from eval to maintain compatibility. In the future, we can look at making it configurable.