### PR TITLE
Update tests to use Kaocha, and some other enhancements. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,9 @@ executors:
     docker:
       - image: circleci/clojure:openjdk-11-lein-2.9.1
     <<: *defaults
-  openjdk13:
+  openjdk14:
     docker:
-      - image: circleci/clojure:openjdk-13-lein-2.9.1-buster
+      - image: circleci/clojure:openjdk-14-lein-2.9.1-buster
     <<: *defaults
 
 # Runs a given set of steps, with some standard pre- and post-
@@ -134,7 +134,7 @@ jobs:
 # The ci-test-matrix does the following:
 #
 # - run tests against the target matrix
-#   - Java 8, 11 and 13
+#   - Java 8, 11 and 14
 #   - Clojure 1.7, 1.8, 1.9, 1.10, master
 # - linter, eastwood and cljfmt
 # - verifies cljdoc config
@@ -185,25 +185,25 @@ workflows:
           clojure_version: "master"
           jdk_version: openjdk11
       - test_code:
-          name: Java 13, Clojure 1.7
+          name: Java 14, Clojure 1.7
           clojure_version: "1.7"
-          jdk_version: openjdk13
+          jdk_version: openjdk14
       - test_code:
-          name: Java 13, Clojure 1.8
+          name: Java 14, Clojure 1.8
           clojure_version: "1.8"
-          jdk_version: openjdk13
+          jdk_version: openjdk14
       - test_code:
-          name: Java 13, Clojure 1.9
+          name: Java 14, Clojure 1.9
           clojure_version: "1.9"
-          jdk_version: openjdk13
+          jdk_version: openjdk14
       - test_code:
-          name: Java 13, Clojure 1.10
+          name: Java 14, Clojure 1.10
           clojure_version: "1.10"
-          jdk_version: openjdk13
+          jdk_version: openjdk14
       - test_code:
-          name: Java 13, Clojure master
+          name: Java 14, Clojure master
           clojure_version: "master"
-          jdk_version: openjdk13
+          jdk_version: openjdk14
       - util_job:
           name: Code Linting
           steps:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 VERSION ?= 1.10
 
 test:
+
+# We use kaocha on Clojure 1.9+, but revert to lein's built in
+# runner with Clojure 1.7 and 1.8.
+
 ifeq ($(VERSION),$(filter $(VERSION),1.9 1.10 master))
 	lein with-profile +$(VERSION),+test run -m kaocha.runner
 else

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@
 VERSION ?= 1.10
 
 test:
+ifeq ($(VERSION),$(filter $(VERSION),1.9 1.10 master))
+	lein with-profile +$(VERSION),+test run -m kaocha.runner
+else
 	lein with-profile +$(VERSION),+test test
+endif
 
 eastwood:
 	lein with-profile +$(VERSION),+eastwood eastwood

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+lein kaocha "$@"

--- a/doc/modules/ROOT/pages/about/compatibility.adoc
+++ b/doc/modules/ROOT/pages/about/compatibility.adoc
@@ -6,7 +6,7 @@ organization.
 == Java
 
 nREPL officially targets Java 8, Java 11 and the most recent rapid
-release version (e.g. Java 13).  More generally speaking - we aim
+release version (e.g. Java 14).  More generally speaking - we aim
 to support all Java releases that are currently officially supported
 by Oracle.
 

--- a/doc/modules/ROOT/pages/hacking_on_nrepl.adoc
+++ b/doc/modules/ROOT/pages/hacking_on_nrepl.adoc
@@ -75,21 +75,53 @@ the REPL you're using.
 
 == Running the tests
 
-The easiest way to run the tests is with the following command:
+The primary way to run tests is using Kaocha. The following command runs
+the test suite on Clojure 1.10:
+
+[source,shell]
+----
+$ bin/kaocha
+----
+
+The following command is useful while actively working on the codebase:
+
+[source,shell]
+----
+$ bin/kaocha --watch --skip-meta :slow
+----
+
+as it will re-run tests on changes, but also skip a handful of slower tests.
+
+=== Running test for Clojure 1.7 and 1.8
+
+Kaocha only supports Clojure 1.9 and up. For earlier versions, we can still use
+Leiningen's test runner. To run the tests only for a specific version of Clojure,
+use a command like this:
+
+[source,shell]
+----
+$ lein with-profile 1.8 test
+----
+
+To run tests for all Clojure versions from 1.7 to 1.10.
 
 [source,shell]
 ----
 $ lein test-all
 ----
 
-This will automatically run the tests for every supported Clojure
-profile (e.g. 1.7, 1.8, 1.9, 1.10). You can run only the tests for a
-specific version of Clojure like this:
+=== Running tests on CI
+
+For ease of use/consistency with other nREPL projects, tests are ran on CI
+environments using a `Makefile`, with the command:
 
 [source,shell]
 ----
-$ lein with-profile 1.9 test
+$ make test
 ----
