### PR TITLE
Fix completion candidate types

### DIFF
--- a/src/clojure/nrepl/util/completion.clj
+++ b/src/clojure/nrepl/util/completion.clj
@@ -24,13 +24,12 @@
 (defn ns-public-vars
   "Returns a list of potential public var name completions for a given namespace"
   [ns]
-  (keys (ns-publics ns)))
+  (vals (ns-publics ns)))
 
 (defn ns-vars
   "Returns a list of all potential var name completions for a given namespace"
   [ns]
-  (for [[sym val] (ns-map ns) :when (var? val)]
-    sym))
+  (filter var? (vals (ns-map ns))))
 
 (defn ns-classes
   "Returns a list of potential class name completions for a given namespace"
@@ -102,15 +101,12 @@
 
 ;;; Candidates
 
-(defn var-type [var]
-  (let [m (meta var)]
-    (cond
-      (:macro m) :macro
-      (:arglists m) :function
-      :else :var)))
-
 (defn annotate-var [var]
-  {:candidate (name var) :type (var-type var)})
+  (let [{macro :macro arglists :arglists var-name :name} (meta var)
+        type (cond macro :macro
+                   arglists :function
+                   :else :var)]
+    {:candidate (name var-name) :type type}))
 
 (defn annotate-class
   [cname]

--- a/test/clojure/nrepl/util/completion_test.clj
+++ b/test/clojure/nrepl/util/completion_test.clj
@@ -1,5 +1,6 @@
 (ns nrepl.util.completion-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.set :as set]
+            [clojure.test :refer :all]
             [nrepl.util.completion :as completion :refer [completions]]))
 
 (defn- candidates
@@ -45,4 +46,22 @@
 
     (is (some #{"String/valueOf"} (candidates "String/")))
 
-    (is (not (some #{"String/indexOf" ".indexOf"} (candidates "String/"))))))
+    (is (not (some #{"String/indexOf" ".indexOf"} (candidates "String/")))))
+
+  (testing "candidate types"
+    (is (some #{{:candidate "comment" :type :macro}}
+              (completions "comment" 'clojure.core)))
+    (is (some #{{:candidate "commute" :type :function}}
+              (completions "commute" 'clojure.core)))
+    (is (some #{{:candidate "unquote" :type :var}}
+              (completions "unquote" 'clojure.core)))
+    (is (some #{{:candidate "if" :ns "clojure.core" :type :special-form}}
+              (completions "if" 'clojure.core)))
+    (is (some #{{:candidate "UnsatisfiedLinkError" :type :class}}
+              (completions "Unsatisfied" 'clojure.core)))
+    (is (some #{{:candidate "clojure.core" :type :namespace}}
+              (completions "clojure.core" 'clojure.core)))
+    (is (some #{{:candidate "Integer/parseInt" :type :static-method}}
+              (completions "Integer/parseInt" 'clojure.core)))
+    (is (some #{{:candidate ".toString" :type :method}}
+              (completions ".toString" 'clojure.core)))))


### PR DESCRIPTION
Previously, `(ns-vars)` and `(ns-public-vars)` returned symbols instead of vars. As a result, `(var-type)` ended up calling `(meta)` on a symbol, which always returns `nil`.

Now, both `(ns-public-vars)` and `(ns-vars)` return vars instead of symbols.