### PR TITLE
Cleaning up CI a bit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,10 +198,10 @@ workflows:
                 name: Verifying Cljdoc
                 command: |
                   make verify_cljdoc
-      - util_job:
-          name: Code coverage
-          steps:
-            - run:
-                name: Running cloverage
-                command: |
-                  make cloverage
+      # - util_job:
+      #     name: Code coverage
+      #     steps:
+      #       - run:
+      #           name: Running cloverage
+      #           command: |
+      #             make cloverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,10 +198,3 @@ workflows:
                 name: Verifying Cljdoc
                 command: |
                   make verify_cljdoc
-      # - util_job:
-      #     name: Code coverage
-      #     steps:
-      #       - run:
-      #           name: Running cloverage
-      #           command: |
-      #             make cloverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,8 @@ jobs:
             - run:
                 name: Running tests
                 command: make test
+            - store_test_results:
+                path: test-results
 
 # The ci-test-matrix does the following:
 #

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ target
 /.lein*
 /.nrepl-port
 pom.xml
+build.xml
+/test-results

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,9 @@
 .PHONY: test docs eastwood cljfmt cloverage release deploy clean
 
-VERSION ?= 1.9
-
-# Some tests need to be filtered based on JVM version.  This selector
-# will be mapped to a function in project.clj, and that function
-# determines which `deftest` to run based on their metadata.
-JAVA_VERSION := $(shell lein with-profile +sysutils \
-                        sysutils :java-version-simple | cut -d " " -f 2)
-TEST_SELECTOR := :java$(JAVA_VERSION)
+VERSION ?= 1.10
 
 test:
-	lein with-profile +$(VERSION) test $(TEST_SELECTOR)
+	lein with-profile +$(VERSION),+test test
 
 eastwood:
 	lein with-profile +$(VERSION),+eastwood eastwood

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,15 @@
 
 VERSION ?= 1.10
 
+# Some tests need to be filtered based on JVM version.  This selector
+# will be mapped to a function in project.clj, and that function
+# determines which `deftest` to run based on their metadata.
+JAVA_VERSION := $(shell lein with-profile +sysutils \
+                        sysutils :java-version-simple | cut -d " " -f 2)
+TEST_SELECTOR := :java$(JAVA_VERSION)
+
 test:
-	lein with-profile +$(VERSION),+test test
+	lein with-profile +$(VERSION),+test test $(TEST_SELECTOR)
 
 eastwood:
 	lein with-profile +$(VERSION),+eastwood eastwood

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,10 @@
                                     :sign-releases false}]]
 
   :profiles {:fastlane {:dependencies [[nrepl/fastlane "0.1.0"]]}
-             :test {:dependencies [[com.hypirion/io "0.3.1"]]}
+             :test {:dependencies [[com.hypirion/io "0.3.1"]]
+                    :plugins      [[test2junit "1.4.2"]]
+                    :test2junit-output-dir "test-results"
+                    :aliases {"test" "test2junit"}}
              ;; Clojure versions matrix
              :provided {:dependencies [[org.clojure/clojure "1.10.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}


### PR DESCRIPTION
- Adding JUnit output, so CircleCI knows more about history of what tests tend to fail etc. Have a look [here](https://circleci.com/build-insights/gh/shen-tian/nrepl/junit-output) to see what it looks like.
- Default to Clojure 1.10 for `Makefile`.
- Skipping the Cloverage job. It's causing more noise than it's worth at the moment.