### PR TITLE
Updating the changelog, and making a correction in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * [#60](https://github.com/nrepl/nrepl/issues/60): Implemented EDN transport.
 * [#140](https://github.com/nrepl/nrepl/issues/140): Added initial version of spec for message responses. These are used during Clojure 1.10 tests.
+* [#97](https://github.com/nrepl/nrepl/issues/97): Added a sideloader, a network classloader that allows dependencies to be added even the source/class files are not available on the server JVM's classpath.
+
 ### Bugs fixed
 
 * [#152](https://github.com/nrepl/nrepl/issues/152): Bug fix to kill session threads when closing sessions

--- a/doc/modules/ROOT/pages/design/middleware.adoc
+++ b/doc/modules/ROOT/pages/design/middleware.adoc
@@ -318,7 +318,7 @@ If a middleware descriptor's `:requires` set contains
 NOTE: Sideloading support was added in nREPL 0.7 and the API is still
 considered experimental, and may change.
 
-nREPL includes `sideloader` middleware. This provides a Java Class Loader that is able to dynamically load classes and resources at runtime by interacting with the nREPL client (as opposed to using the classpath of the JVM hosting nREPL server). 
+nREPL includes `sideloader` middleware. This provides a Java Class Loader that is able to dynamically load classes and resources at runtime by interacting with the nREPL client (as opposed to using the classpath of the JVM hosting nREPL server).
 
 This performs a similar functionality as the `load-file` operation, where we can load Clojure namespaces (as source files) or Java classes (as bytecode) by simply `require` or `import` them.
 
@@ -326,14 +326,14 @@ This allows a client to add new functionality to an already running instance of 
 
 === Starting the sideloader
 
-The sideloader is initialised by a new operation: `sideloader-start`. This will return with status `:done` immediately, and its message ID will be used for all future sideloading requests.
+The sideloader is initialised by a new operation: `sideloader-start`. This will never return with status `:done`, but its message ID will be used for all future sideloading requests.
 
 As additional resources/classes are looked up, server will send messages to the client with status `:sideloader-lookup`, and the following parameters
 
 * `:type`, being `resource` or `class`
 * `:name`, being a string (e.g. `foo/bar.clj` or `foo.bar`)
 
-The client is responsible for responding to the lookup. It does so by replying with the operation `sideloader-provide`, and paramters 
+The client is responsible for responding to the lookup. It does so by replying with the operation `sideloader-provide`, and paramters
 
 * `:type` and `:name` the same as the lookup.
 * `:content` base-64 encoded byte array of the resource or class. An empty response indicates "resource/class not found."


### PR DESCRIPTION
Forgot to update the changelog with the last PR.

Also, we removed the `done` response to `sideloader-start` late in the PR, but didn't update the docs to reflect.