### PR TITLE
Support filesystem (UNIX) socket connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ target
 
 .externalToolBuilders
 
+/.eastwood
 /.lein*
 /.nrepl-port
 pom.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 * [#217](https://github.com/nrepl/nrepl/pull/217): Add keyword completion support.
 * [#226](https://github.com/nrepl/nrepl/pull/226): Add doc and arglists to completion responses.
 * [#238](https://github.com/nrepl/nrepl/pull/238): Expand completion and lookup error message when ns not found.
+* [#217](https://github.com/nrepl/nrepl/pull/217): Add server support
+  for UNIX domain (filesystem) sockets via `-s/--socket PATH` on the
+  command line or `(start-server ... :socket PATH)` whenever the JDK
+  is version 16 or newer or
+  [junixsocket](https://kohlschutter.github.io/junixsocket/) is
+  avaialble as a dependency.
 
 ### Bugs fixed
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ kondo:
 cloverage:
 	lein with-profile -user,+$(VERSION),+cloverage cloverage --codecov
 
+# Roughly match what runs in CI using the current JVM
+check: test eastwood kondo cljfmt cloverage
+
 verify_cljdoc:
 	curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ cljfmt:
 	lein with-profile -user,+$(VERSION),+cljfmt cljfmt check
 
 kondo:
-	clj-kondo --lint src
+	lein with-profile +clj-kondo run -m clj-kondo.main --lint src
 
 cloverage:
 	lein with-profile -user,+$(VERSION),+cloverage cloverage --codecov

--- a/doc/modules/ROOT/pages/usage/server.adoc
+++ b/doc/modules/ROOT/pages/usage/server.adoc
@@ -53,6 +53,30 @@ how you can easily start a ClojureScript capable nREPL:
 $ clj -R:nREPL -m nrepl.cmdline --middleware "[cider.piggieback/wrap-cljs-repl]"
 ----
 
+By default, nREPL listens for connections on a randomly chosen local
+port with no authentication, but you can specify the address or port,
+or, if you're using JDK 16 or newer, or you add a
+https://kohlschutter.github.io/junixsocket/[junixsocket] dependency,
+you can ask it to listen on a UNIX domain (filesystem) socket instead:
+
+[source,clojure]
+----
+{
+;; ...
+:aliases {:nREPL
+          {:extra-deps
+           ;; UNIX domain socket support was added in 0.9.0
+           {nrepl/nrepl {:mvn/version "0.9.0"}
+            com.kohlschutter.junixsocket/junixsocket-core {:mvn/version "2.3.2"}}}}
+}
+----
+
+[source,shell]
+----
+$ mkdir -m go-rwx nrepl-test
+$ clj -R:nREPL -m nrepl.cmdline --socket nrepl-test/socket
+----
+
 Here's a listing of all the options available via nREPL's command-line
 interface (this output was simply generated with `--help`):
 
@@ -63,6 +87,7 @@ interface (this output was simply generated with `--help`):
 -b/--bind ADDR              Bind address, by default "127.0.0.1".
 -h/--host ADDR              Host address to connect to when using --connect. Defaults to "127.0.0.1".
 -p/--port PORT              Start nREPL on PORT. Defaults to 0 (random port) if not specified.
+-s/--socket PATH            Start nREPL on filesystem socket at PATH.
 --ack ACK-PORT              Acknowledge the port of this server to another nREPL server running on ACK-PORT.
 -n/--handler HANDLER        The nREPL message handler to use for each incoming connection; defaults to the result of `(nrepl.server/default-handler)`.
 -m/--middleware MIDDLEWARE  A sequence of vars, representing middleware you wish to mix in to the nREPL handler.
@@ -186,6 +211,20 @@ WARNING: Keep in mind that running a nREPL server on a public address
 is an epic security hole! As the connections are insecure (no
 authentication, no authorization) by default anyone can connect to
 your app and modify its behaviour or run code on the remote host.
+
+You can also ask nREPL to listen on a UNIX domain (filesystem) socket
+with the `:socket` keyword (if you're using JDK 16 or newer add a
+https://kohlschutter.github.io/junixsocket/[junixsocket] dependency),
+which should be as secure as the access to the socket\'s parent
+directories:
+
+[source,clojure]
+----
+=> (require '[nrepl.server :refer [start-server stop-server]])
+nil
+=> (defonce server (start-server :socket "/some/where/safe/nrepl"))
+='user/server
+----
 
 Depending on what the lifecycle of your application is, whether you want to be
 able to easily restart the server, etc., you might want to put the value

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   :javac-options ["-target" "8" "-source" "8"]
 
   :aliases {"bump-version" ["change" "version" "leiningen.release/bump-version"]
-            "test-all" ["with-profile" "+1.7:+1.8:+1.9:+1.10:+fastlane" "test"]
+            "test-all" ["with-profile" "+1.7:+1.8:+1.9:+1.10:+fastlane:+junixsocket" "test"]
             "docs" ["with-profile" "+maint" "run" "-m" "nrepl.impl.docs" "--file"
                     ~(clojure.java.io/as-relative-path
                       (clojure.java.io/file "doc" "modules" "ROOT" "pages" "ops.adoc"))]
@@ -40,6 +40,8 @@
                     ;; TODO: replicate koacha's version filter logic here
                     :test-selectors {:default (complement :min-java-version)}
                     :aliases {"test" "test2junit"}}
+             :junixsocket {:jvm-opts ["-Dnrepl.test.junixsocket=true"]
+                           :dependencies [[com.kohlschutter.junixsocket/junixsocket-core "2.3.2"]]}
              ;; Clojure versions matrix
              :provided {:dependencies [[org.clojure/clojure "1.10.2"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -41,11 +41,11 @@
                     :test-selectors {:default (complement :min-java-version)}
                     :aliases {"test" "test2junit"}}
              ;; Clojure versions matrix
-             :provided {:dependencies [[org.clojure/clojure "1.10.1"]]}
+             :provided {:dependencies [[org.clojure/clojure "1.10.2"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.1"]]
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.2"]]
                     :source-paths ["src/spec"]}
              :master {:repositories [["snapshots"
                                       "https://oss.sonatype.org/content/repositories/snapshots"]]

--- a/project.clj
+++ b/project.clj
@@ -42,6 +42,7 @@
                     :aliases {"test" "test2junit"}}
              :junixsocket {:jvm-opts ["-Dnrepl.test.junixsocket=true"]
                            :dependencies [[com.kohlschutter.junixsocket/junixsocket-core "2.3.2"]]}
+             :clj-kondo {:dependencies [[clj-kondo "2021.06.18"]]}
              ;; Clojure versions matrix
              :provided {:dependencies [[org.clojure/clojure "1.10.2"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -12,8 +12,11 @@
    [nrepl.ack :refer [send-ack]]
    [nrepl.misc :refer [noisy-future]]
    [nrepl.server :as nrepl-server]
+   [nrepl.socket :as socket]
    [nrepl.transport :as transport]
-   [nrepl.version :as version]))
+   [nrepl.version :as version])
+  (:import
+   [java.net URI]))
 
 (defn- clean-up-and-exit
   "Performs any necessary clean up and calls `(System/exit status)`."
@@ -127,6 +130,7 @@ Exit:      Control+D or (exit) or (quit)"
    "-b" "--bind"
    "-h" "--host"
    "-p" "--port"
+   "-s" "--socket"
    "-m" "--middleware"
    "-t" "--transport"
    "-n" "--handler"
@@ -176,6 +180,7 @@ Exit:      Control+D or (exit) or (quit)"
   -b/--bind ADDR              Bind address, by default \"127.0.0.1\".
   -h/--host ADDR              Host address to connect to when using --connect. Defaults to \"127.0.0.1\".
   -p/--port PORT              Start nREPL on PORT. Defaults to 0 (random port) if not specified.
+  -s/--socket PATH            Start nREPL on filesystem socket at PATH.
   --ack ACK-PORT              Acknowledge the port of this server to another nREPL server running on ACK-PORT.
   -n/--handler HANDLER        The nREPL message handler to use for each incoming connection; defaults to the result of `(nrepl.server/default-handler)`.
   -m/--middleware MIDDLEWARE  A sequence of vars, representing middleware you wish to mix in to the nREPL handler.
@@ -336,6 +341,7 @@ Exit:      Control+D or (exit) or (quit)"
   [options]
   {:port (->int (:port options))
    :host (:host options)
+   :socket (:socket options)
    :transport (options->transport options)
    :repl-fn (options->repl-fn options)})
 
@@ -344,10 +350,11 @@ Exit:      Control+D or (exit) or (quit)"
   Returns map of processed options to start an nREPL server."
   [options]
   (let [middleware (sanitize-middleware-option (:middleware options))
-        {:keys [host port transport]} (connection-opts options)]
+        {:keys [host port socket transport]} (connection-opts options)]
     (merge options
            {:host host
             :port port
+            :socket socket
             :transport transport
             :bind (:bind options)
             :middleware middleware
@@ -403,13 +410,14 @@ Exit:      Control+D or (exit) or (quit)"
   Returns connection header string."
   [server options]
   (let [transport (:transport options)
-        port (:port server)
         ^java.net.ServerSocket ssocket (:server-socket server)
-        host (.getHostName (.getInetAddress ssocket))]
+        ^URI uri (socket/as-nrepl-uri ssocket (transport/uri-scheme transport))]
     ;; The format here is important, as some tools (e.g. CIDER) parse the string
     ;; to extract from it the host and the port to connect to
-    (format "nREPL server started on port %d on host %s - %s://%s:%d"
-            port host (transport/uri-scheme transport) host port)))
+    (if-let [host (.getHost uri)]
+      (format "nREPL server started on port %d on host %s - %s"
+              (.getPort uri) host uri)
+      (str "nREPL server started on socket " (.toASCIIString uri)))))
 
 (defn save-port-file
   "Writes a file relative to project classpath with port number so other tools
@@ -427,10 +435,11 @@ Exit:      Control+D or (exit) or (quit)"
   "Creates an nREPL server instance.
   Takes map of CLI options.
   Returns nREPL server map."
-  [{:keys [port bind handler transport greeting]}]
+  [{:keys [port bind socket handler transport greeting]}]
   (nrepl-server/start-server
    :port port
    :bind bind
+   :socket socket
    :handler handler
    :transport-fn transport
    :greeting-fn greeting))
@@ -461,6 +470,12 @@ Exit:      Control+D or (exit) or (quit)"
       (dispatch-commands options))
     (catch clojure.lang.ExceptionInfo ex
       (let [{:keys [:nrepl/kind ::status]} (ex-data ex)]
-        (when (= kind ::exit)
-          (clean-up-and-exit status))
-        (throw ex)))))
+        (case kind
+          ::exit (clean-up-and-exit status)
+          (:nrepl.server/no-filesystem-sockets
+           :nrepl.server/invalid-start-request)
+          (do
+            (binding [*out* *err*]
+              (println (.getMessage ex)))
+            (clean-up-and-exit 2))
+          (throw ex))))))

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -26,7 +26,8 @@
   "Requests that the process exit with the given `status`.  Does not
   return."
   [status]
-  (throw (ex-info nil {::kind ::exit ::status status})))
+  ;; :nrepl/kind is our shared (ns independent) ExceptionInfo discriminator
+  (throw (ex-info nil {:nrepl/kind ::exit ::status status})))
 
 (defn die
   "`Print`s items in `msg` to *err* and then exits with a status of 2."
@@ -458,7 +459,7 @@ Exit:      Control+D or (exit) or (quit)"
     (let [[options _args] (args->cli-options args)]
       (dispatch-commands options))
     (catch clojure.lang.ExceptionInfo ex
-      (let [{:keys [::kind ::status]} (ex-data ex)]
+      (let [{:keys [:nrepl/kind ::status]} (ex-data ex)]
         (when (= kind ::exit)
           (clean-up-and-exit status))
         (throw ex)))))

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -10,6 +10,7 @@
    [nrepl.config :as config]
    [nrepl.core :as nrepl]
    [nrepl.ack :refer [send-ack]]
