### PR TITLE
Allow suppressing ack message when using nrepl.cmdline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   maps that have keywords or symbols as keys. This allowed a simplification of the
   Bencode transport itself.
 * [#158](https://github.com/nrepl/nrepl/issues/158): Interrupt now runs in three stages: calls `interrupt` on the thread, waits 100ms for the thread to respond and return messages, then waits 5000ms for the thread to terminate itself. A hard `.stop` is only called if it fails to do so.
+* [#167](https://github.com/nrepl/nrepl/issues/167): Allow suppressing ack message when using nrepl.cmdline
 
 ## 0.6.0 (2019-02-05)
 

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -128,7 +128,8 @@ Exit:      Control+D or (exit) or (quit)"
     "--connect"
     "--color"
     "--help"
-    "--version"})
+    "--version"
+    "--verbose"})
 
 (defn- expand-shorthands
   "Expand shorthand options into their full forms."
@@ -171,7 +172,8 @@ Exit:      Control+D or (exit) or (quit)"
   -m/--middleware MIDDLEWARE  A sequence of vars, representing middleware you wish to mix in to the nREPL handler.
   -t/--transport TRANSPORT    The transport to use. By default that's nrepl.transport/bencode.
   --help                      Show this help message.
-  -v/--version                Display the nREPL version."))
+  -v/--version                Display the nREPL version.
+  --verbose                   Show verbose output."))
 
 (defn- require-and-resolve
   "Attempts to resolve the config `key`'s `value` as a namespaced symbol
@@ -378,10 +380,10 @@ Exit:      Control+D or (exit) or (quit)"
   (when-let [ack-port (:ack-port options)]
     (let [port (:port server)
           transport (:transport options)]
-      (binding [*out* *err*]
+      (when (:verbose options)
         (println (format "ack'ing my port %d to other server running on port %d"
-                         port ack-port)
-                 (send-ack port ack-port transport))))))
+                         port ack-port)))
+      (send-ack port ack-port transport))))
 
 (defn server-started-message
   "Returns nREPL server started message that some tools rely on to parse the


### PR DESCRIPTION
This commit adds a `--verbose` command line option, and only displays the ack
message if this flag is passed. It also prints the message to `*out*` rather
than `*err*`, which didn't seem to make sense since it's not an erroneous
condition. Finally, the previous message also included the result of calling
`send-ack`, which always returns `nil`.

Fixes https://github.com/nrepl/nrepl/issues/167
