### PR TITLE
Dynamic loading of middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Bundle a couple of print functions compatible with the print middleware (see `nrepl.util.print`).
 * [#174](https://github.com/nrepl/nrepl/issues/174): Provide a built-in `completions` op.
+* [#143](https://github.com/nrepl/nrepl/issues/143): Added a middleware that allows dynamic loading/unloading of middlewares while the server is running.
 
 ## 0.7.0 (2020-03-28)
 

--- a/doc/modules/ROOT/pages/building_clients.adoc
+++ b/doc/modules/ROOT/pages/building_clients.adoc
@@ -116,6 +116,58 @@ This unblocks the `eval` command, which returns the value `Qaz` in the final mes
 
 It's thus important, once sideloading has started, to asynchronously handle lookup requests, without these being blocked by waiting on a response from another message.
 
+== Modifying middleware
+
+To add a middleware that's already available on the server's classpath, it's as
+simple as sending the message
+
+[source,clojure]
+----
+{:op "add-middleware"
+ :middleware ["cider.nrepl.middleware/wrap-version"]}
+----
+
+However, if the middleware is loaded, it's very likely that it hasn't been included
+as a dependency on the server, and thus unavailable on its classpath. Furthermore.
+In this case, we can use the `dynamic-loader` in conjunction with the `sideloader`:
+
+[source,clojure]
+----
+{:op "sideloader-start"}
+;; handle sideloading separatedly...
+;; now we add the middleware
+{:op "add-middleware"
+ :middleware ["cider.nrepl.middleware/wrap-version"]}
+;; confirm it's being loaded..
+{:op "ls-middleware"}
+;; and we should get something like...
+{:status #{:done}
+ :middleware [... "#'cider.nrepl.middleware/wrap-version" ...]}
+----
+
+However, if we tried to use the middleware with an `cider-version` op, we'd get an
+error, because the middleware is implemented in a different namespace, which is
+only loaded on the first use of the `cider-version` op. This is a practice in
+many middleware to improve startup performance. One method of getting around this
+is to request the extra namespace to be loaded at `add-middleware` time too:
+
+[source,clojure]
+----
+;; after starting the sideloader...
+{:op "add-middleware"
+ :middleware ["cider.nrepl.middleware/wrap-version"]
+ :extra-namespaces ["cider.nrepl.middleware.version"]}
+ ;; now, the following shoud work
+ {:op "cider-version"}
+----
+
+There is no operation to remove a single middleware, but it's possible to reset
+the stack to a baseline with the `swap-middleware` operation. If the goal is to
+simply reset the middleware stack, use this in conjuction with
+`nrepl.server/default-middleware`.
+
+Also note that updating the middleware stack may also destroy/re-create middleware state. As an example, sideloading would need to be re-started. The impact on each middleware differs, however, as some of them, e.g. `session` holds their state globally.
+
 == Additional Resources
 
 * https://mauricio.szabo.link/blog/2020/04/04/implementing-a-nrepl-client/

--- a/doc/modules/ROOT/pages/design/middleware.adoc
+++ b/doc/modules/ROOT/pages/design/middleware.adoc
@@ -28,13 +28,13 @@ All of nREPL's provided default functionality is implemented in terms of
 middleware, even foundational bits like session and eval support.  This default
 middleware "stack" aims to match and exceed the functionality offered by the
 standard Clojure REPL, and is available at
-`nrepl.server/default-middlewares`.  Concretely, it consists of a
+`nrepl.server/default-middleware`.  Concretely, it consists of a
 number of middleware functions' vars that are implicitly merged with any
 user-specified middleware provided to
 `nrepl.server/default-handler`.  To understand how that implicit
 merge works, we'll first need to talk about middleware "descriptors".
 
-link:https://github.com/nrepl/nrepl/wiki/Extensions[Other nREPL middlewares are provided by the community].
+link:https://github.com/nrepl/nrepl/wiki/Extensions[Other nREPL middleware are provided by the community].
 
 (See xref:ops.adoc[this documentation listing] for
 details as to the operations implemented by nREPL's default middleware stack,
@@ -125,7 +125,7 @@ Clojure's default stream-based REPL implementation).
 
 The specific contents of a middleware's descriptor depends entirely on its
 objectives: which operations it is to implement/define, how it is to modify
-incoming request messages, and which higher- and lower-level middlewares are to
+incoming request messages, and which higher- and lower-level middleware are to
 aid in accomplishing its aims.
 
 nREPL uses the dependency information in descriptors in order to produce a
@@ -268,7 +268,7 @@ specified in both). The following options are supported:
  :nrepl.middleware.print/quota 8096}
 ----
 
-The functionality of the `print` middleware is reusable by other middlewares. If
+The functionality of the `print` middleware is reusable by other middleware. If
 a middleware descriptor's `:requires` set contains
 `#'nrepl.middleware.print/wrap-print`, then it can expect:
 
@@ -316,7 +316,7 @@ any options are specified in both). The following options are supported:
  :nrepl.middleware.caught/print? true}
 ----
 
