### PR TITLE
Fix op "eval" doc {:values -> :value}

### DIFF
--- a/doc/modules/ROOT/pages/ops.adoc
+++ b/doc/modules/ROOT/pages/ops.adoc
@@ -84,10 +84,10 @@ Optional parameters::
 
 
 Returns::
-* `:ex` The type of exception thrown, if any. If present, then ``values`` will be absent.
+* `:ex` The type of exception thrown, if any. If present, then ``:value`` will be absent.
 * `:ns` \*ns*, after successful evaluation of ``code``.
-* `:root-ex` The type of the root exception thrown, if any. If present, then ``values`` will be absent.
-* `:values` The result of evaluating ``code``, often ``read``able. This printing is provided by the ``print`` middleware. Superseded by ``ex`` and ``root-ex`` if an exception occurs during evaluation.
+* `:root-ex` The type of the root exception thrown, if any. If present, then ``:value`` will be absent.
+* `:value` The result of evaluating ``code``, often ``read``able. This printing is provided by the ``print`` middleware. Superseded by ``ex`` and ``root-ex`` if an exception occurs during evaluation.
 
 
 
@@ -133,10 +133,10 @@ Optional parameters::
 
 
 Returns::
-* `:ex` The type of exception thrown, if any. If present, then ``values`` will be absent.
+* `:ex` The type of exception thrown, if any. If present, then ``:value`` will be absent.
 * `:ns` \*ns*, after successful evaluation of ``code``.
-* `:root-ex` The type of the root exception thrown, if any. If present, then ``values`` will be absent.
-* `:values` The result of evaluating ``code``, often ``read``able. This printing is provided by the ``print`` middleware. Superseded by ``ex`` and ``root-ex`` if an exception occurs during evaluation.
+* `:root-ex` The type of the root exception thrown, if any. If present, then ``:value`` will be absent.
+* `:value` The result of evaluating ``code``, often ``read``able. This printing is provided by the ``print`` middleware. Superseded by ``ex`` and ``root-ex`` if an exception occurs during evaluation.
 
 
 

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -171,6 +171,6 @@
                                                "line" "The line number in [file] at which [code] starts."
                                                "column" "The column number in [file] at which [code] starts."})
                              :returns {"ns" "*ns*, after successful evaluation of `code`."
-                                       "values" "The result of evaluating `code`, often `read`able. This printing is provided by the `print` middleware. Superseded by `ex` and `root-ex` if an exception occurs during evaluation."
-                                       "ex" "The type of exception thrown, if any. If present, then `values` will be absent."
-                                       "root-ex" "The type of the root exception thrown, if any. If present, then `values` will be absent."}}}})
+                                       "value" "The result of evaluating `code`, often `read`able. This printing is provided by the `print` middleware. Superseded by `ex` and `root-ex` if an exception occurs during evaluation."
+                                       "ex" "The type of exception thrown, if any. If present, then `:value` will be absent."
+                                       "root-ex" "The type of the root exception thrown, if any. If present, then `:value` will be absent."}}}})


### PR DESCRIPTION
Only changes are documentation so no new test/changelog

- [x] Before submitting a PR make sure things have been done