### PR TITLE
Adding test for interrupting streamed printing back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bugs fixed
 
 * [#152](https://github.com/nrepl/nrepl/issues/152): Bug fix to kill session threads when closing sessions
+* [#132](https://github.com/nrepl/nrepl/issues/132): Bug fix to avoid malformed bencode messages during interrutps, mainly affecting streamed printing
 
 ### Changes
 

--- a/src/clojure/nrepl/bencode.clj
+++ b/src/clojure/nrepl/bencode.clj
@@ -286,9 +286,9 @@
 (defn #^{:private true} read-map
   [input]
   (->> (token-seq input)
-       (into {} (comp (partition-all 2)
-                      (map (fn [[k v]]
-                             [(string<payload k) v]))))))
+       (partition 2)
+       (map (fn [[k v]] [(string<payload k) v]))
+       (into {})))
 
 ;; The final missing piece is `token-seq`. This a just a simple
 ;; sequence which reads tokens until the next `\e`.

--- a/src/clojure/nrepl/transport.clj
+++ b/src/clojure/nrepl/transport.clj
@@ -70,8 +70,8 @@
 (defmethod <bytes clojure.lang.IPersistentMap
   [input]
   (->> input
-       (into {} (map (fn [[k v]]
-                       [k (<bytes v)])))))
+       (map (fn [[k v]] [k (<bytes v)]))
+       (into {})))
 
 (defmacro ^{:private true} rethrow-on-disconnection
   [^Socket s & body]


### PR DESCRIPTION
I thought #163 paved the way for us to work on #132, but it would appear it fixed #132 already. I'm not 100% sure why, and this might be worth investigating it a bit.

In the meanwhile, this PR also reverts https://github.com/nrepl/nrepl/commit/c99280bbf9078e5b3f96a7ec23f89ea2425b9a4e which makes bencode.clj a bit cleaner, I think.