-The functionality of the `caught` middleware is reusable by other middlewares.
+The functionality of the `caught` middleware is reusable by other middleware.
 If a middleware descriptor's `:requires` set contains
 `#'nrepl.middleware.caught/wrap-caught`, then it can expect:
 
@@ -359,3 +359,19 @@ See link:../building_clients.html[Building Clients] on how to implement the serv
 Once the sideloader has been started, it can be triggered by an ordinary `eval` or `load-file` operation. The nREPL server will first try to find a resource/class on the classpath of its own JVM. Failing this, it will attempt to request it from the nREPL client by the above described mechanism. Should this still fail, expect a `ClassNotFoundException` as usual.
 
 TIP: Once a class has been loaded, it will become available to all sessions on nREPL server.
+
+== Dynamic middleware loading
+
+NOTE: Dynamic middleware loading support was added in nREPL 0.8 and the API is still
+considered experimental, and may change.
+
+nREPL includes a `dynamic-loader` middleware, which can be used, at runtime,
+query and change the middleware stack the nREPL server is using. This is especially
+powerful when combined with sideloading, as it allows a client to configure the
+server after connecting, and provides an alternative to having to specify the middleware required by the client as startup time.
+
+This introduces three new operations:
+
+* `ls-middleware`, to return a list of active middleware, ordered from inside outwards.
+* `add-middleware`, which adds a middleware to the stack. Optionally, a list of `extra-namespaces` could be provided for loading. This is useful when adding middleware that implement some form of deferred loading. Examples include `cider-nrepl` and `refactor-nrepl`. In these cases, some of the required namespaces might only be loaded upon first use, which may occur outside of a sideloading session, and thus fail. This feature allows us to pre-load namespaces when we add a middleware. If loading of any particular middleware fails, the stack will be unchanged.
+* `swap-middleware`, similar to `add-`, but replaces all existing middleware. Note that this _may_ remove the `dynamic-loader` itself.

--- a/doc/modules/ROOT/pages/ops.adoc
+++ b/doc/modules/ROOT/pages/ops.adoc
@@ -8,6 +8,24 @@ This file is _generated_ by #'nrepl.impl.docs/-main
 
 == Operations
 
+=== `add-middleware`
+
+Adding some middleware
+
+Required parameters::
+* `:middleware` a list of middleware
+
+
+Optional parameters::
+* `:extra-namespaces` a list of extra namespaces to load. This is useful when the new middleware feature deferred loading
+
+
+Returns::
+* `:status` ``done``, once done, and ``error``, if there's any problems in loading a middleware
+* `:unresolved-middleware` List of middleware that could not be resolved
+
+
+
 === `clone`
 
 Clones the current session, returning the ID of the newly-created session.
@@ -159,6 +177,21 @@ Returns::
 
 
 