+   [nrepl.misc :refer [noisy-future]]
    [nrepl.server :as nrepl-server]
    [nrepl.transport :as transport]
    [nrepl.version :as version]))
@@ -97,9 +98,9 @@ Exit:      Control+D or (exit) or (quit)"
      (println (repl-intro))
      ;; We take 50ms to listen to any greeting messages, and display the value
      ;; in the `:out` slot.
-     (future (->> (client)
-                  (take-while #(nil? (:id %)))
-                  (run! #(when-let [msg (:out %)] (print msg)))))
+     (noisy-future (->> (client)
+                        (take-while #(nil? (:id %)))
+                        (run! #(when-let [msg (:out %)] (print msg)))))
      (Thread/sleep 50)
      (let [session (nrepl/client-session client)
            ns (atom "user")]

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -5,7 +5,7 @@
    clojure.main
    [nrepl.middleware :refer [set-descriptor!]]
    [nrepl.middleware.interruptible-eval :refer [*msg* evaluate]]
-   [nrepl.misc :refer [uuid response-for]]
+   [nrepl.misc :refer [noisy-future uuid response-for]]
    [nrepl.transport :as t])
   (:import
    (clojure.lang LineNumberingPushbackReader)
@@ -173,11 +173,11 @@
   [^Thread t]
   (.interrupt t)
   (Thread/sleep 100)
-  (future
-    (Thread/sleep 5000)
-    (when-not (= (Thread$State/TERMINATED)
-                 (.getState t))
-      (.stop t))))
+  (noisy-future
+   (Thread/sleep 5000)
+   (when-not (= (Thread$State/TERMINATED)
+                (.getState t))
+     (.stop t))))
 
 (defn session-exec
   "Takes a session id and returns a maps of three functions meant for interruptible-eval:

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -13,6 +13,17 @@
       (apply println "ERROR:" msgs)
       (when ex (.printStackTrace ^Throwable ex)))))
 
+(defmacro noisy-future
+  "Executes body in a future, logging any execptions that make it to the
+  top level."
+  [& body]
+  `(future
+     (try
+       ~@body
+       (catch Throwable ex#
+         (log ex#)
+         (throw ex#)))))
+
 (defmacro returning
   "Executes `body`, returning `x`."
   {:style/indent 1}

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -6,9 +6,9 @@
   (:require [clojure.java.io :as io]))
 
 (defn log
-  [ex & msgs]
-  (let [ex (when (instance? Throwable ex) ex)
-        msgs (if ex msgs (cons ex msgs))]
+  [ex-or-msg & msgs]
+  (let [ex (when (instance? Throwable ex-or-msg) ex-or-msg)
+        msgs (if ex msgs (filter identity (cons ex-or-msg msgs)))]
     (binding [*out* *err*]
       (apply println "ERROR:" msgs)
       (when ex (.printStackTrace ^Throwable ex)))))

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -53,7 +53,7 @@
     :as server}]
   (when-let [sock (try
                     (socket/accept server-socket)
-                    (catch ClosedChannelException ex
+                    (catch ClosedChannelException _
                       nil))]
     (noisy-future
      (let [transport (transport sock)]
@@ -61,7 +61,7 @@
          (swap! open-transports conj transport)
          (when greeting (greeting transport))
          (handle handler transport)
-         (catch SocketException ex
+         (catch SocketException _
            nil)
          (finally
            (swap! open-transports disj transport)
@@ -69,7 +69,7 @@
     (noisy-future
      (try
        (accept-connection server)
-       (catch SocketException ex
+       (catch SocketException _
          nil)))))
 
 (defn stop-server
@@ -186,7 +186,7 @@
     (noisy-future
      (try
        (accept-connection server)
-       (catch SocketException ex
+       (catch SocketException _
          nil)))
     (when ack-port
       (ack/send-ack (:port server) ack-port transport-fn))

--- a/src/clojure/nrepl/socket.clj
+++ b/src/clojure/nrepl/socket.clj
@@ -1,0 +1,238 @@
+(ns nrepl.socket
+  "Compatibility layer for java.io vs java.nio sockets to allow an
+  incremental transition to nio, since the JDK's filesystem sockets
+  don't support the java.io socket interface, and we can't use the
+  compatibility layer for bidirectional read and write:
+  https://bugs.openjdk.java.net/browse/JDK-4509080."
+  (:require
+   [clojure.java.io :as io]
+   [nrepl.misc :refer [log]])
+  (:import
+   (java.io BufferedInputStream BufferedOutputStream File)
+   (java.net InetSocketAddress ProtocolFamily ServerSocket Socket SocketAddress
+             StandardProtocolFamily URI)
+   (java.nio ByteBuffer)
+   (java.nio.file Path)
+   (java.nio.channels Channels ClosedChannelException NetworkChannel
+                      ServerSocketChannel SocketChannel)))
+
+(def orig-warn-on-reflection *warn-on-reflection*)
+
+(defmacro find-class [full-path]
+  `(try
+     (Class/forName (name ~full-path))
+     (catch ClassNotFoundException ex#
+       nil)))
+
+;;; InetSockets (TCP)
+
+(defn inet-socket [bind port]
+  (let [port (or port 0)
+        addr (fn [^String bind port] (InetSocketAddress. bind (int port)))
+        ;; We fallback to 127.0.0.1 instead of to localhost to avoid
+        ;; a dependency on the order of ipv4 and ipv6 records for
+        ;; localhost in /etc/hosts
+        bind (or bind "127.0.0.1")]
+    (doto (ServerSocket.)
+      (.setReuseAddress true)
+      (.bind (addr bind port)))))
+
+;; Unix domain sockets
+
+(def ^Class junixsocket-address-class
+  (find-class 'org.newsclub.net.unix.AFUNIXSocketAddress))
+
+(def ^Class junixsocket-server-class
+  (find-class 'org.newsclub.net.unix.AFUNIXServerSocket))
+
+(def ^Class jdk-unix-address-class
+  (find-class 'java.net.UnixDomainSocketAddress))
+
+(def ^Class jdk-unix-server-class
+  (find-class 'java.nio.channels.ServerSocketChannel))
+
+(def ^:private test-junixsocket?
+  ;; Make it possible to test junixsocket even when JDK >= 16
+  (= "true" (System/getProperty "nrepl.test.junixsocket")))
+
+(def unix-domain-flavor
+  (cond
+    test-junixsocket? (do
+                        (assert junixsocket-address-class)
+                        (assert junixsocket-server-class)
+                        (binding [*out* *err*]
+                          (println "nrepl.test: insisting on junixsocket support"))
+                        :junixsocket)
+    (and jdk-unix-address-class jdk-unix-server-class) :jdk
+    (and junixsocket-address-class junixsocket-server-class) :junixsocket
+    :else nil))
+
+(def jdk-unix-address-of
+  (when (= :jdk unix-domain-flavor)
+    (let [addr-of (.getDeclaredMethod jdk-unix-address-class "of"
+                                      (into-array Class [String]))]
+      (fn [path] (.invoke addr-of nil (into-array String [path]))))))
+
+(def junix-address-of
+  (when (= :junixsocket unix-domain-flavor)
+    (let [c (.getDeclaredConstructor junixsocket-address-class
+                                     (into-array Class [File]))]
+      (fn [path] (.newInstance c (into-array File [(File. ^String path)]))))))
+
+(defn unix-socket-address
+  "Returns a filesystem socket address for the given path string."
+  [^String path]
+  (case unix-domain-flavor
+    :jdk (jdk-unix-address-of path)
+    :junixsocket (junix-address-of path)
+    (let [msg "Support for filesystem sockets requires JDK 16+ or a junixsocket dependency"]
+      (log msg)
+      (throw (ex-info msg {:nrepl/kind ::no-filesystem-sockets})))))
+
+(set! *warn-on-reflection* false)
+
+;; SocketAddress doesn't have .getPath until JDK 16, and we can't refer to
+;; AFUnixSocketAddress unconditionally in the junixsocket cases.  Also note that
+;; the former returns a Path, and the latter returns a string.
+
+(defn- get-path [addr] (.getPath addr))
+
+(set! *warn-on-reflection* orig-warn-on-reflection)
+
+(def jdk-unix-server-socket
+  ;; Dynamic because one argument open doesn't exist until jvm 15, nor UNIX
+  ;; until jvm 16.
+  (when (= :jdk unix-domain-flavor)
+    (let [protocol (-> (.getDeclaredField StandardProtocolFamily "UNIX")
+                       (.get StandardProtocolFamily))
+          protocol (into-array ProtocolFamily [protocol])
+          open (.getDeclaredMethod ServerSocketChannel "open"
+                                   (into-array Class [ProtocolFamily]))]
+      #(.invoke open nil protocol))))
+
+(def junix-server-socket
+  (when (= :junixsocket unix-domain-flavor)
+    (let [make (.getDeclaredMethod junixsocket-server-class "newInstance" nil)]
+      #(.invoke make nil nil))))
+
+(defn unix-server-socket
+  "Returns a filesystem socket bound to the path if the JDK is version
+  16 or newer or if com.kohlschutter.junixsocket/junixsocket-core can
+  be loaded dynamically.  Otherwise throws the ex-info map
+  {:nrepl/kind ::no-filesystem-sockets}."
+  [^String path]
+  (let [^SocketAddress addr (unix-socket-address path)]
+    (case unix-domain-flavor
+      :jdk
+      (let [sock (jdk-unix-server-socket)]
+        (.bind ^ServerSocketChannel sock addr)
+        (let [^Path path (get-path addr)]
+          (-> path .toFile .deleteOnExit))
+        sock)
+
+      :junixsocket
+      (let [sock (junix-server-socket)]
+        (.bind ^ServerSocket sock addr)
+        (let [^String path (get-path addr)]
+          (-> path File. .deleteOnExit))
+        sock)
+
+      (let [msg "Support for filesystem sockets requires JDK 16+ or a junixsocket dependency"]
+        (log msg)
+        (throw (ex-info msg {:nrepl/kind ::no-filesystem-sockets}))))))
+
+(defn as-nrepl-uri [sock transport-scheme]
+  (let [get-local-addr (fn [^NetworkChannel c] (.getLocalAddress c))]
+    (if-let [addr (and (some-> jdk-unix-server-class (instance? sock))
+                       (get-local-addr sock))]
+      (URI. (str transport-scheme "+unix")
+            (let [^Path path (get-path addr)]
+              (-> path .toAbsolutePath str))
+            nil)
+      (if-let [addr (and (some-> junixsocket-server-class (instance? sock))
+                         (.getLocalSocketAddress ^ServerSocket sock))]
+        (URI. (str transport-scheme "+unix")
+              (get-path addr)
+              nil)
+        ;; Assume it's an InetAddress socket
+        (let [sock ^ServerSocket sock]
+          (URI. transport-scheme
+                nil ;; userInfo
+                (-> sock .getInetAddress .getHostName)
+                (.getLocalPort sock)
+                nil       ;; path
+                nil       ;; query
+                nil)))))) ;; fragment
+
+(defprotocol Acceptable
+  (accept [s]
+    "Accepts a connection on s.  Throws ClosedChannelException if s is
+    closed."))
+
+(extend-protocol Acceptable
+  ServerSocketChannel
+  (accept [s] (.accept s))
+
+  ServerSocket
+  (accept [s]
+    (when (.isClosed s)
+      (throw (ClosedChannelException.)))
+    (.accept s)))
+
+;; We have to handle this ourselves for NIO because unfortunately read and write
+;; hang if we use both Channels/newInputStream and Channels/newOutputStream.
+;; Read and write deadlock on a shared channel input/output stream lock
+;; (cf. https://bugs.openjdk.java.net/browse/JDK-4509080).  Verified that this
+;; still happens (via thread dump when hung) with jdk 16.
+
+(definterface Writable
+  (write [byte-array]
+         "Writes the given bytes to the output as per OutputStream write.")
+  (write [byte-array offset length]
+         "Writes the given bytes to the output as per OutputStream write."))
+
+(defrecord BufferedOutputChannel
+           [^SocketChannel channel ^ByteBuffer buffer]
+
+  java.io.Flushable
+  (flush [this]
+    (.flip buffer)
+    (.write channel buffer)
+    (.clear buffer))
+
+  Writable
+  (write [this byte-array]
+    (.write this byte-array 0 (count byte-array)))
+  (write [this byte-array offset length]
+    (if (> length (.capacity buffer))
+      (do
+        (.flush this)
+        (.write channel (ByteBuffer/wrap byte-array) offset length))
+      (do
+        (when (> length (.remaining buffer))
+          (.flush this))
+        (.put buffer byte-array offset length)))))
+
+(defn buffered-output-channel [^SocketChannel channel bytes]
+  (assert (.isBlocking channel))
+  (->BufferedOutputChannel channel (ByteBuffer/allocate bytes)))
+
+(defprotocol AsBufferedInputStreamSubset
+  (buffered-input [x]
+    "Returns a buffered stream (subset of BufferedInputStream) reading from x."))
+
+(extend-protocol AsBufferedInputStreamSubset
+  ;; Use the Channels stream for input but not output to avoid the deadlock
+  SocketChannel (buffered-input [s] (-> s Channels/newInputStream io/input-stream))
+  Socket (buffered-input [s] (io/input-stream s))
+  BufferedInputStream (buffered-input [s] s))
+
+(defprotocol AsBufferedOutputStreamSubset
+  (buffered-output [x]
+    "Returns a buffered stream (subset of BufferedOutputStream) reading from x."))
+
+(extend-protocol AsBufferedOutputStreamSubset
+  ;; Use the Channels stream for input but not output to avoid the deadlock
+  SocketChannel (buffered-output [s] (buffered-output-channel s 8192))
+  Socket (buffered-output [s] (io/output-stream s))
+  BufferedOutputStream (buffered-output [s] s))

--- a/src/clojure/nrepl/socket.clj
+++ b/src/clojure/nrepl/socket.clj
@@ -188,14 +188,15 @@
 (definterface Writable
   (write [byte-array]
          "Writes the given bytes to the output as per OutputStream write.")
-  (write [byte-array offset length]
+  ;; Underscores were added to satisfy clj-kondo
+  (write [_byte-array _offset _length]
          "Writes the given bytes to the output as per OutputStream write."))
 
 (defrecord BufferedOutputChannel
            [^SocketChannel channel ^ByteBuffer buffer]
 
   java.io.Flushable
-  (flush [this]
+  (flush [_this] ;; Underscore was added to satisfy clj-kondo
     (.flip buffer)
     (.write channel buffer)
     (.clear buffer))

--- a/src/clojure/nrepl/transport.clj
+++ b/src/clojure/nrepl/transport.clj
@@ -51,7 +51,7 @@
                          (.put read-queue (transport-read)))
                        (catch Throwable t
                          (.put read-queue t)))
-                     (catch InterruptedException ex
+                     (catch InterruptedException _
                        nil)))]
      (FnTransport.
       (let [failure (atom nil)]

--- a/src/clojure/nrepl/util/completion.clj
+++ b/src/clojure/nrepl/util/completion.clj
@@ -168,16 +168,16 @@
   (.. file (replace ".class" "") (replace File/separator ".")))
 
 (def top-level-classes
-  (future
-    (doall
-     (for [file classfiles :when (re-find #"^[^\$]+\.class" file)]
-       (classname file)))))
+  (misc/noisy-future
+   (doall
+    (for [file classfiles :when (re-find #"^[^\$]+\.class" file)]
+      (classname file)))))
 
 (def nested-classes
-  (future
-    (doall
-     (for [file classfiles :when (re-find #"^[^\$]+(\$[^\d]\w*)+\.class" file)]
-       (classname file)))))
+  (misc/noisy-future
+   (doall
+    (for [file classfiles :when (re-find #"^[^\$]+(\$[^\d]\w*)+\.class" file)]
+      (classname file)))))
 
 (defn resolve-class [ns sym]
   (try (let [val (ns-resolve ns sym)]

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -1,16 +1,35 @@
 (ns nrepl.cmdline-test
   {:author "Chas Emerick"}
   (:require
+   [clojure.java.io :refer [as-file]]
    [clojure.test :refer :all]
    [nrepl.ack :as ack]
+   [nrepl.bencode :refer [write-bencode]]
    [nrepl.cmdline :as cmd]
    [nrepl.core :as nrepl]
    [nrepl.core-test :refer [*server* *transport-fn* transport-fns]]
    [nrepl.server :as server]
+   [nrepl.socket :refer [find-class unix-domain-flavor unix-socket-address]]
    [nrepl.transport :as transport])
   (:import
    (com.hypirion.io Pipe ClosingPipe)
+   (java.lang ProcessBuilder$Redirect)
+   (java.net Socket SocketAddress)
+   (java.nio.channels Channels SocketChannel)
+   (java.nio.file Files)
+   (java.nio.file.attribute PosixFilePermissions)
    (nrepl.server Server)))
+
+(defn create-tmpdir
+  "Creates a temporary directory in parent (something clojure.java.io/as-path
+  can handle) with the specified permissions string (something
+  PosixFilePermissions/asFileAttribute can handle i.e. \"rw-------\") and
+  returns its Path."
+  [parent prefix permissions]
+  (let [nio-path (.toPath (as-file parent))
+        perms (PosixFilePermissions/fromString permissions)
+        attr (PosixFilePermissions/asFileAttribute perms)]
+    (Files/createTempDirectory nio-path prefix (into-array [attr]))))
 
 (defn- start-server-for-transport-fn
   [transport-fn f]
@@ -206,3 +225,58 @@
                                           :transport 'nrepl.transport/tty})]
         (is (thrown? clojure.lang.ExceptionInfo
                      (cmd/interactive-repl server options)))))))
+
+;;; Unix domain socket tests
+
+(defn send-jdk-socket-message [message path]
+  (let [^SocketAddress addr (unix-socket-address path)
+        sock (SocketChannel/open addr)]
+    ;; Assume it's safe to use Channels input/output streams here since
+    ;; we're never reading and writing at the same time.
+    ;; (cf. https://bugs.openjdk.java.net/browse/JDK-4509080 - not fixed
+    ;; as of at least JDK 16).
+    (with-open [out (Channels/newOutputStream sock)]
+      (write-bencode out message))))
+
+(defn send-junixsocket-message [message path]
+  (let [^Class sock-class (find-class 'org.newsclub.net.unix.AFUNIXSocket)
+        new-instance (.getDeclaredMethod sock-class "newInstance" nil)
+        addr (unix-socket-address path)]
+    (with-open [^Socket sock (.invoke new-instance nil nil)]
+      (.connect sock addr)
+      (write-bencode (.getOutputStream sock) message))))
+
+(deftest ^:slow basic-fs-socket-behavior
+
+  (if-not unix-domain-flavor
+    (binding [*out* *err*]
+      ;; Otherwise kaocha treats no tests as an error
+      (is (not unix-domain-flavor))
+      (println "Skipping UNIX domain socket tests for JDK < 16 without junixsocket dependency"))
+    (let [tmpdir (create-tmpdir "target" "socket-test-" "rwx------")
+          sock-path (str tmpdir "/socket")
+          sock-file (as-file sock-path)]
+      (try
+        ;; Use a Process rather than sh so we can see server errors
+        (let [cmd (into-array ["java"
+                               "-cp" (System/getProperty "java.class.path")
+                               "nrepl.main" "-s" sock-path])
+              server (.start (doto (ProcessBuilder. ^"[Ljava.lang.String;" cmd)
+                               (.redirectOutput ProcessBuilder$Redirect/INHERIT)
+                               (.redirectError ProcessBuilder$Redirect/INHERIT)))]
+          (try
+            (while (not (.exists sock-file))
+              (Thread/sleep 100))
+            (case unix-domain-flavor
+              :jdk
+              (send-jdk-socket-message {:code "(System/exit 42)" :op :eval}
+                                       sock-path)
+              :junixsocket
+              (send-junixsocket-message {:code "(System/exit 42)" :op :eval}
+                                        sock-path))
+            (is (= 42 (.waitFor server)))
+            (finally
+              (.destroy server))))
+        (finally
+          (.delete sock-file)
+          (Files/delete tmpdir))))))

--- a/test/clojure/nrepl/edn_test.clj
+++ b/test/clojure/nrepl/edn_test.clj
@@ -2,11 +2,13 @@
   (:require [clojure.test :refer [deftest is testing]]
             [nrepl.core :as nrepl]
             [nrepl.server :as server]
-            [nrepl.transport :as transport]))
+            [nrepl.transport :as transport])
+  (:import
+   (nrepl.server Server)))
 
 (defn return-evaluation
   [message]
-  (with-open [server (server/start-server :transport-fn transport/edn)]
+  (with-open [^Server server (server/start-server :transport-fn transport/edn)]
     (with-open [^nrepl.transport.FnTransport
                 conn (nrepl/connect :transport-fn transport/edn
                                     :port (:port server))]


### PR DESCRIPTION
Add support for UNIX domain sockets (filesystem sockets) via
junixsocket along with a corresponding -s/--socket commandline option,
and depict these connections with an augmented URI scheme,
e.g. nrepl+unix:/some/where%20am%20i

    $ lein run -m nrepl.cmdline -s nreplsock
    nREPL server started on socket /home/rlb/test/nreplsock - nrepl+unix:/home/rlb/test/nreplsock

    $ echo -n 'd4:code7:(+ 2 2)2:op4:evale' | nc -U nreplsock
    d2:n...

When this transport is suitable, it avoids concerns over port
conflicts, and allows access control via the permissions of the parent
directories.


This is unfinished, but I wanted to see if it was likely to be of interest before proceeding further.  (After an obviously long hiatus, I'm finally back to working on nrepl access control.)  I don't see this proposal as an alternative to #46 -- I'm still interested in that too, but if/when they're feasible, filesystem sockets should allow solid (simple) access control without having to resolve all of the questions we were still sorting with respect to handling tokens, etc.

Of course if we do want to pursue this, among other things I'll need to add tests, and I imagine there are any number of questions to answer here too (e.g. the random choice I made about the URI scheme, dependencies, etc.).

The current socket provider is https://github.com/kohlschutter/junixsocket  I'd used it fairly recently for its support for forwarding file descriptors along with the connection: https://kohlschutter.github.io/junixsocket/filedescriptors.html