### PR TITLE
Change how we set classloaders to fix hotloading in Lein

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * [#125](https://github.com/nrepl/nrepl/issues/125): The built-in client supports `greeting-fn`.
 * [#126](https://github.com/nrepl/nrepl/issues/126): The built-in client exits with an error message when the tty transport is selected. It used to fail silently. This was never supported.
+* [#113](https://github.com/nrepl/nrepl/issues/113): Fix an issue with hotloading using Pomegranate in Leiningen.
 
 ## 0.7.0 (2020-03-28)
 

--- a/tests.edn
+++ b/tests.edn
@@ -6,4 +6,12 @@
  :plugins                             [:kaocha.plugin/profiling
                                        :kaocha.plugin/junit-xml]
  :kaocha.plugin.randomize/randomize?  false
- :kaocha.plugin.junit-xml/target-file "test-results/junit.xml"}
+ :kaocha.plugin.junit-xml/target-file "test-results/junit.xml"
+ :bindings {kaocha.stacktrace/*stacktrace-filters* ["clojure.core"
+                                                    "clojure.lang."
+                                                    "clojure.main"
+                                                    "clojure.test$"
+                                                    "java.lang."
+                                                    "kaocha."
+                                                    "lambdaisland."
+                                                    "orchestra."]}}


### PR DESCRIPTION
Fixes #113 

As far as I can tell, the cause is that the combination of using Leiningen in/out of projects, as stated in the original issue, is causing a variation in when `Compiler/LOADER` is first bound. If this happens early enough, the execution thread's `ContextualClassLoader` might not have a suitable common ancestor with `Compiler/LOADER` for Pomegranate to modify. 

This change skips the LOADER value at `eval` time, using instead, the `ContextualClassLoader` instead. This is quite likely the `DynamicClassloader` for the thread, set by the `session` middleware. This guarantees the common ancestor property.

I added a check to see the two classloaders have a common ancestor in `eval`.

I'm a bit worried about this breaking something in a very complex Java environment with exotic class loading behaviour that depends on specific interaction with how the Clojure compiler behaves, so would be good to get at least some testing by someone who works on such a stack.