### PR TITLE
Fixing the telnet server functionality

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,8 @@
                                     :sign-releases false}]]
 
   :profiles {:fastlane {:dependencies [[nrepl/fastlane "0.1.0"]]}
-             :test {:dependencies [[com.hypirion/io "0.3.1"]]
+             :test {:dependencies [[com.hypirion/io "0.3.1"]
+                                   [commons-net/commons-net "3.6"]]
                     :plugins      [[test2junit "1.4.2"]]
                     :test2junit-output-dir "test-results"
                     :aliases {"test" "test2junit"}}

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -259,7 +259,7 @@
   "Drops the session associated with the given message."
   [{:keys [session transport] :as msg}]
   (let [{:keys [close] session-id :id} (meta session)]
-    (close)
+    (when close (close))
     (swap! sessions dissoc session-id)
     (t/send transport (response-for msg :status #{:done :session-closed}))))
 

--- a/src/clojure/nrepl/transport.clj
+++ b/src/clojure/nrepl/transport.clj
@@ -160,7 +160,7 @@
                      (merge {:op "eval" :code [code] :ns @cns :id (str "eval" (uuid))}
                             (when @session-id {:session @session-id})))
          read-seq (atom (cons {:op "clone"} (repeatedly read-msg)))
-         write (fn [{:strs [out err value status ns new-session id] :as msg}]
+         write (fn [{:keys [out err value status ns new-session id] :as msg}]
                  (when new-session (reset! session-id new-session))
                  (when ns (reset! cns ns))
                  (doseq [^String x [out err value] :when x]


### PR DESCRIPTION
While looking at #126, I noticed that the TTY server is broken. Turns out this happened in #135 (my bad), and was further impacted by #153.

To test this:

```
lein install
clj -Sdeps '{:deps {nrepl {:mvn/version "0.7.0-alpha2"}}}' -m nrepl.cmdline --transport nrepl.transport/tty --port 7888 --headless
```

Then, in a different terminal

```
telnet localhost 7888
```

I had to install telnet on my mac using `brew install telnet`.

Feels like we should have a regression test for this kinda thing... not too sure what that would look like though.