### PR TITLE
Fix load-file returns

### DIFF
--- a/doc/modules/ROOT/pages/ops.adoc
+++ b/doc/modules/ROOT/pages/ops.adoc
@@ -172,7 +172,6 @@ Optional parameters::
 
 Returns::
 * `:ex` The type of exception thrown, if any. If present, then ``:value`` will be absent.
-* `:ns` \*ns*, after successful evaluation of ``code``.
 * `:root-ex` The type of the root exception thrown, if any. If present, then ``:value`` will be absent.
 * `:value` The result of evaluating ``code``, often ``read``able. This printing is provided by the ``print`` middleware. Superseded by ``ex`` and ``root-ex`` if an exception occurs during evaluation.
 

--- a/src/clojure/nrepl/middleware/load_file.clj
+++ b/src/clojure/nrepl/middleware/load_file.clj
@@ -109,4 +109,5 @@ be loaded."} file-contents (atom {}))
                                           ::middleware/descriptor
                                           :handles
                                           (get "eval")
-                                          :returns)}}})
+                                          :returns
+                                          (dissoc "ns"))}}})


### PR DESCRIPTION
The "Built-in Ops" doc says that the `load-file` op returns `*ns*` under the `:ns` key after successful evaluation. However, according to the change log, the `:ns` key for `load-file` was removed in v0.2.8. There's also [a comment in the code](https://github.com/nrepl/nrepl/blob/23361dd2792338310c048df22a5995c80bf4c37d/src/clojure/nrepl/middleware/load_file.clj#L92-L94) that says it was removed to avoid confusion.