### PR TITLE
Fixing the stream-printing test

### DIFF
--- a/src/clojure/nrepl/transport.clj
+++ b/src/clojure/nrepl/transport.clj
@@ -105,7 +105,9 @@
    (let [in (PushbackInputStream. (io/input-stream in))
          out (io/output-stream out)]
      (fn-transport
-      #(let [payload (rethrow-on-disconnection s (bencode/read-bencode in))
+      #(let [payload (rethrow-on-disconnection s
+                                               (locking in
+                                                 (bencode/read-bencode in)))
              unencoded (<bytes (payload "-unencoded"))
              to-decode (apply dissoc payload "-unencoded" unencoded)]
          (merge (dissoc payload "-unencoded")

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -344,7 +344,7 @@
                                                 :code (code (range))
                                                 ::middleware.print/stream? 1})
                               (map #(dissoc % :id :session)))
-          _ (Thread/sleep 500)
+          _ (Thread/sleep 12)
           interrupt-responses (->> (message session {:op :interrupt})
                                    (mapv #(dissoc % :id :session)))]
       ;; check the interrupt succeeded first; otherwise eval-responses will not terminate

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -344,7 +344,7 @@
                                                 :code (code (range))
                                                 ::middleware.print/stream? 1})
                               (map #(dissoc % :id :session)))
-          _ (Thread/sleep 100)
+          _ (Thread/sleep 500)
           interrupt-responses (->> (message session {:op :interrupt})
                                    (mapv #(dissoc % :id :session)))]
       ;; check the interrupt succeeded first; otherwise eval-responses will not terminate

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -344,7 +344,7 @@
                                                 :code (code (range))
                                                 ::middleware.print/stream? 1})
                               (map #(dissoc % :id :session)))
-          _ (Thread/sleep 12)
+          _ (Thread/sleep 100)
           interrupt-responses (->> (message session {:op :interrupt})
                                    (mapv #(dissoc % :id :session)))]
       ;; check the interrupt succeeded first; otherwise eval-responses will not terminate


### PR DESCRIPTION
Think I've isolated the sub-test that fails for #132. Using this PR to trigger some re-runs to see if a longer wait makes it more robust.