### PR TITLE
Make print middleware configurable via global config file

### DIFF
--- a/test/clojure/nrepl/middleware/print_test.clj
+++ b/test/clojure/nrepl/middleware/print_test.clj
@@ -8,6 +8,7 @@
    IDs, and message IDs"
   (:refer-clojure :exclude [print])
   (:require [clojure.test :refer [deftest is testing]]
+            [nrepl.config :as config]
             [nrepl.core :refer [combine-responses]]
             [nrepl.middleware.print :as print]
             [nrepl.transport :as t])
@@ -231,3 +232,33 @@
                      print/*quota*    8]
              (handle {:value        (range 512)
                       ::print/quota 16}))))))
+
+(deftest print-fn-var-only
+  (testing-print "setting *print-fn* works, but ::print-fn in the message does not"
+    (is (not= (handle {:value (range 10)
+                       ::print/print-fn custom-printer-2})
+              (binding [print/*print-fn* custom-printer-2]
+                (handle {:value (range 10)}))))))
+
+(deftest config-override
+  (testing-print "config file can be used to set default printer"
+    (with-redefs [config/config {::print/print   `custom-printer
+                                 ::print/options {:sub "bar"}}]
+      (is (= (handle {:value          3
+                      ::print/print   `custom-printer
+                      ::print/options {:sub "bar"}})
+             (handle {:value 3})))))
+  (testing-print "config file can be used to set streaming"
+    (with-redefs [config/config {::print/stream? 1
+                                 ::print/buffer-size 8}]
+      (is (= [{:value "(0 1 2 3"}
+              {:value " 4 5 6 7"}
+              {:value " 8 9)"}
+              {}]
+             (handle {:value (range 10)}))))))
+
+(deftest print-utils
+  (testing-print "Using the built-in util-fn to pretty print"
+    (is (= [{:value "(0\n 1\n 2\n 3\n 4\n 5\n 6\n 7\n 8\n 9\n 10\n 11\n 12\n 13\n 14\n 15\n 16\n 17\n 18\n 19\n 20\n 21\n 22\n 23\n 24\n 25\n 26\n 27\n 28\n 29)"}]
+           (handle {:value (range 30)
+                    ::print/print `nrepl.util.print/pprint})))))


### PR DESCRIPTION
`warp-print` actually has some fairly complex resolution order for `print-fn`, which cannot be directly overridden by a message directly. It looks something like:

1. request inferred fn
2. `:print-fn` in response
3. `*print-fn*` in session
4. `pr`-esque function

(I'm not 100% sure this is right).

This approach respects that by placing the weight of config file values quite high up, between 1) and 2), rather than  between 3 and 4, which I originally imagined. I think this is quite easy to reason about, as the config file is closer to what the client can do.

This can also act as a general approach for configuring middleware using the config file.

Does this seems like a good approach? If so, the code could be cleaned up a bit, and documentation updated.

Closes #93 