### PR TITLE
Ensure distinct static member completion candidates #201

### DIFF
--- a/src/clojure/nrepl/util/completion.clj
+++ b/src/clojure/nrepl/util/completion.clj
@@ -52,8 +52,9 @@
 (defn static-members
   "Returns a list of potential static members for a given class"
   [^Class class]
-  (for [member (concat (.getMethods class) (.getDeclaredFields class)) :when (static? member)]
-    (.getName ^Member member)))
+  (distinct
+   (for [member (concat (.getMethods class) (.getDeclaredFields class)) :when (static? member)]
+     (.getName ^Member member))))
 
 (defn path-files [^String path]
   (cond (.endsWith path "/*")

--- a/test/clojure/nrepl/util/completion_test.clj
+++ b/test/clojure/nrepl/util/completion_test.clj
@@ -45,6 +45,7 @@
            (candidates "java.lang.System/out")))
 
     (is (some #{"String/valueOf"} (candidates "String/")))
+    (is (every? #(= 1 %) (vals (frequencies (candidates "String/")))))
 
     (is (not (some #{"String/indexOf" ".indexOf"} (candidates "String/")))))
 


### PR DESCRIPTION
Static methods such as `String/valueOf` have many overloads. Prior to this commit, the `static-members` function returned one completion candidate for each overload.