### PR TITLE
First interrupt a thread. Stop it if that doesn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@
 * [#140](https://github.com/nrepl/nrepl/issues/140): Added initial version of spec for message responses. These are used during Clojure 1.10 tests.
 * [#97](https://github.com/nrepl/nrepl/issues/97): Added a sideloader, a network classloader that allows dependencies to be added even the source/class files are not available on the server JVM's classpath.
 
-### Changes
-
-* [#158](https://github.com/nrepl/nrepl/issues/158): Interrupt now runs in three stages: calls `interrupt` on the thread, waits 100ms for the thread to respond and return messages, then waits 5000ms for the thread to terminate itself. A hard `.stop` is only called if it fails to do so.
-
 ### Bugs fixed
 
 * [#152](https://github.com/nrepl/nrepl/issues/152): Bug fix to kill session threads when closing sessions
@@ -21,6 +17,7 @@
 * [#137](https://github.com/nrepl/nrepl/pull/137): Expanded Bencode writer to work with
   maps that have keywords or symbols as keys. This allowed a simplification of the
   Bencode transport itself.
+* [#158](https://github.com/nrepl/nrepl/issues/158): Interrupt now runs in three stages: calls `interrupt` on the thread, waits 100ms for the thread to respond and return messages, then waits 5000ms for the thread to terminate itself. A hard `.stop` is only called if it fails to do so.
 
 ## 0.6.0 (2019-02-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * [#140](https://github.com/nrepl/nrepl/issues/140): Added initial version of spec for message responses. These are used during Clojure 1.10 tests.
 * [#97](https://github.com/nrepl/nrepl/issues/97): Added a sideloader, a network classloader that allows dependencies to be added even the source/class files are not available on the server JVM's classpath.
 
+### Changes
+
+* [#158](https://github.com/nrepl/nrepl/issues/158): Interrupt now runs in three stages: calls `interrupt` on the thread, waits 100ms for the thread to respond and return messages, then waits 5000ms for the thread to terminate itself. A hard `.stop` is only called if it fails to do so.
+
 ### Bugs fixed
 
 * [#152](https://github.com/nrepl/nrepl/issues/152): Bug fix to kill session threads when closing sessions

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -196,6 +196,7 @@
                         ;; First interrupt the thread. Then wait for a timeout
                         ;; if not terminated, do a hard stop
                         (.interrupt t)
+                        (Thread/sleep 100)
                         (future
                           (Thread/sleep 5000)
                           (when-not (= (Thread$State/TERMINATED)

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -150,6 +150,30 @@
       (and (instance? Compiler$CompilerException e)
            (instance? ThreadDeath (.getCause e)))))
 
+(defn- interrupt-stop
+  "This works as follows
+
+  1. Calls interrupt
+  2. Wait 100ms. This is mainly to allow thread that respond quickly to
+     interrupts to send a message back in response to the interrupt. Significantly,
+     this includes an exception thrown by `Thread/sleep`.
+  3. Asynchronously: wait another 5000ms for the thread to cleanly terminate.
+     Only calls `.stop` if it fails to do so (and risk state corruption)
+
+  This set of behaviours strikes a balance between allowing a thread to respond
+  to an interrupt, but also ensuring we actually kill runaway processes.
+
+  If required, a future feature could make both timeouts configurable, either
+  as a server config or parameters provided by the `interrupt` message."
+  [^Thread t]
+  (.interrupt t)
+  (Thread/sleep 100)
+  (future
+    (Thread/sleep 5000)
+    (when-not (= (Thread$State/TERMINATED)
+                 (.getState t))
+      (.stop t))))
+
 (defn session-exec
   "Takes a session id and returns a maps of three functions meant for interruptible-eval:
    * :exec, takes an id (typically a msg-id), a thunk and an ack runnables (see #'default-exec for ampler
@@ -192,19 +216,11 @@
                       (nil? current) :idle
                       (and (or (nil? exec-id) (= current exec-id)) ; cas only checks identity, so check equality first
                            (compare-and-set! running current nil))
-                      (let [t ^Thread @thread]
-                        ;; First interrupt the thread. Then wait for a timeout
-                        ;; if not terminated, do a hard stop
-                        (.interrupt t)
-                        (Thread/sleep 100)
-                        (future
-                          (Thread/sleep 5000)
-                          (when-not (= (Thread$State/TERMINATED)
-                                       (.getState t))
-                            (.stop t)))
+                      (do
+                        (interrupt-stop @thread)
                         (reset! thread (spawn-thread))
                         current))))
-     :close #(.interrupt ^Thread @thread)
+     :close #(interrupt-stop @thread)
      :exec (fn [exec-id r ack]
              (.put queue [exec-id r ack]))}))
 

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -193,13 +193,14 @@
                       (and (or (nil? exec-id) (= current exec-id)) ; cas only checks identity, so check equality first
                            (compare-and-set! running current nil))
                       (let [t ^Thread @thread]
-                        ;; First try interrup. Allow a timeout
-                        ;; then if not terminated, stop
+                        ;; First interrupt the thread. Then wait for a timeout
+                        ;; if not terminated, do a hard stop
                         (.interrupt t)
-                        (Thread/sleep 100)
-                        (when-not (= (Thread$State/TERMINATED)
-                                     (.getState t))
-                          (.stop t))
+                        (future
+                          (Thread/sleep 5000)
+                          (when-not (= (Thread$State/TERMINATED)
+                                       (.getState t))
+                            (.stop t)))
                         (reset! thread (spawn-thread))
                         current))))
      :close #(.interrupt ^Thread @thread)

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -953,7 +953,7 @@
                 first
                 clean-response
                 :status)))
-    (is (= #{:done :eval-error :interrupted}
+    (is (= #{:done :interrupted}
            (->> resp
                 combine-responses
                 clean-response


### PR DESCRIPTION
Fixes #158 

Right now, an interrupt first calls `Thread.interrupt()`. It waits 100ms for the thread to terminate itself. Failing that, it calls `Thread.stop()`. This gives code that respects the interrupt flag a chance to exit in a more safe manner.

A few things to note:

- `Thread.sleep()` throws an `InterruptedException` when interrupted. This causes an `eval-error` if not otherwise handled. One test has been updated to reflect this. This does change nREPL's behaviour. I'm not sure how much of an issue this could be?
- The 100ms waiting time was arbitrary. Guess the "correct" value depends on how often the thread being interrupted checks the flag. I have no idea what's the typical interval, but can imagine a situation where the client would want to set the time to be longer? I also feel like the default wait time shouldn't be too long. @FreekPaans: just to get one more data point, what would be the "right" timeout for you?

I think this provides us a way to deal with the #132, where a an interrupted eval with streamed printing can generate malformed bencode. Not too sure how that should be done though.