### PR TITLE
Some housekeeping on middleware code

### DIFF
--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -143,13 +143,6 @@
        (evaluate msg))
      the-session)))
 
-(defn interrupted?
-  "Returns true if the given throwable was ultimately caused by an interrupt."
-  [^Throwable e]
-  (or (instance? ThreadDeath (clojure.main/root-cause e))
-      (and (instance? Compiler$CompilerException e)
-           (instance? ThreadDeath (.getCause e)))))
-
 (defn- interrupt-stop
   "This works as follows
 

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -88,7 +88,7 @@
    #'nrepl.middleware.load-file/wrap-load-file
    #'nrepl.middleware.session/add-stdin
    #'nrepl.middleware.session/session
-   #'nrepl.middleware.sideloader/sideloader])
+   #'nrepl.middleware.sideloader/wrap-sideloader])
 
 (defn default-handler
   "A default handler supporting interruptible evaluation, stdin, sessions, and


### PR DESCRIPTION
- Removed some unused code from `interruptable-eval`, from back when it handled interrupts. Added doc string for the ns, including a note about this.
- Consolidated all the sideloader code into its own ns. The only interface to the rest of the codebase is just a `:classloader` key on the session.
- Renamed `sideloader` to `wrap-sideloader`, following preferred pattern for new middlewares.