### PR TITLE
Lookup op fixes

### DIFF
--- a/src/clojure/nrepl/util/lookup.clj
+++ b/src/clojure/nrepl/util/lookup.clj
@@ -43,13 +43,19 @@
     (special-sym-meta sym)
     (normal-sym-meta ns sym)))
 
+(defn resolve-file
+  [path]
+  (if-let [resource (io/resource path)]
+    (str resource)
+    path))
+
 (defn normalize-meta
   [m]
   (-> m
       (select-keys var-meta-whitelist)
       (update :ns str)
       (update :name str)
-      (update :file (comp str io/resource))
+      (update :file resolve-file)
       (cond-> (:macro m) (update :macro str))
       (assoc :arglists-str (str (:arglists m)))))
 

--- a/src/clojure/nrepl/util/lookup.clj
+++ b/src/clojure/nrepl/util/lookup.clj
@@ -50,6 +50,7 @@
       (update :ns str)
       (update :name str)
       (update :file (comp str io/resource))
+      (cond-> (:macro m) (update :macro str))
       (assoc :arglists-str (str (:arglists m)))))
 
 (defn lookup

--- a/src/clojure/nrepl/util/lookup.clj
+++ b/src/clojure/nrepl/util/lookup.clj
@@ -8,31 +8,10 @@
   the API is subject to changes."
   {:author "Bozhidar Batsov"
    :added "0.8"}
-  (:refer-clojure :exclude [qualified-symbol?])
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
    [nrepl.misc :as misc]))
-
-;;; Utility functions for dealing with symbols
-(defn qualify-sym
-  "Qualify a symbol, if any in `sym`, with `ns`.
-
-  Return nil if `sym` is nil, attempting to generate a valid symbol even
-  in case some `ns` is missing."
-  {:added "0.5"}
-  [ns sym]
-  (when sym
-    (symbol (some-> ns str) (str sym))))
-
-(defn qualified-symbol?
-  "Return true if `x` is a symbol with a namespace.
-
-  This is only available from Clojure 1.9 so we backport it until we
-  drop support for Clojure 1.8."
-  {:added "0.5"}
-  [x]
-  (boolean (and (symbol? x) (namespace x) true)))
 
 ;;; Var meta logic
 (def var-meta-whitelist
@@ -53,17 +32,16 @@
            :file "clojure/core.clj"
            :special-form "true")))
 
-(defn qualified-sym-meta
+(defn normal-sym-meta
   [ns sym]
   (if-let [var (ns-resolve ns sym)]
     (meta var)))
 
 (defn sym-meta
   [ns sym]
-  (cond
-    (special-symbol? sym) (special-sym-meta sym)
-    (qualified-symbol? sym) (qualified-sym-meta ns sym)
-    :else (qualified-sym-meta ns (qualify-sym ns sym))))
+  (if (special-symbol? sym)
+    (special-sym-meta sym)
+    (normal-sym-meta ns sym)))
 
 (defn normalize-meta
   [m]

--- a/test/clojure/nrepl/middleware/lookup_test.clj
+++ b/test/clojure/nrepl/middleware/lookup_test.clj
@@ -15,7 +15,8 @@
 
 (def-repl-test lookup-op
   (doseq [op [{:op "lookup" :sym "map" :ns "clojure.core"}
-              {:op "lookup" :sym "map" :ns "nrepl.core"}]]
+              {:op "lookup" :sym "map" :ns "nrepl.core"}
+              {:op "lookup" :sym "future" :ns "nrepl.core"}]]
     (let [result (-> (nrepl/message session op)
                      nrepl/combine-responses
                      clean-response)]

--- a/test/clojure/nrepl/middleware/lookup_test.clj
+++ b/test/clojure/nrepl/middleware/lookup_test.clj
@@ -14,11 +14,13 @@
    :bar 2})
 
 (def-repl-test lookup-op
-  (let [result (-> (nrepl/message session {:op "lookup" :sym "map" :ns "clojure.core"})
-                   nrepl/combine-responses
-                   clean-response)]
-    (is (= #{:done} (:status result)))
-    (is (not-empty (:info result)))))
+  (doseq [op [{:op "lookup" :sym "map" :ns "clojure.core"}
+              {:op "lookup" :sym "map" :ns "nrepl.core"}]]
+    (let [result (-> (nrepl/message session op)
+                     nrepl/combine-responses
+                     clean-response)]
+      (is (= #{:done} (:status result)))
+      (is (not-empty (:info result))))))
 
 (def-repl-test lookup-op-error
   (let [result (-> (nrepl/message session {:op "lookup"})

--- a/test/clojure/nrepl/util/lookup_test.clj
+++ b/test/clojure/nrepl/util/lookup_test.clj
@@ -14,7 +14,8 @@
     (is (not-empty (lookup 'nrepl.util.lookup 'str/upper-case))))
 
   (testing "non-qualified lookup"
-    (is (not-empty (lookup 'clojure.core 'map))))
+    (is (not-empty (lookup 'clojure.core 'map)))
+    (is (not-empty (lookup 'nrepl.util.lookup 'map))))
 
   (testing "Java sym lookup"
     (is (empty? (lookup 'clojure.core 'String)))))

--- a/test/clojure/nrepl/util/lookup_test.clj
+++ b/test/clojure/nrepl/util/lookup_test.clj
@@ -17,5 +17,11 @@
     (is (not-empty (lookup 'clojure.core 'map)))
     (is (not-empty (lookup 'nrepl.util.lookup 'map))))
 
+  (testing "macro lookup"
+    (is (= {:ns "clojure.core"
+            :name "future"
+            :macro "true"}
+           (select-keys (lookup 'clojure.core 'future) [:ns :name :macro]))))
+
   (testing "Java sym lookup"
     (is (empty? (lookup 'clojure.core 'String)))))

--- a/test/clojure/nrepl/util/lookup_test.clj
+++ b/test/clojure/nrepl/util/lookup_test.clj
@@ -25,3 +25,9 @@
 
   (testing "Java sym lookup"
     (is (empty? (lookup 'clojure.core 'String)))))
+
+(deftest normalize-meta-test
+  (is (not-empty (:file (l/normalize-meta {:file "clojure/core.clj"}))))
+
+  (is (= "/foo/bar/baz.clj"
+         (:file (l/normalize-meta {:file "/foo/bar/baz.clj"})))))


### PR DESCRIPTION
Addresses the following issues:

- `lookup` of clojure.core vars from other namespaces fail
- `lookup` of macros fail because `true` can't be encoded into Bencode
- `lookup` of a var whose `:file` is not in the classpath returns empty `:file` key

Notes:

- Would be useful to test that non-macro vars don't return the `:macro` key at all, but I wasn't sure how to fit that in with the way the tests are currently written.
- Would it make sense to test that `normalize-meta` returns something that can be turned into a `java.net.URI` when looking up a file in the classpath? I didn't implement that because I wanted to keep things simple for now.