### PR TITLE
Skip the interrupt on stream printing test until it's reliable.

### DIFF
--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -386,18 +386,20 @@
       (is (= {:ns "user"} resp3))
       (is (= {:status #{:done}} resp4))))
 
-  (testing "interruptible"
-    (let [eval-responses (->> (message session {:op "eval"
-                                                :code (code (range))
-                                                ::middleware.print/stream? 1})
-                              (map clean-response))
-          _ (Thread/sleep 100)
-          interrupt-responses (->> (message session {:op "interrupt"})
-                                   (mapv clean-response))]
+  ;; This test currently fails intermittently on CI.
+  ;; See https://github.com/nrepl/nrepl/issues/132
+  #_(testing "interruptible"
+      (let [eval-responses (->> (message session {:op "eval"
+                                                  :code (code (range))
+                                                  ::middleware.print/stream? 1})
+                                (map clean-response))
+            _ (Thread/sleep 100)
+            interrupt-responses (->> (message session {:op "interrupt"})
+                                     (mapv clean-response))]
       ;; check the interrupt succeeded first; otherwise eval-responses will not terminate
-      (is (= [{:status #{:done}}] interrupt-responses))
-      (is (.startsWith (:value (first eval-responses)) "(0 1 2 3"))
-      (is (= {:status #{:done :interrupted}} (last eval-responses)))))
+        (is (= [{:status #{:done}}] interrupt-responses))
+        (is (.startsWith (:value (first eval-responses)) "(0 1 2 3"))
+        (is (= {:status #{:done :interrupted}} (last eval-responses)))))
 
   (testing "respects buffer-size option"
     (is (= [{:value "(0 1 2 3"}


### PR DESCRIPTION
#132 is making CI fail almost all the time. Given there's no quick fix for it, (and we do think it's a real bug) can I suggest we skip the failing test so we can expect CI to be green?

As far as I can gather, the bug is not a big issue (given how long 0.6.0 has been in the wild).

If we are worried about just forgetting the issue, we can open a PR to add the test back in, and try to fix that? Feels like a better alternative than having the test fail by default?

 
