### PR TITLE
Small client fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 * [#174](https://github.com/nrepl/nrepl/issues/174): Provide a built-in `completions` op.
 * [#143](https://github.com/nrepl/nrepl/issues/143): Added a middleware that allows dynamic loading/unloading of middlewares while the server is running.
 
+### Bugs fixed
+
+* [#125](https://github.com/nrepl/nrepl/issues/125): The built-in client supports `greeting-fn`.
+* [#126](https://github.com/nrepl/nrepl/issues/126): The built-in client exits with an error message when the tty transport is selected. It used to fail silently. This was never supported.
+
 ## 0.7.0 (2020-03-28)
 
 ### New features

--- a/doc/modules/ROOT/pages/usage/clients.adoc
+++ b/doc/modules/ROOT/pages/usage/clients.adoc
@@ -72,6 +72,8 @@ user=> (+ 1 2)
 3
 ----
 
+The built in client does not support the tty transport. Use `nc` or `telnet` instead.
+
 Most users, however, are advised to use REPL-y or their favourite
 editor instead for optimal results.
 

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -357,6 +357,8 @@ Exit:      Control+D or (exit) or (quit)"
         repl-fn (:repl-fn options)
         host (:host server)
         port (:port server)]
+    (when (= transport #'transport/tty)
+      (die "The built-in client does not support the tty transport. Consider using `nc` or `telnet`.\n"))
     (repl-fn host port (merge (when (:color options) colored-output)
                               {:transport transport}))))
 

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -161,7 +161,9 @@
         (Thread/sleep 2000)
         (.destroy server-process)))))
 
-;; This ignores *transport-fn*, as it tests the TTY transport
+;; The following tests ignore the server started in the fixture, as they only test
+;; the TTY transport.
+
 (deftest ^:slow tty-server
   (let [free-port      (with-open [ss (java.net.ServerSocket.)]
                          (.bind ss nil)
@@ -188,3 +190,12 @@
                (last resp))))
       (finally
         (.destroy server-process)))))
+
+(deftest no-tty-client
+  (testing "Trying to connect with the tty transport should fail."
+    (with-open [server (server/start-server :transport-fn #'transport/tty)]
+      (let [options (cmd/connection-opts {:port      (:port server)
+                                          :host      "localhost"
+                                          :transport 'nrepl.transport/tty})]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (cmd/interactive-repl server options)))))))


### PR DESCRIPTION
Two small fixes to the built-in client. Fixes #126 and Fixes #125 

To test the error message when trying to run the built-in client with the tty transport: 

```
$ lein run -m nrepl.cmdline --interactive --transport nrepl.transport/tty
nREPL server started on port 50285 on host localhost - telnet://localhost:50285
The built-in client does not support the tty transport. Consider using `nc` or `telnet`.
```
It's covered by a test

The greeting-fn change can be verified by following the instructions in #125. It would take a bit more work to cover with tests, which doesn't feel worth the effort.