### PR TITLE
Make nrepl.cmdline runnable from uberjar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,6 +43,7 @@
              :sysutils {:plugins [[lein-sysutils "0.2.0"]]}
              :maint {:source-paths ["src/maint"]
                      :dependencies [[org.clojure/tools.cli "0.4.1"]]}
+             :aot {:aot [nrepl.cmdline]}
 
              ;; CI tools
              :cloverage [:test

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -12,7 +12,8 @@
    [nrepl.ack :refer [send-ack]]
    [nrepl.server :as nrepl-server]
    [nrepl.transport :as transport]
-   [nrepl.version :as version]))
+   [nrepl.version :as version])
+  (:gen-class))
 
 (defn- clean-up-and-exit
   "Performs any necessary clean up and calls `(System/exit status)`."


### PR DESCRIPTION
Hi, it's more like an issue, but code diff is better than words :)
I want to use nrepl with existing jars without modifying them, like that:

```
lein with-profile +1.10,+aot uberjar
java -cp some.jar:nrepl-standalone.jar nrepl.cmdline -b 127.0.0.1 -p 7888
```

1) to live without `clj` command line I have to `:gen-class`
2) almost sure that global `:aot [nrepl.cmdline]` will break release jars, that's why a profile, another way could be a simplest new ns just to include `:gen-class` and refer `nrepl.cmdline/-main`
3) even if you're ok with that - not sure how to release it, afaik it's a bad practice to include aoted nses (even one?) into clojars releases