+
+this will check the `VERSION` environmental variable, and switch between Kaocha
+and Leiningen tests based on which is available.
 
 == Running cljfmt
 

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   :javac-options ["-target" "8" "-source" "8"]
 
   :aliases {"bump-version" ["change" "version" "leiningen.release/bump-version"]
-            "test-all" ["with-profile" "+1.7:+1.8:+1.9:+fastlane" "test"]
+            "test-all" ["with-profile" "+1.7:+1.8:+1.9:+1.10:+fastlane" "test"]
             "docs" ["with-profile" "+maint" "run" "-m" "nrepl.impl.docs" "--file"
                     ~(clojure.java.io/as-relative-path
                       (clojure.java.io/file "doc" "modules" "ROOT" "pages" "ops.adoc"))]

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,8 @@
             "test-all" ["with-profile" "+1.7:+1.8:+1.9:+fastlane" "test"]
             "docs" ["with-profile" "+maint" "run" "-m" "nrepl.impl.docs" "--file"
                     ~(clojure.java.io/as-relative-path
-                      (clojure.java.io/file "doc" "modules" "ROOT" "pages" "ops.adoc"))]}
+                      (clojure.java.io/file "doc" "modules" "ROOT" "pages" "ops.adoc"))]
+            "kaocha" ["with-profile" "+test" "run" "-m" "kaocha.runner"]}
 
   :release-tasks [["vcs" "assert-committed"]
                   ["bump-version" "release"]
@@ -30,7 +31,9 @@
 
   :profiles {:fastlane {:dependencies [[nrepl/fastlane "0.1.0"]]}
              :test {:dependencies [[com.hypirion/io "0.3.1"]
-                                   [commons-net/commons-net "3.6"]]
+                                   [commons-net/commons-net "3.6"]
+                                   [lambdaisland/kaocha "1.0-612"]
+                                   [lambdaisland/kaocha-junit-xml "0.0-70"]]
                     :plugins      [[test2junit "1.4.2"]]
                     :test2junit-output-dir "test-results"
                     :aliases {"test" "test2junit"}}

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -18,6 +18,18 @@
 
 (def ^{:private true} sessions (atom {}))
 
+(defn close-all-sessions!
+  "Use this fn to manually shut down all sessions. Since each new session spanws
+   a new thread, and sessions need to be otherwise explicitly closed, we can
+   accumulate too many active sessions for the JVM. This occurs when we are
+   running tests in watch mode."
+  []
+  (run! (fn [[id session]]
+          (when-let [close (:close (meta session))]
+            (close))
+          (swap! sessions dissoc id))
+        @sessions))
+
 ;; TODO: the way this is currently, :out and :err will continue to be
 ;; associated with a particular *msg* (and session) even when produced from a future,
 ;; agent, etc. due to binding conveyance.  This may or may not be desirable

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -119,7 +119,7 @@
                   server
                   {:transport #'transport/bencode})))))
 
-(deftest ack
+(deftest ^:slow ack
   (let [ack-port (:port *server*)
         server-process (apply sh ["java" "-Dnreplacktest=y"
                                   "-cp" (System/getProperty "java.class.path")
@@ -143,7 +143,7 @@
       (finally
         (.destroy server-process)))))
 
-(deftest explicit-port-argument
+(deftest ^:slow explicit-port-argument
   (let [ack-port (:port *server*)
         free-port (with-open [ss (java.net.ServerSocket.)]
                     (.bind ss nil)
@@ -162,7 +162,7 @@
         (.destroy server-process)))))
 
 ;; This ignores *transport-fn*, as it tests the TTY transport
-(deftest tty-server
+(deftest ^:slow tty-server
   (let [free-port      (with-open [ss (java.net.ServerSocket.)]
                          (.bind ss nil)
                          (.getLocalPort ss))

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -18,6 +18,7 @@
    [nrepl.ack :as ack]
    [nrepl.middleware.caught :as middleware.caught]
    [nrepl.middleware.print :as middleware.print]
+   [nrepl.middleware.session :as session]
    [nrepl.middleware.sideloader :as sideloader]
    [nrepl.misc :refer [uuid]]
    [nrepl.server :as server]
@@ -66,9 +67,12 @@
   (keys transport-fn->protocol))
 
 (defn repl-server-fixture
+  "This iterates through each transport being tested, starts a server,
+   runs the test against that server, then cleans up all sessions."
   [f]
   (doseq [transport-fn transport-fns]
-    (start-server-for-transport-fn transport-fn f)))
+    (start-server-for-transport-fn transport-fn f)
+    (session/close-all-sessions!)))
 
 (use-fixtures :each repl-server-fixture)
 

--- a/test/clojure/nrepl/edn_test.clj
+++ b/test/clojure/nrepl/edn_test.clj
@@ -6,8 +6,9 @@
 
 (defn return-evaluation
   [message]
-  (with-open [server (server/start-server :transport-fn transport/edn :port 7889)]
-    (with-open [conn (nrepl/url-connect "nrepl+edn://localhost:7889")]
+  (with-open [server (server/start-server :transport-fn transport/edn)]
+    (with-open [conn (nrepl/connect :transport-fn transport/edn
+                                    :port (:port server))]
       (-> (nrepl/client conn 1000)
           (nrepl/message message)
           nrepl/response-values))))

--- a/tests.edn
+++ b/tests.edn
@@ -1,0 +1,9 @@
+#kaocha/v1
+{:tests                               [{:source-paths ["src/clojure"]
+                                        :test-paths   ["test/clojure"]}]
+ :reporter                            #profile {:ci      kaocha.report/documentation
+                                                :default kaocha.report/dots}
+ :plugins                             [:kaocha.plugin/profiling
+                                       :kaocha.plugin/junit-xml]
+ :kaocha.plugin.randomize/randomize?  false
+ :kaocha.plugin.junit-xml/target-file "test-results/junit.xml"}


### PR DESCRIPTION
I've been using Kaocha locally while working on nREPL, and it's been a much better experience, especially with output capturing + watch. This PR does the following:

- Adding Kaocha, while maintaining compatibility for `lein test` for Clojure 1.7 and 1.8. The makefile has been updated to do the switch automatically. I've also added a hook for manually clearing sessions and killing their threads after a test run, as this was causing the JVM to crash fairly quickly in "watch" mode because we start hundreds of thread per test run. All this is documented, and I've expanded the "hacking on nREPL" section.
- Bye java 13 hi java 14.
- Fixed the `edn-test` that were failing on CI at times. Letting each test run pick its own port helps.