### PR TITLE
Fix broken cross references in documentation

### DIFF
--- a/doc/modules/ROOT/pages/about/contributing.adoc
+++ b/doc/modules/ROOT/pages/about/contributing.adoc
@@ -4,7 +4,7 @@
 
 Report issues and suggest features and improvements on the
 link:https://github.com/nrepl/nrepl/issues[GitHub issue tracker]. Don't ask
-questions on the issue tracker - use the <<about/support.adoc#,support channels>> instead.
+questions on the issue tracker - use the xref:about/support.adoc[support channels] instead.
 
 If you want to file a bug, please provide all the necessary info listed in
 our issue reporting template (it's loaded automatically when you create a

--- a/doc/modules/ROOT/pages/design/handlers.adoc
+++ b/doc/modules/ROOT/pages/design/handlers.adoc
@@ -13,7 +13,7 @@ may seem peculiar, but is motivated by two factors:
   code like `"(+ 1 2) (def a 6)"`).
 
 Thus, messages provided to nREPL handlers are guaranteed to contain a
-`:transport` entry containing the <<design/transports.adoc,transports>> that should be used
+`:transport` entry containing the xref:design/transports.adoc[transports] that should be used
 to send all responses precipitated by a given message.  (This slot is added by
 the nREPL server itself, thus, if a client sends any message containing a
 `"transport"` entry, it will be bashed out by the `Transport` that was the

--- a/doc/modules/ROOT/pages/design/middleware.adoc
+++ b/doc/modules/ROOT/pages/design/middleware.adoc
@@ -36,7 +36,7 @@ merge works, we'll first need to talk about middleware "descriptors".
 
 link:https://github.com/nrepl/nrepl/wiki/Extensions[Other nREPL middlewares are provided by the community].
 
-(See <<ops.adoc, this documentation listing>> for
+(See xref:ops.adoc[this documentation listing] for
 details as to the operations implemented by nREPL's default middleware stack,
 what each operation expects in request messages, and what they emit for
 responses.)
@@ -105,7 +105,7 @@ The values in the `:handles` map are used to support the `"describe"` operation,
 which provides "a machine- and human-readable directory and documentation for
 the operations supported by an nREPL endpoint" (see
 `nrepl.impl.docs/generate-ops-info` and the results of
-`lein with-profile +maint run nrepl.impl.docs` <<ops.adoc,here>>).
+`lein with-profile +maint run nrepl.impl.docs` xref:ops.adoc[here]).
 
 TIP: There's also `lein with-profile +maint run nrepl.impl.docs --output md` if you'd like to
 generate an ops listing in Markdown format.

--- a/doc/modules/ROOT/pages/design/overview.adoc
+++ b/doc/modules/ROOT/pages/design/overview.adoc
@@ -1,7 +1,6 @@
 = Overview
 
-nREPL largely consists of three abstractions: <<design/handlers.adoc,handlers>>,
-<<design/middleware.adoc,middleware>>, and  <<design/transports.adoc,transports>>.
+nREPL largely consists of three abstractions: xref:design/handlers.adoc[handlers], xref:design/middleware.adoc[middleware], and xref:design/transports.adoc[transports].
 These are roughly analogous to the handlers, middleware, and
 adapters of link:https://github.com/ring-clojure/ring[Ring], though there are some
 important semantic differences. Finally, nREPL is fundamentally message-oriented
@@ -10,7 +9,7 @@ provided by e.g.  terminals).
 
 == Messages
 
-It is convention to express nREPL messages as EDN maps. For most purposes, it's sufficient to imagine that we communicate with nREPL via EDN, much the same way as we send and receive JSON to and from a REST endpoint. This is typically not what actually happens, and the details are discussed in <<design/transports.adoc,the transport section>>, however, this conceptual simplification serves us well.
+It is convention to express nREPL messages as EDN maps. For most purposes, it's sufficient to imagine that we communicate with nREPL via EDN, much the same way as we send and receive JSON to and from a REST endpoint. This is typically not what actually happens, and the details are discussed in xref:design/transports.adoc[the transport section], however, this conceptual simplification serves us well.
 
 === Requests
 

--- a/doc/modules/ROOT/pages/faq.adoc
+++ b/doc/modules/ROOT/pages/faq.adoc
@@ -2,7 +2,7 @@
 
 == What's the difference between contrib's nREPL and this one?
 
-See <<about/history.adoc#,our history>>.
+See xref:about/history.adoc[our history].
 Very simply put - this project is the continuation of the contrib project.
 
 == Does nREPL support ClojureScript?
@@ -27,15 +27,15 @@ important tickets from our backlog.
 
 == Are there any interesting nREPL extensions worth checking out?
 
-Sure! See <<third_party_middleware.adoc#,third party middleware>> for details.
+Sure! See xref:extensions.adoc[Extensions] for details.
 
 == Where can I get help regarding nREPL?
 
