### PR TITLE
Moving all stringification into bencode encoder itself.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### New features
 
-* [#60](https://github.com/nrepl/nrepl/issues/60): Implemented EDN transport.
+* [#60](https://github.com/nrepl/nrepl/issues/60): Implemented EDN transport
+
+### Changes
+
+* [#137](https://github.com/nrepl/nrepl/pull/137): Expanded Bencode writer to work with
+  maps that has keywords or symbols as keys. This allowed a simplification of the
+  Bencode transport itself.
 
 ## 0.6.0 (2019-02-05)
 

--- a/src/clojure/nrepl/bencode.clj
+++ b/src/clojure/nrepl/bencode.clj
@@ -389,9 +389,23 @@
 
 (declare lexicographically)
 
+(defn #^{:private true} thing>string
+  [thing]
+  (cond
+    (string? thing)
+    thing
+    (or (keyword? thing)
+        (symbol? thing))
+    (let [nspace (namespace thing)
+          name   (name thing)]
+      (str (when nspace (str nspace "/")) name))))
+
 (defmethod write-bencode :map
   [#^OutputStream output m]
-  (let [translation (into {} (map (juxt string>payload identity) (keys m)))
+  (let [translation (into {} (map (juxt (comp string>payload
+                                              thing>string)
+                                        identity)
+                                  (keys m)))
         key-strings (sort lexicographically (keys translation))
         >value      (comp m translation)]
     (.write output (int d))

--- a/src/clojure/nrepl/transport.clj
+++ b/src/clojure/nrepl/transport.clj
@@ -23,19 +23,6 @@
      ms or if the underlying channel has been closed.")
   (send [this msg] "Sends msg. Implementations should return the transport."))
 
-;; adapted from clojure.walk to support namespaced keywords
-(defn- stringify-key
-  [k]
-  (cond
-    (and (keyword? k) (namespace k)) (str (namespace k) "/" (name k))
-    (keyword? k) (name k)
-    :else k))
-
-(defn- stringify-keys
-  [m]
-  (let [f (fn [[k v]] [(stringify-key k) v])]
-    (walk/postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m)))
-
 (deftype FnTransport [recv-fn send-fn close]
   Transport
   (send [this msg] (send-fn msg) this)
@@ -120,7 +107,7 @@
       #(rethrow-on-disconnection s
                                  (locking out
                                    (doto out
-                                     (bencode/write-bencode (stringify-keys %))
+                                     (bencode/write-bencode %)
                                      .flush)))
       (fn []
         (if s

--- a/test/clojure/nrepl/bencode_test.clj
+++ b/test/clojure/nrepl/bencode_test.clj
@@ -159,7 +159,10 @@
 (deftest test-map-writing
   (are [x y] (= (>output x :writer write-bencode) y)
     {}             "de"
-    {"ham" "eggs"} "d3:ham4:eggse"))
+    {"ham" "eggs"} "d3:ham4:eggse"
+    {:ham "eggs"}  "d3:ham4:eggse"
+    {'ham "eggs"}  "d3:ham4:eggse"
+    {:h/am "eggs"} "d4:h/am4:eggse"))
 
 (deftest test-nested-writing
   (are [x y] (= (>output x :writer write-bencode) y)


### PR DESCRIPTION
This extends the bencode encoder to handle maps with either keywords or symbols as keywords. Currently, this causes the `write-bencode` function to fail.

This allows us to further simplify the bencode transport, by relieving it of stringification duties.

---

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

Thanks!

*If you're just starting out to hack on nREPL you might find this [section of its
manual][1] extremely useful.*

[1]: https:/nrepl.org/nrepl/hacking_on_nrepl.html
