### PR TITLE
Adding some docs that weren't added properly from #173

### DIFF
--- a/doc/modules/ROOT/pages/ops.adoc
+++ b/doc/modules/ROOT/pages/ops.adoc
@@ -110,6 +110,7 @@ Optional parameters::
 * `:id` An opaque message ID that will be included in responses related to the evaluation, and which may be used to restrict the scope of a later "interrupt" operation.
 * `:line` The line number in [file] at which [code] starts.
 * `:ns` The namespace in which to perform the evaluation. The supplied namespace must exist already (e.g. be loaded). If no namespace is specified the evaluation falls back to ``\*ns*`` for the session in question.
+* `:read-cond` The options passed to the reader before the evaluation. Useful when middleware in a higher layer wants to process reader conditionals.
 * `:nrepl.middleware.caught/caught` A fully-qualified symbol naming a var whose function to use to convey interactive errors. Must point to a function that takes a ``java.lang.Throwable`` as its sole argument.
 * `:nrepl.middleware.caught/print?` If logical true, the printed value of any interactive errors will be returned in the response (otherwise they will be elided). Delegates to ``nrepl.middleware.print`` to perform the printing. Defaults to false.
 * `:nrepl.middleware.print/buffer-size` The size of the buffer to use when streaming results. Defaults to 1024.

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -160,7 +160,8 @@
                                                "ns" "The namespace in which to perform the evaluation. The supplied namespace must exist already (e.g. be loaded). If no namespace is specified the evaluation falls back to `*ns*` for the session in question."
                                                "file" "The path to the file containing [code]. `clojure.core/*file*` will be bound to this."
                                                "line" "The line number in [file] at which [code] starts."
-                                               "column" "The column number in [file] at which [code] starts."})
+                                               "column" "The column number in [file] at which [code] starts."
+                                               "read-cond" "The options passed to the reader before the evaluation. Useful when middleware in a higher layer wants to process reader conditionals."})
                              :returns {"ns" "*ns*, after successful evaluation of `code`."
                                        "value" "The result of evaluating `code`, often `read`able. This printing is provided by the `print` middleware. Superseded by `ex` and `root-ex` if an exception occurs during evaluation."
                                        "ex" "The type of exception thrown, if any. If present, then `:value` will be absent."


### PR DESCRIPTION
The `read-cond` docs were added to the ops.adoc directly, so we lost them in the next regen. This adds them to the descriptors.