-See the <<about/support.adoc#,Support>> section of the manual.
+See the xref:about/support.adoc[Support] section of the manual.
 
 == What should I do if I run into some issues with nREPL?
 
-Don't panic! Next step - visit the <<troubleshooting.adoc#,Troubleshooting>> section of
+Don't panic! Next step - visit the xref:troubleshooting.adoc[Troubleshooting] section of
 the manual.
 
 == How can I help the project?

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -46,7 +46,7 @@ nature to the link:https://langserver.org/[Language Server Protocol]. nREPL is n
 ambitious as LSP, but on the other hand it's also much simpler and it's trivial to
 create nREPL clients in any language.
 
-TIP: You can find some alternative nREPL implementations and more on the subject <<beyond_clojure.adoc,here>>.
+TIP: You can find some alternative nREPL implementations and more on the subject xref:beyond_clojure.adoc[here].
 
 == Community-Driven
 
@@ -57,7 +57,7 @@ reasons why we decided to leave the "Clojure Contrib" umbrella.
 
 Everyone's welcome to get involved in the project, so we can take it to the next level!
 
-TIP: Check out the how you can help nREPL <<about/contributing.adoc,here>>.
+TIP: Check out the how you can help nREPL xref:about/contributing.adoc[here].
 
 == Status
 
@@ -74,4 +74,4 @@ a responsible manner and backwards-compatible ways.
 NOTE: The migration of nREPL out of Clojure Contrib is probably the
 only case where we were forced to make breaking changes.footnote:[Apart
 from removing deprecated code that is.] Those are detailed in great
-detail <<installation.adoc#upgrading,here>>.
+detail xref:installation.adoc#upgrading[here].

--- a/doc/modules/ROOT/pages/usage/clients.adoc
+++ b/doc/modules/ROOT/pages/usage/clients.adoc
@@ -121,4 +121,4 @@ Each message must contain at least an `:op` (or `"op"`) slot, which specifies
 the "type" of the operation to be performed.  The operations supported by an
 nREPL endpoint are determined by the handlers and middleware stack used when
 starting that endpoint; the default middleware stack (described below) supports
-a particular set of operations, <<ops.adoc,detailed here>>.
+a particular set of operations, xref:ops.adoc[detailed here].

--- a/doc/modules/ROOT/pages/usage/server.adoc
+++ b/doc/modules/ROOT/pages/usage/server.adoc
@@ -143,7 +143,7 @@ WARNING: You should think long and hard before hot-patching code in
 production, but that's a subject for an unrelated discussion.
 
 nREPL provides a socket-based server that you can trivially start from your
-application.  <<installation.adoc#,Add it to your project's dependencies>>, and add code
+application.  xref:installation.adoc[Add it to your project's dependencies], and add code
 like this to your app:
 
 [source,clojure]
@@ -177,7 +177,7 @@ able to easily restart the server, etc., you might want to put the value
 `start-server` returns into an atom or somesuch.  Anyway, once your app is
 running an nREPL server, you can connect to it from a tool like Leiningen or
 Counterclockwise or REPL-y, or from another Clojure process, as shown
- <<usage/clients.adoc,here>>.
+ xref:usage/clients.adoc[here].
 
 You can stop the server with `(stop-server server)`.
 
@@ -187,7 +187,7 @@ Note that nREPL is not limited to its default messaging protocol, nor to its
 default use of sockets.  nREPL provides a _transport_ abstraction for
 implementing support for alternative protocols and connection methods.
 Alternative transport implementations are available, and implementing your own
-is not difficult; read more about transports <<design/transports.adoc,here>>.
+is not difficult; read more about transports xref:design/transports.adoc[here].
 
 === Server Configuration
 


### PR DESCRIPTION
Some page references are broken and point back to the current page.
Some of the page cross references ending with an '#' are working as
expected. However, the official antora documentation urges toward
using the xref macro for page cross references instead of the double
angled brackets syntax (<< >>).

Hence, the following changes:

  - Standardize page cross references syntax across project using xref
  - Replace deprecated reference to third_party_middleware.adoc at
    doc/modules/ROOT/pages/faq.adoc:30 and points to extensions.adoc
    instead.

Each page cross references were manually tested. The references were
found with the following bash command: `grep -Enr '<<.*\.adoc.*>>' doc`
 and have all been changed.

Examples of reference pointing back to the same page.

  - doc/modules/ROOT/pages/index.adoc:49
  - doc/modules/ROOT/pages/index.adoc:60
  - doc/modules/ROOT/pages/design/handlers.adoc:16
  - doc/modules/ROOT/pages/design/middleware.adoc:39
  - doc/modules/ROOT/pages/design/middleware.adoc:108
  - doc/modules/ROOT/pages/design/overview.adoc:4

References:

  - https://docs.antora.org/antora/2.0/asciidoc/page-to-page-xref/
  - https://docs.antora.org/antora/2.0/asciidoc/in-page-xref/

Issue tracker: https://github.com/nrepl/nrepl/issues/149