+=== `ls-middleware`
+
+List of current middleware
+
+Required parameters::
+{blank}
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:middleware` list of vars representing loaded middleware, from inside out
+
+
+
 === `ls-sessions`
 
 Lists the IDs of all active sessions.
@@ -221,4 +254,22 @@ Optional parameters::
 
 Returns::
 * `:status` A status of "need-input" will be sent if a session's \*in* requires content in order to satisfy an attempted read operation.
+
+
+
+=== `swap-middleware`
+
+Replace the whole middleware stack
+
+Required parameters::
+* `:middleware` a list of middleware
+
+
+Optional parameters::
+* `:extra-namespaces` a list of extra namespaces to load. This is useful when the new middleware feature deferred loading
+
+
+Returns::
+* `:status` ``done``, once done, and ``error``, if there's any problems in loading a middleware
+* `:unresolved-middleware` List of middleware that could not be resolved
 

--- a/project.clj
+++ b/project.clj
@@ -65,7 +65,8 @@
              :cljfmt {:plugins [[lein-cljfmt "0.6.1"]]
                       :cljfmt {:indents {as-> [[:inner 0]]
                                          with-debug-bindings [[:inner 0]]
-                                         merge-meta [[:inner 0]]}}}
+                                         merge-meta [[:inner 0]]
+                                         testing-dynamic [[:inner 0]]}}}
 
              :eastwood [:test
                         {:plugins [[jonase/eastwood "0.3.4"]]

--- a/src/clojure/nrepl/middleware/dynamic_loader.clj
+++ b/src/clojure/nrepl/middleware/dynamic_loader.clj
@@ -1,0 +1,101 @@
+(ns nrepl.middleware.dynamic-loader
+  "Support the ability to interactively update the middleware of the *running*
+  nREPL server. This can be used by tools to configure an existing instance of
+  an environment after connection.
+
+  When combined with the sideloader, this could be used to inject middleware
+  that are unknown to the server prior to connection."
+  {:author "Shen Tian", :added "0.8"}
+  (:require [clojure.string :as str]
+            [nrepl.middleware :refer [linearize-middleware-stack set-descriptor!]]
+            [nrepl.middleware.session :as middleware.session]
+            [nrepl.misc :as misc :refer [response-for]]
+            [nrepl.transport :as t]))
+
+(def ^:dynamic *state* nil)
+
+(defn wrap-ping
+  [h]
+  (fn [{:keys [op transport] :as msg}]
+    (case op
+      "ping"
+      (t/send transport (response-for msg {:pong "pong"
+                                           :status :done}))
+      (h msg))))
+
+(set-descriptor! #'wrap-ping
+                 {:require #{}
+                  :expects #{}
+                  :handles {"ping"
+                            {:doc "Ping"
+                             :require {}
+                             :returns {"status" "done"}}}})
+
+(defn unknown-op
+  "Sends an :unknown-op :error for the given message."
+  [{:keys [op transport] :as msg}]
+  (t/send transport (response-for msg :status #{:error :unknown-op :done} :op op)))
+
+(defn- update-stack!
+  [session middleware]
+  (let [ctxcl  (.getContextClassLoader (Thread/currentThread))
+        alt-cl (when-let [classloader (:classloader (meta session))]
+                 (classloader))
+        cl     (or alt-cl
+                   ctxcl)]
+    (.setContextClassLoader (Thread/currentThread) cl)
+    (try
+      (with-bindings {clojure.lang.Compiler/LOADER cl}
+        (let [stack (->> middleware
+                         (map (fn [middleware-str-or-var]
+                                (if (var? middleware-str-or-var)
+                                  middleware-str-or-var
+                                  (-> middleware-str-or-var
+                                      (str/replace "#'" "")
+                                      symbol
+                                      misc/requiring-resolve))))
+                         linearize-middleware-stack)]
+          (reset! *state* {:handler ((apply comp (reverse stack)) unknown-op)
+                           :stack   stack})))
+      (catch Throwable t
+        {:error        t
+         :alt-cl?      (boolean alt-cl)
+         :before-stack (map str (:stack @*state*))})
+      (finally
+        (.setContextClassLoader (Thread/currentThread) ctxcl)))))
+
+(defn wrap-dynamic-loader
+  [h]
+  (fn [{:keys [op transport session middleware] :as msg}]
+    (case op
+      "add-middleware"
+      (do
+        (let [{:keys [error alt-cl? before-stack]}
+              (update-stack! session (concat middleware (:stack @*state*)))]
+          (when error
+            (t/send transport (response-for msg {:error        (str error)
+                                                 :sideloading  (str alt-cl?)
+                                                 :before-stack before-stack}))))
+        (t/send transport (response-for msg {:status :done})))
+
+      "swap-middleware"
+      (do
+        (update-stack! session middleware)
+        (when transport
+          (t/send transport (response-for msg :middleware (mapv str (:stack @*state*))))
+          (t/send transport (response-for msg {:status :done}))))
+
+      "ls-middleware"
+      (do
+        (t/send transport (response-for msg :middleware (mapv str (:stack @*state*))))
+        (t/send transport (response-for msg {:status :done})))
+
+      (h msg))))
+
+(set-descriptor! #'wrap-dynamic-loader
+                 {:requires #{#'middleware.session/session}
+                  :expects  #{}
+                  :handles  {"add-middleware"
+                             {:doc     "Adding some middleware, dynamically"
+                              :require {"middleware" "a list of middleware"}
+                              :returns {"status" "done, once done"}}}})

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -71,9 +71,9 @@
          alt-cl# (when-let [classloader# (:classloader (meta ~session))]
                    (classloader#))
          cl#     (or alt-cl# ctxcl#)]
-    (.setContextClassLoader (Thread/currentThread) cl#)
-    (try
-      (with-bindings {clojure.lang.Compiler/LOADER cl#}
-        ~@body)
-      (finally
-        (.setContextClassLoader (Thread/currentThread) ctxcl#)))))
+     (.setContextClassLoader (Thread/currentThread) cl#)
+     (try
+       (with-bindings {clojure.lang.Compiler/LOADER cl#}
+         ~@body)
+       (finally
+         (.setContextClassLoader (Thread/currentThread) ctxcl#)))))

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -95,14 +95,18 @@
    #'nrepl.middleware.dynamic-loader/wrap-dynamic-loader])
 
 (defn default-handler
-  "A default handler supporting interruptible evaluation, stdin, sessions, and
-   readable representations of evaluated expressions via `pr`.
+  "A default handler supporting interruptible evaluation, stdin, sessions,
+   readable representations of evaluated expressions via `pr`, sideloading, and
+   dynamic loading of middlewares.
 
    Additional middlewares to mix into the default stack may be provided; these
    should all be values (usually vars) that have an nREPL middleware descriptor
-   in their metadata (see `nrepl.middleware/set-descriptor!`)."
+   in their metadata (see `nrepl.middleware/set-descriptor!`).
+
+   This handler bootstraps by initiating with just the dynamic loader, then
+   using that to load the other middleware."
   [& additional-middleware]
-  (let [initial-handler (dynamic-loader/wrap-dynamic-loader unknown-op)
+  (let [initial-handler (dynamic-loader/wrap-dynamic-loader nil)
         state           (atom {:handler initial-handler
                                :stack   [#'nrepl.middleware.dynamic-loader/wrap-dynamic-loader]})]
     (binding [dynamic-loader/*state* state]

--- a/test-resources/ping.clj
+++ b/test-resources/ping.clj
@@ -1,23 +1,36 @@
 (ns ping
   (:require [nrepl.middleware :as middleware :refer [set-descriptor!]]
-            [nrepl.misc :refer [response-for]]
+            [nrepl.misc :as misc :refer [response-for]]
             [nrepl.transport :as t]))
+
+(def deferred-handler
+  (delay
+    (fn [{:keys [transport] :as msg}]
+      (t/send transport (response-for msg
+                                      {:pong
+                                       ((misc/requiring-resolve (symbol "ping-imp/pong")))
+                                       :status :done})))))
 
 (defn wrap-ping
   [h]
   (fn [{:keys [op transport] :as msg}]
     (case op
       "ping"
-      (t/send transport (response-for msg {:pong "pong"
+      (t/send transport (response-for msg {:pong   "pong"
                                            :status :done}))
-      (h msg))))
+      "deferred-ping"
+      (@deferred-handler msg)
 
-(def pong :pong)
+      (h msg))))
 
 (set-descriptor! #'wrap-ping
                  {:requires #{}
                   :expects  #{}
                   :handles  {"ping"
-                             {:doc     "Ping"
-                              :require {}
-                              :returns {"status" "done"}}}})
+                             {:doc      "Ping"
+                              :requires {}
+                              :returns  {"status" "done"}}
+                             "deferred-ping"
+                             {:doc      "Ping"
+                              :requires {}
+                              :returns  {"status" "done"}}}})

--- a/test-resources/ping.clj
+++ b/test-resources/ping.clj
@@ -1,0 +1,23 @@
+(ns ping
+  (:require [nrepl.middleware :as middleware :refer [set-descriptor!]]
+            [nrepl.misc :refer [response-for]]
+            [nrepl.transport :as t]))
+
+(defn wrap-ping
+  [h]
+  (fn [{:keys [op transport] :as msg}]
+    (case op
+      "ping"
+      (t/send transport (response-for msg {:pong "pong"
+                                           :status :done}))
+      (h msg))))
+
+(def pong :pong)
+
+(set-descriptor! #'wrap-ping
+                 {:requires #{}
+                  :expects  #{}
+                  :handles  {"ping"
+                             {:doc     "Ping"
+                              :require {}
+                              :returns {"status" "done"}}}})

--- a/test-resources/ping.clj
+++ b/test-resources/ping.clj
@@ -1,4 +1,7 @@
 (ns ping
+  "This provides an example of a middleware, including a deferred handler
+  that's not loaded until called. This is representative of how cider-nrepl
+  and refactor-nrepl handles deferred loading"
   (:require [nrepl.middleware :as middleware :refer [set-descriptor!]]
             [nrepl.misc :as misc :refer [response-for]]
             [nrepl.transport :as t]))

--- a/test-resources/ping_imp.clj
+++ b/test-resources/ping_imp.clj
@@ -1,0 +1,3 @@
+(ns ping-imp)
+
+(defn pong [] "pong-deferred")

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -1251,7 +1251,8 @@
     (File. project-base-dir "test-resources/ping.clj"))
 
    ["resource" "ping_imp.clj"]
-   "(ns ping-imp) (defn pong [] \"pong-deferred\")"})
+   (slurp
+    (File. project-base-dir "test-resources/ping_imp.clj"))})
 
 (def-repl-test dynamic-middleware-test
   (let [rsp (->> (message client {:op "ls-middleware"})

--- a/test/clojure/nrepl/describe_test.clj
+++ b/test/clojure/nrepl/describe_test.clj
@@ -12,7 +12,8 @@
 (def ^{:private true} op-names
   #{"load-file" "ls-sessions" "interrupt" "stdin"
     "describe" "eval" "close" "clone" "completions"
-    "sideloader-start" "sideloader-provide"})
+    "sideloader-start" "sideloader-provide"
+    "add-middleware"})
 
 (def-repl-test simple-describe
   (let [{{:keys [nrepl clojure java]} :versions

--- a/test/clojure/nrepl/describe_test.clj
+++ b/test/clojure/nrepl/describe_test.clj
@@ -1,20 +1,14 @@
 (ns nrepl.describe-test
   {:author "Chas Emerick"}
-  (:require [clojure.test :refer [is testing use-fixtures]]
-            [nrepl.core :as nrepl]
-            [nrepl.core-test :refer [def-repl-test repl-server-fixture]]
-            [nrepl.middleware :as middleware]
-            [nrepl.server :as server]
-            [nrepl.version :as version]))
+  (:require
+   [clojure.test :refer [is testing use-fixtures]]
+   [nrepl.core :as nrepl]
+   [nrepl.core-test :refer [def-repl-test repl-server-fixture]]
+   [nrepl.middleware :as middleware]
+   [nrepl.server :as server]
+   [nrepl.version :as version]))
 
 (use-fixtures :once repl-server-fixture)
-
-(def ^{:private true} op-names
-  "Get all the op names from default middlewares automatically"
-  (->> server/default-middlewares
-       (map #(-> % meta :nrepl.middleware/descriptor :handles keys))
-       (reduce concat)
-       set))
 
 (def-repl-test simple-describe
   (let [{{:keys [nrepl clojure java]} :versions
@@ -29,13 +23,13 @@
       (is (= (clojure-version) (:version-string clojure)))
       (is (= (System/getProperty "java.version") (:version-string java))))
 
-    (is (= op-names (set (map name (keys ops)))))
+    (is (= server/built-in-ops (set (map name (keys ops)))))
     (is (every? empty? (map val ops)))))
 
 (def-repl-test verbose-describe
   (let [{:keys [ops aux]} (nrepl/combine-responses
                            (nrepl/message timeout-client
                                           {:op "describe" :verbose? "true"}))]
-    (is (= op-names (set (map name (keys ops)))))
+    (is (= server/built-in-ops (set (map name (keys ops)))))
     (is (every? seq (map (comp :doc val) ops)))
     (is (= {:current-ns "user"} aux))))

--- a/test/clojure/nrepl/describe_test.clj
+++ b/test/clojure/nrepl/describe_test.clj
@@ -1,19 +1,20 @@
 (ns nrepl.describe-test
   {:author "Chas Emerick"}
-  (:require
-   [clojure.test :refer :all]
-   [nrepl.core :as nrepl]
-   [nrepl.core-test :refer [def-repl-test repl-server-fixture project-base-dir]]
-   [nrepl.middleware :as middleware]
-   [nrepl.version :as version]))
+  (:require [clojure.test :refer [is testing use-fixtures]]
+            [nrepl.core :as nrepl]
+            [nrepl.core-test :refer [def-repl-test repl-server-fixture]]
+            [nrepl.middleware :as middleware]
+            [nrepl.server :as server]
+            [nrepl.version :as version]))
 
 (use-fixtures :once repl-server-fixture)
 
 (def ^{:private true} op-names
-  #{"load-file" "ls-sessions" "interrupt" "stdin"
-    "describe" "eval" "close" "clone" "completions"
-    "sideloader-start" "sideloader-provide"
-    "add-middleware"})
+  "Get all the op names from default middlewares automatically"
+  (->> server/default-middlewares
+       (map #(-> % meta :nrepl.middleware/descriptor :handles keys))
+       (reduce concat)
+       set))
 
 (def-repl-test simple-describe
   (let [{{:keys [nrepl clojure java]} :versions

--- a/test/clojure/nrepl/middleware/dynamic_loader_test.clj
+++ b/test/clojure/nrepl/middleware/dynamic_loader_test.clj
@@ -1,0 +1,63 @@
+(ns nrepl.middleware.dynamic-loader-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [nrepl.core :refer [combine-responses]]
+            [nrepl.middleware.dynamic-loader :as sut]
+            [nrepl.transport :as t]))
+
+(defn test-transport [queue]
+  (t/fn-transport
+   nil
+   #(swap! queue conj %)))
+
+(defmacro testing-dynamic
+  "Macro useful for defining tests for the dynamic-loader"
+  {:style/indent 1}
+  [doc & body]
+  `(testing ~doc
+     (let [state#   (atom {:handler (sut/wrap-dynamic-loader sut/unknown-op)
+                           :stack   ["#'nrepl.middleware.dynamic-loader/wrap-dynamic-loader"]})
+           ~'handle (fn [msg#]
+                      (let [resps#          (atom [])
+                            resp-transport# (test-transport resps#)]
+                        (binding [sut/*state* state#]
+                          ((:handler @state#) (assoc msg# :transport
+                                                     resp-transport#)))
+                        (combine-responses @resps#)))]
+       ~@body)))
+
+(deftest wrap-dynamic-loader-test
+  (testing-dynamic "Booting with no middleware"
+    (is (= ["#'nrepl.middleware.dynamic-loader/wrap-dynamic-loader"]
+           (:middleware (handle {:op "ls-middleware"}))))
+    (is (contains? (:status (handle {:op "describe"}))
+                   :unknown-op)))
+  (testing-dynamic "Adding a middleware works"
+    (handle {:op          "add-middleware"
+             :middleware ["nrepl.middleware.session/session"]})
+    (is (= ["#'nrepl.middleware.dynamic-loader/wrap-dynamic-loader"
+            "#'nrepl.middleware.session/session"]
+           (:middleware (handle {:op "ls-middleware"}))))
+    (is (contains? (:status (handle {:op "ls-sessions"}))
+                   :done)))
+  (testing-dynamic "Adding a middleware is cumulative"
+    (handle {:op          "add-middleware"
+             :middleware ["nrepl.middleware.session/session"]})
+    (is (= ["#'nrepl.middleware.dynamic-loader/wrap-dynamic-loader"
+            "#'nrepl.middleware.session/session"] ;; with session
+           (:middleware (handle {:op "ls-middleware"}))))
+    (handle {:op          "add-middleware"
+             :middleware ["nrepl.middleware.interruptible-eval/interruptible-eval"]})
+    (is (= 5 ;; now we have all these: session eval print caught dynamic
+           (count (:middleware (handle {:op "ls-middleware"}))))))
+  (testing-dynamic "Swap removes existing middleware"
+    (handle {:op          "add-middleware"
+             :middleware ["nrepl.middleware.session/session"
+                          "nrepl.middleware/wrap-describe"]})
+    (is (= 3 ;; now we have all these: session eval print caught dynamic
+           (count (:middleware (handle {:op "ls-middleware"})))))
+    (handle {:op          "swap-middleware"
+             :middleware ["nrepl.middleware.dynamic-loader/wrap-dynamic-loader"]})
+    (let [ls-result (:middleware (handle {:op "ls-middleware"}))]
+      (is (= 2 (count ls-result)))
+      (is (not (contains? (set ls-result)
+                          "#'nrepl.middleware/wrap-describe"))))))

--- a/test/clojure/nrepl/middleware/dynamic_loader_test.clj
+++ b/test/clojure/nrepl/middleware/dynamic_loader_test.clj
@@ -61,3 +61,18 @@
       (is (= 2 (count ls-result)))
       (is (not (contains? (set ls-result)
                           "#'nrepl.middleware/wrap-describe"))))))
+
+(deftest wrap-dynamic-loader-error
+  (testing-dynamic "Adding an unknown middleware returns an error"
+    (handle {:op         "add-middleware"
+             :middleware ["nrepl.middleware/wrap-describe"]})
+    ;; Sanity test the describe works
+    (is (some? (:versions (handle {:op "describe"}))))
+    (let [resp (handle {:op         "add-middleware"
+                        :middleware ["unknown-middleware/wrap-wot?"]})]
+      (is (contains? (:status resp)
+                     :error))
+      (is (contains? (set (:unresolved-middleware resp))
+                     "unknown-middleware/wrap-wot?"))
+      ;; The handler still works
+      (is (some? (:versions (handle {:op "describe"})))))))


### PR DESCRIPTION
This add a new middleware, `dynamic-loader` (open to other suggestions), that allows us to modify the middleware stack on the fly. When combined with sideloading, this would allow us to inject middleware that the host JVM is not even aware of at startup.

A possible use case, e.g. CIDER, to connect to an already running nREPL instance, check what middleware are loaded, and if missing `cider-nrepl`, load it.

Closes #143 

## API

The new middleware defines three new ops:

- `ls-middleware`: returns a list of middleware currently loaded.
- `add-middleware`: add a collection of middleware to the existing stack. This will re-sort all the existing middleware as well as the new ones.
- `swap-middleware`: replaces the existing stack with a new set of middleware.

## Implementation

This is done via a new middleware, `dnyamic-loader/wrap-dynamic-loader`. There are two interesting bits

### Passing of state

An earlier design had the `dynamic-loader` being a specialised handler, and not a middleware. It was initialised with a list of middleware. This worked quite well, and the handler held its own state of what middleware are active. However it had to be the top most layer, so we can't use any upstream middleware in this handler. In particular, not having access to `session` made sideloading difficult.

Thus, the current design used an external state atom that stores `:handler`, the active handler fn built out of all the middleware and `:stack`, the list of individual active middleware. In `server/default-handler`, we create this atom, and close over it to return the handler.

We the bind a `*state*` var in the `dynamic-loader` ns to this atom when calling the handler. This allows the middleware to modify the global(ish) handler/stack state. (The state is not actually global. It will be created each time we create a new server via `default-handler`).
This allows us to preserve `wrap-dynamic-handler` as a 1-arity fn that works well with `set-descriptor!` and `linearize-middleware-stack` etc., while effectively passing the state in.

Here's the key lines of code, showing how we create state, bootstrap the stack, and close over the state in the resultant handler:

```clojure
(defn default-handler
  [& additional-middlewares]
  (let [initial-handler (dynamic-loader/wrap-dynamic-loader unknown-op)
        state           (atom {:handler initial-handler
                               :stack   [#'nrepl.middleware.dynamic-loader/wrap-dynamic-loader]})]
    (binding [dynamic-loader/*state* state]
      (initial-handler {:op          "swap-middlewares"
                        :state       state
                        :middlewares (concat default-middlewares additional-middlewares)}))
    (fn [msg]
      (binding [dynamic-loader/*state* state]
        ((:handler @state) msg)))))
```

Open to suggestions on this approach. It's a bit loopy, but the weirdness is concentrated in very few places, and makes it easy to reason able this middleware like any other, most of the time.

### Working with the sideloader

When updating middleware, this will look to the same `(:classloader (meta session))` value that the sideloader uses, just like `interruptable-eval`. You'll want to enable the sideloader in the "nREPL config" session, update the middleware, and be free to use the middleware without having to deal the sideloader during regular use.

Note that the `dynamic-loader` doesn't interact directly with `sideloader`, thus can be before or after it on the stack. However, it does require `session` to come before it, just for the sideloading case.

## Other notes

- The PR is not ready to merge, but does have working tests, including the all important case where we combine this with the sideloader. I'd be keen for comments on the design.
- I'd like to do more on error handling/documentation/tests
- Once we have this in, a path for deferred middleware loading, e.g. the current cider ones, can be simplified a bit: 
  - Instead of loading all middleware, and have them manage their own deferred loading, have an "entry point" middleware, which doesn't depend on any of the others, but has a registry of which opts correspond to which middleware. 
  - When one of those ops is first called, use the dynamic loader to add the relevant middleware to the stack, then handle the original message.