### PR TITLE
Remove lein-sysutils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,8 @@
 
 VERSION ?= 1.10
 
-# Some tests need to be filtered based on JVM version.  This selector
-# will be mapped to a function in project.clj, and that function
-# determines which `deftest` to run based on their metadata.
-JAVA_VERSION := $(shell lein with-profile +sysutils \
-                        sysutils :java-version-simple | cut -d " " -f 2)
-TEST_SELECTOR := :java$(JAVA_VERSION)
-
 test:
-	lein with-profile +$(VERSION),+test test $(TEST_SELECTOR)
+	lein with-profile +$(VERSION),+test test
 
 eastwood:
 	lein with-profile +$(VERSION),+eastwood eastwood

--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,6 @@
                                       "https://oss.sonatype.org/content/repositories/snapshots"]]
                       :dependencies [[org.clojure/clojure "1.11.0-master-SNAPSHOT"]]}
 
-             :sysutils {:plugins [[lein-sysutils "0.2.0"]]}
              :maint {:source-paths ["src/maint"]
                      :dependencies [[org.clojure/tools.cli "0.4.1"]]}
 


### PR DESCRIPTION
We no longer have tests that are Java version dependent.