### PR TITLE
Avoid writing partial messages in the bencode transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#125](https://github.com/nrepl/nrepl/issues/125): The built-in client supports `greeting-fn`.
 * [#126](https://github.com/nrepl/nrepl/issues/126): The built-in client exits with an error message when the tty transport is selected. It used to fail silently. This was never supported.
 * [#113](https://github.com/nrepl/nrepl/issues/113): Fix an issue with hotloading using Pomegranate in Leiningen.
+* [#17](https://github.com/nrepl/nrepl/issues/17): It was possible for the bencode transport to write partial messages if a middleware tries to write something unencodable. This could cause the client or server to hang.
 
 ## 0.7.0 (2020-03-28)
 

--- a/test/clojure/nrepl/bencode_test.clj
+++ b/test/clojure/nrepl/bencode_test.clj
@@ -8,7 +8,7 @@
 
 
 (ns nrepl.bencode-test
-  (:require [clojure.test :refer [are deftest is]]
+  (:require [clojure.test :refer [are deftest is testing]]
             [nrepl.bencode :as bencode :refer [read-bencode
                                                read-netstring
                                                write-bencode
@@ -196,3 +196,10 @@
                (decode :reader read-bencode)
                (get "data")
                seq)))))
+
+(deftest unwritable-values
+  (testing "write-bencode writes eagerly"
+    (let [out (ByteArrayOutputStream.)]
+      (is (thrown? IllegalArgumentException
+                   (write-bencode out {"obj" (Object.)})))
+      (is (= "d3:obj" (String. (.toByteArray out)))))))

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -18,7 +18,7 @@
                       :handler (ack/handle-ack (server/default-handler)))]
     (binding [*server* server
               *transport-fn* transport-fn]
-      (testing (str (-> transport-fn meta :name) " transport\n")
+      (testing (str (-> transport-fn meta :name) " transport")
         (ack/reset-ack-port!)
         (f))
       (set! *print-length* nil)

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -58,7 +58,7 @@
   (with-open [server (server/start-server :transport-fn transport-fn)]
     (binding [*server* server
               *transport-fn* transport-fn]
-      (testing (str (-> transport-fn meta :name) " transport\n")
+      (testing (str (-> transport-fn meta :name) " transport")
         (f))
       (set! *print-length* nil)
       (set! *print-level* nil))))

--- a/test/clojure/nrepl/transport_test.clj
+++ b/test/clojure/nrepl/transport_test.clj
@@ -1,0 +1,11 @@
+(ns nrepl.transport-test
+  (:require [nrepl.transport :as sut]
+            [clojure.test :refer [deftest testing is]])
+  (:import [java.io ByteArrayOutputStream]))
+
+(deftest bencode-safe-write-test
+  (testing "safe-write-bencode only writes if the whole message is writable"
+    (let [out (ByteArrayOutputStream.)]
+      (is (thrown? IllegalArgumentException
+                   (#'sut/safe-write-bencode out {"obj" (Object.)})))
+      (is (empty? (.toByteArray out))))))


### PR DESCRIPTION
Fixes #17 

This adds a `write-bencode*` fn to the bencode ns. It first writes to a buffer, and only once successful, write to the provided output stream.

I don't see any reason we'd ever what to send half a message down bencode, so this feels like it's a reasonable default behaviour.