### PR TITLE
Stringification of all ops internally

### DIFF
--- a/doc/modules/ROOT/pages/design/middleware.adoc
+++ b/doc/modules/ROOT/pages/design/middleware.adoc
@@ -245,7 +245,7 @@ specified in both). The following options are supported:
 
 [source,clojure]
 ----
-{:op :eval
+{:op "eval"
  :code "(+ 1 1)"
  :nrepl.middleware.print/print 'my.custom/print-value
  :nrepl.middleware.print/options {:print-width 120}
@@ -296,7 +296,7 @@ any options are specified in both). The following options are supported:
 
 [source,clojure]
 ----
-{:op :eval
+{:op "eval"
  :code "(/ 1 0)"
  :nrepl.middleware.caught/caught 'my.custom/print-stacktrace
  :nrepl.middleware.caught/print? true}

--- a/doc/modules/ROOT/pages/design/overview.adoc
+++ b/doc/modules/ROOT/pages/design/overview.adoc
@@ -10,22 +10,19 @@ provided by e.g.  terminals).
 
 == Messages
 
-nREPL messages are maps.  The keys and values that may be included in messages
-depends upon the transport being used; different transports may encode messages
-differently, and therefore may or may not be able to represent certain data
-types.
+It is convention to express nREPL messages as EDN maps. For most purposes, it's sufficient to imagine that we communicate with nREPL via EDN, much the same way as we send and receive JSON to and from a REST endpoint. This is typically not what actually happens, and the details are discussed in <<design/transports.adoc,the transport section>>, however, this conceptual simplification serves us well.
 
 === Requests
 
 Each message sent to an nREPL endpoint constitutes a "request" to perform a
-particular operation, which is indicated by a `"op"` entry.  Each operation may
+particular operation, which is indicated by a `:op` entry.  Each operation may
 further require the incoming message to contain other data.  Which data an
 operation requires or may accept varies; for example, a message to evaluate
 some code might look like this:
 
 [source,clojure]
 ----
-{"op" "eval" "code" "(+ 1 2 3)"}
+{:op "eval" :code "(+ 1 2 3)"}
 ----
 
 The result(s) of performing each operation may be sent back to the nREPL client
@@ -38,9 +35,9 @@ The server may produce multiple messages in response to each client message (req
 The structure of the response is unique per each message type, but there are a few
 fundamental properties that will always be around in the responses:
 
-- `id` The ID of the request for which the response was generated.
-- `session` The ID of the session for which the response was generated.
-- `status` The status of the response. Here there would either be something like "done"
+- `:id` The ID of the request for which the response was generated.
+- `:session` The ID of the session for which the response was generated.
+- `:status` The status of the response. Here there would either be something like "done"
 if a request has been fully processed or the reason for a failure (e.g. "namespace-not-found"). Not every
 response message would have the status key. If some request generated multiple response messages only the
 final one would have the status attached to it.
@@ -48,19 +45,19 @@ final one would have the status attached to it.
 As mentioned earlier each op would produce different response messages. Here's what you can expect
 to see in responses generated as a result of an `eval` op invocation.
 
-- `ns` The stringified value of `*ns*` at the time of the response message's
+- `:ns` The stringified value of `*ns*` at the time of the response message's
   generation.
-- `out` Contains content written to `*out*` while the request's code was being evaluated.  Messages containing `*out*` content may be sent at the discretion
+- `:out` Contains content written to `*out*` while the request's code was being evaluated.  Messages containing `*out*` content may be sent at the discretion
 of the server, though at minimum corresponding with flushes of the underlying
 stream/writer.
-- `err` Same as `out`, but for `*err*`.
-- `value` The result of printing a result of evaluating a form in the code sent
+- `:err` Same as `:out`, but for `*err*`.
+- `:value` The result of printing a result of evaluating a form in the code sent
   in the corresponding request.  More than one value may be sent, if more than
 one form can be read from the request's code string.  In contrast to the output
 written to `*out*` and `*err*`, this may be usefully/reliably read and utilized
 by the client, e.g. in tooling contexts, assuming the evaluated code returns a
 printable and readable value.  Interactive clients will likely want to simply
-stream `value`'s content to their UI's primary output / log.
+stream `:value`'s content to their UI's primary output / log.
 
 Note that evaluations that are interrupted may nevertheless result
 in multiple response messages being sent prior to the interrupt

--- a/doc/modules/ROOT/pages/design/transports.adoc
+++ b/doc/modules/ROOT/pages/design/transports.adoc
@@ -24,7 +24,7 @@ link:https://github.com/nrepl/nrepl/wiki/Extensions[Other nREPL transports are p
 
 == Bencode Transport
 
-Bencode is a relatively simple format, and comprises of of two scalar types (byte strings and integer) and two collection types (dictionaries and lists).
+This is, and will mostly likely remain, nREPL's default and primary transport. It is pronounced B-Encode, and is a relatively simple format, comprising of only two scalar types (byte strings and integer) and two collection types (dictionaries and lists).
 
 A simple nREPL message, to run the operation `eval` on the code `(+ 2 2)` would look like this in bencode (linebreaks added for clarity):
 
@@ -44,11 +44,29 @@ In documentation, this message would typically be expressed in EDN format:
 {:op "eval" :code "(+ 2 2)"}
 ----
 
-which, once encoded, would yield the above bencode message. Since bencode does not have a keyword type, Clojure keywords are encoded and transmitted as strings. nREPL server performs a `keywordize-keys` operation on the decoded map. Thus, the use of keywords in writing nREPL message is mainly for clarity. The following messages, when encoded using nREPL's bencode encoder and received by nREPL, are eqivalent:
+Given that many, if not most, nREPL client do not use EDN as their native data formats, it's best to think of this as the format of a message once received by nREPL. Correpondingly, responses are in the form they take just before being sent through the transport.
+
+nREPL's bencode encoder/decoder performs the following type conversions:
+
+.How nrepl.bencode handles types
+|=======================================
+| EDN type > | Bencode type > | EDN type
+
+| String     | String         | String
+| Keyword    | String         | String
+| Symbol     | String         | String
+| Integer    | Integer        | Integer
+| Map        | Dictionary     | Map
+| Vector     | List           | Vector 
+| List       | List           | Vector
+| Set        | List           | Vector
+|=======================================
+
+In addition, nREPL server performs a `keywordize-keys` operation on the recieved map, restoring the likes of `:op` and `:code` to keywords. Thus, the use of keywords in writing nREPL message is mainly for clarity. The following messages, when encoded using nREPL's bencode encoder and received by nREPL, are eqivalent:
 
 [source,clojure]
 ----
- {:op "eval"  ...}
+ {:op "eval"  ...} ;; this is also the internal representation
  {:op :eval ...}
  {"op" "eval" ...}
  {"op" :eval ...}
@@ -68,6 +86,24 @@ in the future.
 
 NOTE: The EDN transport was introduced in nREPL 0.7.
 
+The main difference between the bencode transport and the EDN one is that instead of bencode dictionaries and lists, and being limited to integer and byte string types, you'd be sending and receiving full EDN structures and types, including maps, vectors, lists, sets, strings, keywords and symbols. The structures of the messages is similar, only the data format changes.
+
+This may be useful in a couple of usecases: In some clients, including ClojureScript ones, where EDN is easier to handle than bencode. Furthermore, because this transport exposes more of the richer data types in the internals of nREPL and its middlewares, it may support more complex usecases.
+
+The introduction of the EDN transport does require more specification of the message format, whereby some vagueness was allowed for by the limitatioms of bencode. For example, `:op` values are strings, and `:status` is either a keyword, or a set of keywords. This may cause some surprised, unintended consequences. Thus tweaks to the EDN message format may be possible until the transport is declared mature. Documentation of this using `clojure.spec` is planned.
+
+For example, of the (same as before) four messages
+
+[source,clojure]
+----
+ {:op "eval"  ...}
+ {:op :eval ...}
+ {"op" "eval" ...}
+ {"op" :eval ...}
+----
+
+the first one is considered canonical, though nREPL will accept the second one as well. The third and fourth one will not work.
+
 Using the EDN transport is pretty simple. You just need to start an nREPL server with EDN transport and you're good to go:
 
 [source,clojure]
@@ -86,24 +122,6 @@ You can also start an nREPL with a EDN transport using `clj`:
 $ clj -R:nrepl -m nrepl.cmdline -t nrepl.transport/edn
 nREPL server started on port 63266 on host localhost - nrepl+edn://localhost:63266
 ----
-
-The main difference between the bencode transport and the EDN one is that instead of bencode dictionaries and lists, and being limited to integer and byte string types, you'd be sending and receiving full EDN structures and types, including maps, vectors, lists, sets, strings, keywords and symbols. The structures of the messages is similar, only the data format changes.
-
-This may be useful in a couple of usecases: In some clients, including ClojureScript ones, where EDN is easier to handle than bencode. Furthermore, because this transport exposes more of the richer data types in the internals of nREPL and its middlewares, it may support more complex usecases.
-
-The introduction of the EDN transport does require more specification of the message format, whereby some vagueness was allowed for by the limitatioms of bencode. For example, `:op` values are strings, and `:status` is either a keyword, or a set of keywords. This may cause some surprised, unintended consequences. Thus tweaks to the EDN message format may be possible until the transport is declared mature. Documentation of this using `clojure.spec` is planned.
-
-For example, of the (same) four messages
-
-[source,clojure]
-----
- {:op "eval"  ...}
- {:op :eval ...}
- {"op" "eval" ...}
- {"op" :eval ...}
-----
-
-the first one is considered canonical, though nREPL will accept the second one as well. The third and fourth one will not work.
 
 == TTY Transport
 

--- a/doc/modules/ROOT/pages/design/transports.adoc
+++ b/doc/modules/ROOT/pages/design/transports.adoc
@@ -22,41 +22,37 @@ NOTE: It's the bencode transport that is used by default by
 
 link:https://github.com/nrepl/nrepl/wiki/Extensions[Other nREPL transports are provided by the community].
 
-== TTY Transport
+== Bencode Transport
 
-Using the TTY transport is pretty simple. You just need to start an nREPL server with TTY transport and you're good to go:
+Bencode is a relatively simple format, and comprises of of two scalar types (byte strings and integer) and two collection types (dictionaries and lists).
+
+A simple nREPL message, to run the operation `eval` on the code `(+ 2 2)` would look like this in bencode (linebreaks added for clarity):
+
+----
+d
+4:code
+7:(+ 2 2)
+2:op
+4:eval
+e
+----
+
+In documentation, this message would typically be expressed in EDN format:
 
 [source,clojure]
 ----
-(require
- '[nrepl.server :as server]
- '[nrepl.transport :as transport])
-
-(server/start-server :port 12345 :transport-fn transport/tty :greeting-fn transport/tty-greeting)
+{:op "eval" :code "(+ 2 2)"}
 ----
 
-NOTE: The `:greeting-fn` is responsible for printing the initial message you'll see
-upon connecting.
+which, once encoded, would yield the above bencode message. Since bencode does not have a keyword type, Clojure keywords are encoded and transmitted as strings. nREPL server performs a `keywordize-keys` operation on the decoded map. Thus, the use of keywords in writing nREPL message is mainly for clarity. The following messages, when encoded using nREPL's bencode encoder and received by nREPL, are eqivalent:
 
-Afterwards you can simply connect to the server with some TTY client like `telnet`, `nc` or `inf-clojure`.
-
-[source,shell]
+[source,clojure]
 ----
-$ nc localhost 12345
-
-;; Clojure 1.9.0
-user=>
+ {:op "eval"  ...}
+ {:op :eval ...}
+ {"op" "eval" ...}
+ {"op" :eval ...}
 ----
-
-Starting with nREPL 0.5 you can also start an nREPL with a TTY transport using `clj`:
-
-[source,shell]
-----
-$ clj -R:nrepl -m nrepl.cmdline -t nrepl.transport/tty
-nREPL server started on port 63266 on host localhost - telnet://localhost:63266
-----
-
-== Bencode Transport
 
 There's nothing special you have to do to use the bencode transport,
 as it's the default transport for `nrepl.server/start-server`.
@@ -91,8 +87,54 @@ $ clj -R:nrepl -m nrepl.cmdline -t nrepl.transport/edn
 nREPL server started on port 63266 on host localhost - nrepl+edn://localhost:63266
 ----
 
-The main difference between the bencode transport and the EDN one is that instead of sending and receiving bencode dictionaries and lists, and being limited to integer and byte types, you'd be sending and receiving full EDN structures and types, including maps, vectors, lists, sets, strings, keywords and symbols. The structures of the messages is similar, only the data format changes.
+The main difference between the bencode transport and the EDN one is that instead of bencode dictionaries and lists, and being limited to integer and byte string types, you'd be sending and receiving full EDN structures and types, including maps, vectors, lists, sets, strings, keywords and symbols. The structures of the messages is similar, only the data format changes.
 
 This may be useful in a couple of usecases: In some clients, including ClojureScript ones, where EDN is easier to handle than bencode. Furthermore, because this transport exposes more of the richer data types in the internals of nREPL and its middlewares, it may support more complex usecases.
 
 The introduction of the EDN transport does require more specification of the message format, whereby some vagueness was allowed for by the limitatioms of bencode. For example, `:op` values are strings, and `:status` is either a keyword, or a set of keywords. This may cause some surprised, unintended consequences. Thus tweaks to the EDN message format may be possible until the transport is declared mature. Documentation of this using `clojure.spec` is planned.
+
+For example, of the (same) four messages
+
+[source,clojure]
+----
+ {:op "eval"  ...}
+ {:op :eval ...}
+ {"op" "eval" ...}
+ {"op" :eval ...}
+----
+
+the first one is considered canonical, though nREPL will accept the second one as well. The third and fourth one will not work.
+
+== TTY Transport
+
+Using the TTY transport is pretty simple. You just need to start an nREPL server with TTY transport and you're good to go:
+
+[source,clojure]
+----
+(require
+ '[nrepl.server :as server]
+ '[nrepl.transport :as transport])
+
+(server/start-server :port 12345 :transport-fn transport/tty :greeting-fn transport/tty-greeting)
+----
+
+NOTE: The `:greeting-fn` is responsible for printing the initial message you'll see
+upon connecting.
+
+Afterwards you can simply connect to the server with some TTY client like `telnet`, `nc` or `inf-clojure`.
+
+[source,shell]
+----
+$ nc localhost 12345
+
+;; Clojure 1.9.0
+user=>
+----
+
+Starting with nREPL 0.5 you can also start an nREPL with a TTY transport using `clj`:
+
+[source,shell]
+----
+$ clj -R:nrepl -m nrepl.cmdline -t nrepl.transport/tty
+nREPL server started on port 63266 on host localhost - telnet://localhost:63266
+----

--- a/doc/modules/ROOT/pages/design/transports.adoc
+++ b/doc/modules/ROOT/pages/design/transports.adoc
@@ -91,6 +91,8 @@ $ clj -R:nrepl -m nrepl.cmdline -t nrepl.transport/edn
 nREPL server started on port 63266 on host localhost - nrepl+edn://localhost:63266
 ----
 
-The main difference between the bencode transport and the EDN one is that instead of sending and receiving
-bencode dictionaries you'd be sending and receiving EDN maps. The structures of the messages is identical, only
-the data format changes.
+The main difference between the bencode transport and the EDN one is that instead of sending and receiving bencode dictionaries and lists, and being limited to integer and byte types, you'd be sending and receiving full EDN structures and types, including maps, vectors, lists, sets, strings, keywords and symbols. The structures of the messages is similar, only the data format changes.
+
+This may be useful in a couple of usecases: In some clients, including ClojureScript ones, where EDN is easier to handle than bencode. Furthermore, because this transport exposes more of the richer data types in the internals of nREPL and its middlewares, it may support more complex usecases.
+
+The introduction of the EDN transport does require more specification of the message format, whereby some vagueness was allowed for by the limitatioms of bencode. For example, `:op` values are strings, and `:status` is either a keyword, or a set of keywords. This may cause some surprised, unintended consequences. Thus tweaks to the EDN message format may be possible until the transport is declared mature. Documentation of this using `clojure.spec` is planned.

--- a/doc/modules/ROOT/pages/hacking_on_nrepl.adoc
+++ b/doc/modules/ROOT/pages/hacking_on_nrepl.adoc
@@ -83,7 +83,7 @@ $ lein test-all
 ----
 
 This will automatically run the tests for every supported Clojure
-profile (e.g. 1.7, 1.8, 1.9). You can run only the tests for a
+profile (e.g. 1.7, 1.8, 1.9, 1.10). You can run only the tests for a
 specific version of Clojure like this:
 
 [source,shell]

--- a/doc/modules/ROOT/pages/ops.adoc
+++ b/doc/modules/ROOT/pages/ops.adoc
@@ -8,7 +8,7 @@ This file is _generated_ by #'nrepl.impl.docs/-main
 
 == Operations
 
-=== `"clone"`
+=== `clone`
 
 Clones the current session, returning the ID of the newly-created session.
 
@@ -24,7 +24,7 @@ Returns::
 
 
 
-=== `"close"`
+=== `close`
 
 Closes the specified session.
 
@@ -39,7 +39,7 @@ Returns::
 {blank}
 
 
-=== `"describe"`
+=== `describe`
 
 Produce a machine- and human-readable directory and documentation for the operations supported by an nREPL endpoint.
 
@@ -57,7 +57,7 @@ Returns::
 
 
 
-=== `"eval"`
+=== `eval`
 
 Evaluates code. Note that unlike regular stream-based Clojure REPLs, nREPL's ``"eval"`` short-circuits on first read error and will not try to read and execute the remaining code in the message.
 
@@ -90,7 +90,7 @@ Returns::
 
 
 
-=== `"interrupt"`
+=== `interrupt`
 
 Attempts to interrupt some executing request. When interruption succeeds, the thread used for execution is killed, and a new thread spawned for the session. While the session middleware ensures that Clojure dynamic bindings are preserved, other ThreadLocals are not. Hence, when running code intimately tied to the current thread identity, it is best to avoid interruptions.
 
@@ -110,7 +110,7 @@ Returns::
 
 
 
-=== `"load-file"`
+=== `load-file`
 
 Loads a body of code, using supplied path and filename info to set source file and line number metadata. Delegates to underlying "eval" middleware/handler.
 
@@ -139,7 +139,7 @@ Returns::
 
 
 
-=== `"ls-sessions"`
+=== `ls-sessions`
 
 Lists the IDs of all active sessions.
 
@@ -154,7 +154,7 @@ Returns::
 
 
 
-=== `"stdin"`
+=== `stdin`
 
 Add content from the value of "stdin" to \*in* in the current session.
 

--- a/doc/modules/ROOT/pages/ops.adoc
+++ b/doc/modules/ROOT/pages/ops.adoc
@@ -4,11 +4,11 @@ This file is _generated_ by #'nrepl.impl.docs/-main
 ////
 = Supported nREPL operations
 
-[small]#generated from a verbose 'describe' response (nREPL v0.6.1-SNAPSHOT)#
+[small]#generated from a verbose 'describe' response (nREPL v0.7.0-SNAPSHOT)#
 
 == Operations
 
-=== `:clone`
+=== `"clone"`
 
 Clones the current session, returning the ID of the newly-created session.
 
@@ -24,7 +24,7 @@ Returns::
 
 
 
-=== `:close`
+=== `"close"`
 
 Closes the specified session.
 
@@ -39,7 +39,7 @@ Returns::
 {blank}
 
 
-=== `:describe`
+=== `"describe"`
 
 Produce a machine- and human-readable directory and documentation for the operations supported by an nREPL endpoint.
 
@@ -57,9 +57,9 @@ Returns::
 
 
 
-=== `:eval`
+=== `"eval"`
 
-Evaluates code. Note that unlike regular stream-based Clojure REPLs, nREPL's ``:eval`` short-circuits on first read error and will not try to read and execute the remaining code in the message.
+Evaluates code. Note that unlike regular stream-based Clojure REPLs, nREPL's ``"eval"`` short-circuits on first read error and will not try to read and execute the remaining code in the message.
 
 Required parameters::
 * `:code` The code to be evaluated.
@@ -90,7 +90,7 @@ Returns::
 
 
 
-=== `:interrupt`
+=== `"interrupt"`
 
 Attempts to interrupt some executing request. When interruption succeeds, the thread used for execution is killed, and a new thread spawned for the session. While the session middleware ensures that Clojure dynamic bindings are preserved, other ThreadLocals are not. Hence, when running code intimately tied to the current thread identity, it is best to avoid interruptions.
 
@@ -110,7 +110,7 @@ Returns::
 
 
 
-=== `:load-file`
+=== `"load-file"`
 
 Loads a body of code, using supplied path and filename info to set source file and line number metadata. Delegates to underlying "eval" middleware/handler.
 
@@ -139,7 +139,7 @@ Returns::
 
 
 
-=== `:ls-sessions`
+=== `"ls-sessions"`
 
 Lists the IDs of all active sessions.
 
@@ -154,7 +154,7 @@ Returns::
 
 
 
-=== `:stdin`
+=== `"stdin"`
 
 Add content from the value of "stdin" to \*in* in the current session.
 

--- a/doc/modules/ROOT/pages/usage/clients.adoc
+++ b/doc/modules/ROOT/pages/usage/clients.adoc
@@ -101,7 +101,7 @@ the full content of message responses easily:
 ----
 => (with-open [conn (nrepl/connect :port 59258)]
      (-> (nrepl/client conn 1000)
-         (nrepl/message {:op :eval :code "(time (reduce + (range 1e6)))"})
+         (nrepl/message {:op "eval" :code "(time (reduce + (range 1e6)))"})
          doall      ;; `message` and `client-session` all return lazy seqs
          pprint))
 nil

--- a/src/clojure/nrepl/ack.clj
+++ b/src/clojure/nrepl/ack.clj
@@ -48,4 +48,4 @@
        ;; consume response from the server, solely to let that side
        ;; finish cleanly without (by default) spewing a SocketException when
        ;; the ack client goes away suddenly
-       (dorun (nrepl/message client {:op :ack :port my-port}))))))
+       (dorun (nrepl/message client {:op "ack" :port my-port}))))))

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -202,7 +202,7 @@ Exit:      Control+D or (exit) or (quit)"
   (let [transport (:transport @running-repl)
         client (:client @running-repl)]
     (if (and transport client)
-      (doseq [res (nrepl/message client {:op :interrupt})]
+      (doseq [res (nrepl/message client {:op "interrupt"})]
         (when (= ["done" "session-idle"] (:status res))
           (System/exit 0)))
       (System/exit 0))))

--- a/src/clojure/nrepl/core.clj
+++ b/src/clojure/nrepl/core.clj
@@ -137,9 +137,9 @@
 (defmacro code
   "Expands into a string consisting of the macro's body's forms
    (literally, no interpolation/quasiquoting of locals or other
-   references), suitable for use in an :eval message, e.g.:
+   references), suitable for use in an `\"eval\"` message, e.g.:
 
-   {:op :eval, :code (code (+ 1 1) (slurp \"foo.txt\"))}"
+   {:op \"eval\", :code (code (+ 1 1) (slurp \"foo.txt\"))}"
   [& body]
   (apply code* body))
 

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -147,7 +147,7 @@
                  {:requires #{"clone" "close" #'caught/wrap-caught  #'print/wrap-print}
                   :expects #{}
                   :handles {"eval"
-                            {:doc "Evaluates code. Note that unlike regular stream-based Clojure REPLs, nREPL's `:eval` short-circuits on first read error and will not try to read and execute the remaining code in the message."
+                            {:doc "Evaluates code. Note that unlike regular stream-based Clojure REPLs, nREPL's `\"eval\"` short-circuits on first read error and will not try to read and execute the remaining code in the message."
                              :requires {"code" "The code to be evaluated."
                                         "session" "The ID of the session within which to evaluate the code."}
                              :optional (merge caught/wrap-caught-optional-arguments

--- a/src/clojure/nrepl/middleware/print.clj
+++ b/src/clojure/nrepl/middleware/print.clj
@@ -156,7 +156,7 @@
         resp (transduce (map print-key) rf resp keys)]
     (transport/send transport (cond-> resp
                                 (::truncated-keys resp)
-                                (update :status conj ::truncated)))))
+                                (update :status #(set (conj % ::truncated)))))))
 
 (defn- printing-transport
   [{:keys [transport] :as msg} opts]

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -19,11 +19,17 @@
     (catch Throwable t
       (log t "Unhandled REPL handler exception processing message" msg))))
 
+(defn- liberally-accept
+  "Accept messages that are not quite in spec"
+  [msg]
+  (cond-> msg
+    (keyword? (:op msg)) (update :op name)))
+
 (defn handle
   "Handles requests received via [transport] using [handler].
    Returns nil when [recv] returns nil for the given transport."
   [handler transport]
-  (when-let [msg (t/recv transport)]
+  (when-let [msg (liberally-accept (t/recv transport))]
     (future (handle* msg handler transport))
     (recur handler transport)))
 

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -19,10 +19,10 @@
     (catch Throwable t
       (log t "Unhandled REPL handler exception processing message" msg))))
 
-(defn- liberally-accept
-  "Accept messages that are not quite in spec. This comes into effect with
+(defn- normalize-msg
+  "Normalize messages that are not quite in spec. This comes into effect with
    The EDN transport, and other transports that allow more types/data structures
-   than bencode, as there's more oppertunity to be out of specification."
+   than bencode, as there's more opportunity to be out of specification."
   [msg]
   (cond-> msg
     (keyword? (:op msg)) (update :op name)))
@@ -31,7 +31,7 @@
   "Handles requests received via [transport] using [handler].
    Returns nil when [recv] returns nil for the given transport."
   [handler transport]
-  (when-let [msg (liberally-accept (t/recv transport))]
+  (when-let [msg (normalize-msg (t/recv transport))]
     (future (handle* msg handler transport))
     (recur handler transport)))
 

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -20,7 +20,9 @@
       (log t "Unhandled REPL handler exception processing message" msg))))
 
 (defn- liberally-accept
-  "Accept messages that are not quite in spec"
+  "Accept messages that are not quite in spec. This comes into effect with
+   The EDN transport, and other transports that allow more types/data structures
+   than bencode, as there's more oppertunity to be out of specification."
   [msg]
   (cond-> msg
     (keyword? (:op msg)) (update :op name)))

--- a/src/maint/nrepl/impl/docs.clj
+++ b/src/maint/nrepl/impl/docs.clj
@@ -92,7 +92,7 @@ use in e.g. wiki pages, github, etc."
          (:version-string version/version)
          ")#\n\n== Operations"
          (for [[op {:keys [doc optional requires returns]}] (sort ops)]
-           (str "\n\n=== `" (pr-str (name op)) "`\n\n"
+           (str "\n\n=== `" (name op) "`\n\n"
                 (adoc-escape doc) "\n\n"
                 "Required parameters::\n"
                 (message-slot-adoc (sort requires))

--- a/src/maint/nrepl/impl/docs.clj
+++ b/src/maint/nrepl/impl/docs.clj
@@ -92,7 +92,7 @@ use in e.g. wiki pages, github, etc."
          (:version-string version/version)
          ")#\n\n== Operations"
          (for [[op {:keys [doc optional requires returns]}] (sort ops)]
-           (str "\n\n=== `" (pr-str op) "`\n\n"
+           (str "\n\n=== `" (pr-str (name op)) "`\n\n"
                 (adoc-escape doc) "\n\n"
                 "Required parameters::\n"
                 (message-slot-adoc (sort requires))

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -139,7 +139,7 @@
           (let [client (nrepl/client transport-2 1000)]
             ;; just a sanity check
             (is (= "y"
-                   (-> (nrepl/message client {:op :eval
+                   (-> (nrepl/message client {:op "eval"
                                               :code "(System/getProperty \"nreplacktest\")"})
                        first
                        nrepl/read-response-value

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -80,7 +80,7 @@
              ~'session (client-session ~'client)
              ~'timeout-client (client transport# 1000)
              ~'timeout-session (client-session ~'timeout-client)
-             ~'repl-eval #(message % {:op :eval :code %2})
+             ~'repl-eval #(message % {:op "eval" :code %2})
              ~'repl-values (comp response-values ~'repl-eval)]
          ~@body))))
 
@@ -155,14 +155,14 @@
 
 (def-repl-test use-alternative-eval-fn
   (is (= {:value ["-124750"]}
-         (-> (message timeout-client {:op :eval :eval "nrepl.core-test/dumb-alternative-eval"
+         (-> (message timeout-client {:op "eval" :eval "nrepl.core-test/dumb-alternative-eval"
                                       :code "(reduce + (range 500))"})
              combine-responses
              (select-keys [:value])))))
 
 (def-repl-test source-tracking-eval
   (let [sym (name (gensym))
-        request {:op :eval :ns "user" :code (format "(def %s 1000)" sym)
+        request {:op "eval" :ns "user" :code (format "(def %s 1000)" sym)
                  :file "test.clj" :line 42 :column 10}
         _ (doall (message timeout-client request))
         meta (meta (resolve (symbol "user" sym)))]
@@ -172,14 +172,14 @@
 
 (def-repl-test no-code
   (is (= {:status #{:error :no-code :done}}
-         (-> (message timeout-client {:op :eval})
+         (-> (message timeout-client {:op "eval"})
              combine-responses
              clean-response
              (select-keys [:status])))))
 
 (def-repl-test unknown-op
   (is (= {:op "abc" :status #{:error :unknown-op :done}}
-         (-> (message timeout-client {:op :abc})
+         (-> (message timeout-client {:op "abc"})
              combine-responses
              clean-response
              (select-keys [:op :status])))))
@@ -191,7 +191,7 @@
              clean-response
              :status)))
   (let [session-id (new-session timeout-client)
-        session-alive? #(contains? (-> (message timeout-client {:op :ls-sessions})
+        session-alive? #(contains? (-> (message timeout-client {:op "ls-sessions"})
                                        combine-responses
                                        :sessions
                                        set)
@@ -199,7 +199,7 @@
     (is session-id)
     (is (session-alive?))
     (is (= #{:done :session-closed}
-           (-> (message timeout-client {:op :close :session session-id})
+           (-> (message timeout-client {:op "close" :session session-id})
                combine-responses
                clean-response
                :status)))
@@ -238,7 +238,7 @@
   (let [sid (-> session meta ::nrepl/taking-until :session)]
     (with-open [transport2 (nrepl.core/connect :port (:port *server*)
                                                :transport-fn *transport-fn*)]
-      (transport/send transport2 {:op :eval :code "(println :foo)"
+      (transport/send transport2 {:op "eval" :code "(println :foo)"
                                   "session" sid})
       (is (= [{:out ":foo\n"}
               {:ns "user" :value "nil"}
@@ -269,11 +269,11 @@
           "7 8 9"
           " 10)"]
          ;; new session
-         (->> (message client {:op :eval :out-limit 5 :code "(print (range 11))"})
+         (->> (message client {:op "eval" :out-limit 5 :code "(print (range 11))"})
               (map :out)
               (remove nil?))
          ;; existing session
-         (->> (message session {:op :eval :out-limit 5 :code "(print (range 11))"})
+         (->> (message session {:op "eval" :out-limit 5 :code "(print (range 11))"})
               (map :out)
               (remove nil?)))))
 
@@ -292,14 +292,14 @@
              :status #{:nrepl.middleware.print/error}}
             {:ns "user" :value "42"}
             {:status #{:done}}]
-           (->> (message client {:op :eval
+           (->> (message client {:op "eval"
                                  :code "(+ 34 8)"
                                  ::middleware.print/print "my.missing.ns/printer"})
                 (mapv clean-response)))))
 
   (testing "custom printing function symbol should be used"
     (is (= ["<foo true ...>"]
-           (-> (message client {:op :eval
+           (-> (message client {:op "eval"
                                 :code "true"
                                 ::middleware.print/print `custom-printer})
                (combine-responses)
@@ -307,7 +307,7 @@
 
   (testing "empty print options are ignored"
     (is (= ["<foo 42 ...>"]
-           (-> (message client {:op :eval
+           (-> (message client {:op "eval"
                                 :code "42"
                                 ::middleware.print/print `custom-printer
                                 ::middleware.print/options {}})
@@ -316,7 +316,7 @@
 
   (testing "options should be passed to printer"
     (is (= ["<foo 3 bar>"]
-           (-> (message client {:op :eval
+           (-> (message client {:op "eval"
                                 :code "3"
                                 ::middleware.print/print `custom-printer
                                 ::middleware.print/options {:sub "bar"}})
@@ -327,14 +327,14 @@
   (testing "custom ::print/keys"
     (is (= [{:ns "user" :value [1 2 3 4 5]}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code "[1 2 3 4 5]"
                                   ::middleware.print/keys []})
                 (mapv clean-response))))))
 
 (def-repl-test streamed-printing
   (testing "value response arrives before ns response"
-    (let [responses (->> (message client {:op :eval
+    (let [responses (->> (message client {:op "eval"
                                           :code (code (range 10))
                                           ::middleware.print/stream? 1})
                          (mapv clean-response))]
@@ -344,7 +344,7 @@
              responses))))
 
   (testing "multiple forms"
-    (let [responses (->> (message client {:op :eval
+    (let [responses (->> (message client {:op "eval"
                                           :code (code (range 10)
                                                       (range 10))
                                           ::middleware.print/stream? 1})
@@ -357,7 +357,7 @@
              responses))))
 
   (testing "*out* still handled correctly"
-    (let [responses (->> (message client {:op :eval
+    (let [responses (->> (message client {:op "eval"
                                           :code (code (->> (range 2)
                                                            (map println)))
                                           ::middleware.print/stream? 1})
@@ -370,7 +370,7 @@
              responses))))
 
   (testing "large output should be streamed"
-    (let [[resp1 resp2 resp3 resp4] (->> (message client {:op :eval
+    (let [[resp1 resp2 resp3 resp4] (->> (message client {:op "eval"
                                                           :code (code (range 512))
                                                           ::middleware.print/stream? 1})
                                          (mapv clean-response))]
@@ -382,12 +382,12 @@
       (is (= {:status #{:done}} resp4))))
 
   (testing "interruptible"
-    (let [eval-responses (->> (message session {:op :eval
+    (let [eval-responses (->> (message session {:op "eval"
                                                 :code (code (range))
                                                 ::middleware.print/stream? 1})
                               (map clean-response))
           _ (Thread/sleep 100)
-          interrupt-responses (->> (message session {:op :interrupt})
+          interrupt-responses (->> (message session {:op "interrupt"})
                                    (mapv clean-response))]
       ;; check the interrupt succeeded first; otherwise eval-responses will not terminate
       (is (= [{:status #{:done}}] interrupt-responses))
@@ -402,14 +402,14 @@
             {:value " 14 15)"}
             {:ns "user"}
             {:status #{:done}}]
-           (->> (message client {:op :eval
+           (->> (message client {:op "eval"
                                  :code (code (range 16))
                                  ::middleware.print/stream? 1
                                  ::middleware.print/buffer-size 8})
                 (mapv clean-response)))))
 
   (testing "works with custom printer"
-    (let [[resp1 resp2 resp3 resp4] (->> (message client {:op :eval
+    (let [[resp1 resp2 resp3 resp4] (->> (message client {:op "eval"
                                                           :code (code (range 512))
                                                           ::middleware.print/stream? 1
                                                           ::middleware.print/print `custom-printer})
@@ -422,7 +422,7 @@
       (is (= {:status #{:done}} resp4))))
 
   (testing "works with custom printer and print-options"
-    (let [[resp1 resp2 resp3 resp4] (->> (message client {:op :eval
+    (let [[resp1 resp2 resp3 resp4] (->> (message client {:op "eval"
                                                           :code (code (range 512))
                                                           ::middleware.print/stream? 1
                                                           ::middleware.print/print `custom-printer
@@ -442,7 +442,7 @@
              :status #{:nrepl.middleware.print/truncated}
              ::middleware.print/truncated-keys [:value]}
             {:status #{:done}}]
-           (->> (message client {:op :eval
+           (->> (message client {:op "eval"
                                  :code (code (range 512))
                                  ::middleware.print/quota 8})
                 (mapv clean-response)))))
@@ -452,7 +452,7 @@
             {:status #{:nrepl.middleware.print/truncated}}
             {:ns "user"}
             {:status #{:done}}]
-           (->> (message client {:op :eval
+           (->> (message client {:op "eval"
                                  :code (code (range 512))
                                  ::middleware.print/stream? 1
                                  ::middleware.print/quota 8})
@@ -464,7 +464,7 @@
              :status #{:nrepl.middleware.print/truncated}
              ::middleware.print/truncated-keys [:value]}
             {:status #{:done}}]
-           (->> (message client {:op :eval
+           (->> (message client {:op "eval"
                                  :code (code (range 512))
                                  ::middleware.print/print `custom-printer
                                  ::middleware.print/quota 8})
@@ -475,7 +475,7 @@
             {:status #{:nrepl.middleware.print/truncated}}
             {:ns "user"}
             {:status #{:done}}]
-           (->> (message client {:op :eval
+           (->> (message client {:op "eval"
                                  :code (code (range 512))
                                  ::middleware.print/print `custom-printer
                                  ::middleware.print/stream? 1
@@ -490,20 +490,20 @@
   (testing "setting *print-fn* works"
     (is (= [{:ns "user" :value "<bar #'nrepl.core-test/custom-session-printer>"}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code (code (set! nrepl.middleware.print/*print-fn* (resolve `custom-session-printer)))})
                 (mapv clean-response))))
 
     (is (= [{:ns "user" :value "<bar (0 1 2 3 4 5 6 7 8 9)>"}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code (code (range 10))})
                 (mapv clean-response)))))
 
   (testing "request can still override *print-fn*"
     (is (= [{:ns "user" :value "<foo (0 1 2 3 4 5 6 7 8 9) ...>"}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code (code (range 10))
                                   ::middleware.print/print `custom-printer})
                 (mapv clean-response)))))
@@ -514,7 +514,7 @@
             {:value "<bar 8>"}
             {:ns "user"}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code (code (set! nrepl.middleware.print/*stream?* true)
                                               (set! nrepl.middleware.print/*buffer-size* 8))})
                 (mapv clean-response))))
@@ -525,14 +525,14 @@
             {:value "9)>"}
             {:ns "user"}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code (code (range 10))})
                 (mapv clean-response)))))
 
   (testing "request can still override stream options"
     (is (= [{:ns "user" :value "<bar (0 1 2 3 4 5 6 7 8 9)>"}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code (code (range 10))
                                   ::middleware.print/stream? nil})
                 (mapv clean-response))))
@@ -541,7 +541,7 @@
             {:value "5 6 7 8 9)>"}
             {:ns "user"}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code (code (range 10))
                                   ::middleware.print/buffer-size 16})
                 (mapv clean-response)))))
@@ -550,14 +550,14 @@
     (is (= [{:value "<bar 8>"}
             {:ns "user"}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code (code (set! nrepl.middleware.print/*quota* 8))})
                 (mapv clean-response))))
     (is (= [{:value "<bar (0 "}
             {:status #{:nrepl.middleware.print/truncated}}
             {:ns "user"}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code (code (range 512))})
                 (mapv clean-response)))))
 
@@ -566,7 +566,7 @@
             {:status #{:nrepl.middleware.print/truncated}}
             {:ns "user"}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code (code (range 512))
                                   ::middleware.print/quota 16})
                 (mapv clean-response))))))
@@ -642,13 +642,13 @@
                                        (ns baz)))
                    combine-responses
                    :ns)))
-  (is (= [5] (response-values (message session {:op :eval :code "bar" :ns "user"}))))
+  (is (= [5] (response-values (message session {:op "eval" :code "bar" :ns "user"}))))
   ;; NREPL-72: :ns argument to eval shouldn't affect *ns* outside of the scope of that evaluation
   (is (= "baz" (-> (repl-eval session "5") combine-responses :ns))))
 
 (def-repl-test error-on-nonexistent-ns
   (is (= #{:error :namespace-not-found :done}
-         (-> (message timeout-client {:op :eval :code "(+ 1 1)" :ns (name (gensym))})
+         (-> (message timeout-client {:op "eval" :code "(+ 1 1)" :ns (name (gensym))})
              combine-responses
              clean-response
              :status))))
@@ -663,23 +663,23 @@
 (def-repl-test interrupt
   (testing "ephemeral session"
     (is (= #{:error :session-ephemeral :done}
-           (:status (clean-response (first (message client {:op :interrupt}))))
-           (:status (clean-response (first (message client {:op :interrupt :interrupt-id "foo"})))))))
+           (:status (clean-response (first (message client {:op "interrupt"}))))
+           (:status (clean-response (first (message client {:op "interrupt" :interrupt-id "foo"})))))))
 
   (testing "registered session"
     (is (= #{:done :session-idle}
-           (:status (clean-response (first (message session {:op :interrupt}))))
-           (:status (clean-response (first (message session {:op :interrupt :interrupt-id "foo"}))))))
+           (:status (clean-response (first (message session {:op "interrupt"}))))
+           (:status (clean-response (first (message session {:op "interrupt" :interrupt-id "foo"}))))))
 
-    (let [resp (message session {:op :eval :code (code (do
-                                                         (def halted? true)
-                                                         halted?
-                                                         (Thread/sleep 30000)
-                                                         (def halted? false)))})]
+    (let [resp (message session {:op "eval" :code (code (do
+                                                          (def halted? true)
+                                                          halted?
+                                                          (Thread/sleep 30000)
+                                                          (def halted? false)))})]
       (Thread/sleep 100)
       (is (= #{:done :error :interrupt-id-mismatch}
-             (:status (clean-response (first (message session {:op :interrupt :interrupt-id "foo"}))))))
-      (is (= #{:done} (-> session (message {:op :interrupt}) first clean-response :status)))
+             (:status (clean-response (first (message session {:op "interrupt" :interrupt-id "foo"}))))))
+      (is (= #{:done} (-> session (message {:op "interrupt"}) first clean-response :status)))
       (is (= #{} (reduce disj #{:done :interrupted} (-> resp combine-responses clean-response :status))))
       (is (= [true] (repl-values session "halted?"))))))
 
@@ -706,7 +706,7 @@
           start-time (System/currentTimeMillis)
           elapsed-times (map (fn [session eval-duration]
                                (let [expr (pr-str `(Thread/sleep ~eval-duration))
-                                     responses (message session {:op :eval :code expr})]
+                                     responses (message session {:op "eval" :code expr})]
                                  (future
                                    (is (= [nil] (response-values responses)))
                                    (- (System/currentTimeMillis) start-time))))
@@ -747,7 +747,7 @@
     (let [server (server/start-server :transport-fn *transport-fn*)
           transport (connect :port (:port server)
                              :transport-fn *transport-fn*)]
-      (transport/send transport {:op :eval :code "(+ 1 1)"})
+      (transport/send transport {:op "eval" :code "(+ 1 1)"})
 
       (let [reader (future (while true (transport/recv transport)))]
         (Thread/sleep 100)
@@ -764,10 +764,10 @@
       ;; for some transports that don't throw an exception the first time
       ;; a message is sent after the server is closed.
       (try
-        (transport/send transport {:op :eval :code "(+ 5 1)"})
+        (transport/send transport {:op "eval" :code "(+ 5 1)"})
         (catch Throwable t))
       (Thread/sleep 100)
-      (is (thrown? SocketException (transport/send transport {:op :eval :code "(+ 5 1)"}))))))
+      (is (thrown? SocketException (transport/send transport {:op "eval" :code "(+ 5 1)"}))))))
 
 (deftest server-starts-with-minimal-configuration
   (testing "Ensure server starts with minimal configuration"
@@ -775,7 +775,7 @@
           transport (connect :port (:port server))
           client (client transport Long/MAX_VALUE)]
       (is (= ["3"]
-             (-> (message client {:op :eval :code "(- 4 1)"})
+             (-> (message client {:op "eval" :code "(- 4 1)"})
                  combine-responses
                  :value))))))
 
@@ -803,10 +803,10 @@
   (is (= '((1 2 3)) (response-values (for [resp (repl-eval session "(read)")]
                                        (do
                                          (when (-> resp clean-response :status (contains? :need-input))
-                                           (session {:op :stdin :stdin "(1 2 3)"}))
+                                           (session {:op "stdin" :stdin "(1 2 3)"}))
                                          resp)))))
 
-  (session {:op :stdin :stdin "a\nb\nc\n"})
+  (session {:op "stdin" :stdin "a\nb\nc\n"})
   (doseq [x "abc"]
     (is (= [(str x)] (repl-values session "(read-line)")))))
 
@@ -814,24 +814,24 @@
   (is (= nil (response-values (for [resp (repl-eval session "(read)")]
                                 (do
                                   (when (-> resp clean-response :status (contains? :need-input))
-                                    (session {:op :stdin :stdin []}))
+                                    (session {:op "stdin" :stdin []}))
                                   resp))))))
 
 (def-repl-test request-multiple-read-newline-*in*
   (is (= '(:ohai) (response-values (for [resp (repl-eval session "(read)")]
                                      (do
                                        (when (-> resp clean-response :status (contains? :need-input))
-                                         (session {:op :stdin :stdin ":ohai\n"}))
+                                         (session {:op "stdin" :stdin ":ohai\n"}))
                                        resp)))))
 
-  (session {:op :stdin :stdin "a\n"})
+  (session {:op "stdin" :stdin "a\n"})
   (is (= ["a"] (repl-values session "(read-line)"))))
 
 (def-repl-test request-multiple-read-with-buffered-newline-*in*
   (is (= '(:ohai) (response-values (for [resp (repl-eval session "(read)")]
                                      (do
                                        (when (-> resp clean-response :status (contains? :need-input))
-                                         (session {:op :stdin :stdin ":ohai\na\n"}))
+                                         (session {:op "stdin" :stdin ":ohai\na\n"}))
                                        resp)))))
 
   (is (= ["a"] (repl-values session "(read-line)"))))
@@ -840,7 +840,7 @@
   (is (= '(:ohai) (response-values (for [resp (repl-eval session "(read)")]
                                      (do
                                        (when (-> resp clean-response :status (contains? :need-input))
-                                         (session {:op :stdin :stdin ":ohai :kthxbai\n"}))
+                                         (session {:op "stdin" :stdin ":ohai :kthxbai\n"}))
                                        resp)))))
 
   (is (= [" :kthxbai"] (repl-values session "(read-line)"))))
@@ -849,7 +849,7 @@
   (with-open [conn (url-connect (str (transport-fn->protocol *transport-fn*)
                                      "://127.0.0.1:"
                                      (:port *server*)))]
-    (transport/send conn {:op :eval :code "(+ 1 1)"})
+    (transport/send conn {:op "eval" :code "(+ 1 1)"})
     (is (= [2] (response-values (response-seq conn 100))))))
 
 (deftest test-ack
@@ -871,17 +871,17 @@
         conn (nrepl/connect :port port :transport-fn *transport-fn*)
         client (nrepl/client conn 1000)
         sess (nrepl/client-session client)
-        sess-id (->> (sess {:op :eval
+        sess-id (->> (sess {:op "eval"
                             :code "(+ 1 4)"})
                      last
                      :session)
         new-sess-id (->> (sess {:session sess-id
-                                :op :clone})
+                                :op "clone"})
                          last
                          :session)
         cloned-sess (nrepl/client-session client :session new-sess-id)
         cloned-sess-*1 (->> (cloned-sess {:session new-sess-id
-                                          :op :eval
+                                          :op "eval"
                                           :code "*1"})
                             first
                             :value)]
@@ -904,7 +904,7 @@
     (Thread/sleep 100)
     (is (= #{:done}
            (->> session
-                (#(message % {:op :interrupt}))
+                (#(message % {:op "interrupt"}))
                 first
                 clean-response
                 :status)))
@@ -958,7 +958,7 @@
 
 (def-repl-test caught-options
   (testing "bad symbol should fall back to default"
-    (let [[resp1 resp2 resp3 resp4] (->> (message session {:op :eval
+    (let [[resp1 resp2 resp3 resp4] (->> (message session {:op "eval"
                                                            :code (code (first 1))
                                                            ::middleware.caught/caught "my.missing.ns/repl-caught"})
                                          (mapv clean-response))]
@@ -979,13 +979,13 @@
              :ex "class java.lang.IllegalArgumentException"
              :root-ex "class java.lang.IllegalArgumentException"}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code (code (first 1))
                                   ::middleware.caught/caught `custom-repl-caught})
                 (mapv clean-response)))))
 
   (testing "::print? option"
-    (let [[resp1 resp2 resp3] (->> (message session {:op :eval
+    (let [[resp1 resp2 resp3] (->> (message session {:op "eval"
                                                      :code (code (first 1))
                                                      ::middleware.caught/print? 1})
                                    (mapv clean-response))]
@@ -998,7 +998,7 @@
       (is (= {:status #{:done}}
              resp3)))
 
-    (let [[resp1 resp2 resp3] (->> (message session {:op :eval
+    (let [[resp1 resp2 resp3] (->> (message session {:op "eval"
                                                      :code (code (first 1))
                                                      ::middleware.caught/caught `custom-repl-caught
                                                      ::middleware.caught/print? 1})
@@ -1022,7 +1022,7 @@
   (testing "setting *caught-fn* works"
     (is (= [{:ns "user" :value "#'nrepl.core-test/custom-session-repl-caught"}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code (code (set! nrepl.middleware.caught/*caught-fn* (resolve `custom-session-repl-caught)))})
                 (mapv clean-response))))
 
@@ -1031,7 +1031,7 @@
              :ex "class java.lang.ArithmeticException"
              :root-ex "class java.lang.ArithmeticException"}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code (code (/ 1 0))})
                 (mapv clean-response)))))
 
@@ -1041,13 +1041,13 @@
              :ex "class java.lang.ArithmeticException"
              :root-ex "class java.lang.ArithmeticException"}
             {:status #{:done}}]
-           (->> (message session {:op :eval
+           (->> (message session {:op "eval"
                                   :code (code (/ 1 0))
                                   ::middleware.caught/caught `custom-repl-caught})
                 (mapv clean-response)))))
 
   (testing "request can still provide ::print? option"
-    (let [[resp1 resp2 resp3] (->> (message session {:op :eval
+    (let [[resp1 resp2 resp3] (->> (message session {:op "eval"
                                                      :code (code (/ 1 0))
                                                      ::middleware.caught/print? 1})
                                    (mapv clean-response))]
@@ -1060,7 +1060,7 @@
       (is (= {:status #{:done}}
              resp3)))
 
-    (let [[resp1 resp2 resp3] (->> (message session {:op :eval
+    (let [[resp1 resp2 resp3] (->> (message session {:op "eval"
                                                      :code (code (/ 1 0))
                                                      ::middleware.caught/caught `custom-repl-caught
                                                      ::middleware.caught/print? 1})

--- a/test/clojure/nrepl/describe_test.clj
+++ b/test/clojure/nrepl/describe_test.clj
@@ -10,8 +10,8 @@
 (use-fixtures :once repl-server-fixture)
 
 (def ^{:private true} op-names
-  #{:load-file :ls-sessions :interrupt :stdin
-    :describe :eval :close :clone})
+  #{"load-file" "ls-sessions" "interrupt" "stdin"
+    "describe" "eval" "close" "clone"})
 
 (def-repl-test simple-describe
   (let [{{:keys [nrepl clojure java]} :versions
@@ -26,13 +26,13 @@
       (is (= (clojure-version) (:version-string clojure)))
       (is (= (System/getProperty "java.version") (:version-string java))))
 
-    (is (= op-names (set (keys ops))))
+    (is (= op-names (set (map name (keys ops)))))
     (is (every? empty? (map val ops)))))
 
 (def-repl-test verbose-describe
   (let [{:keys [ops aux]} (nrepl/combine-responses
                            (nrepl/message timeout-client
                                           {:op "describe" :verbose? "true"}))]
-    (is (= op-names (set (keys ops))))
+    (is (= op-names (set (map name (keys ops)))))
     (is (every? seq (map (comp :doc val) ops)))
     (is (= {:current-ns "user"} aux))))

--- a/test/clojure/nrepl/edn_test.clj
+++ b/test/clojure/nrepl/edn_test.clj
@@ -20,5 +20,5 @@
     (is (= (return-evaluation {:op :eval :code "(+ 2 3)"})
            [5])))
   (testing "simple expressions"
-    (is (= (return-evaluation {:op :eval :code "(range 40)"})
+    (is (= (return-evaluation {:op "eval" :code "(range 40)"})
            [(eval '(range 40))]))))


### PR DESCRIPTION
This follows on discussions from, and closes #138.

- Updates the handful of `:op` as keywords in the main body of the code.
- Updates most of the tests to use string ops. It's telling that most of what needed changing was the test suite. Also modified the test suite to be stricter on EDN transports (we'll need to update fastlane)
- The EDN transport is now entirely transparent! `edn/read` and `str` are sufficient.
- Added a `liberally-accept` wrapper to incoming messages, so we still accept keyword ops.
- Updated all documentation where I could find it to be consistent.
- Added the missing `uri-scheme`, left out of the original PR.
- Expanded the documentation section on EDN transport.

---

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

Thanks!

*If you're just starting out to hack on nREPL you might find this [section of its
manual][1] extremely useful.*

[1]: https:/nrepl.org/nrepl/hacking_on_nrepl.html
