### PR TITLE
Fix lookup of non-special symbol special forms

### DIFF
--- a/src/clojure/nrepl/util/lookup.clj
+++ b/src/clojure/nrepl/util/lookup.clj
@@ -57,6 +57,7 @@
       (update :name str)
       (update :file resolve-file)
       (cond-> (:macro m) (update :macro str))
+      (cond-> (:special-form m) (update :special-form str))
       (assoc :arglists-str (str (:arglists m)))))
 
 (defn lookup

--- a/test/clojure/nrepl/middleware/lookup_test.clj
+++ b/test/clojure/nrepl/middleware/lookup_test.clj
@@ -15,6 +15,7 @@
 
 (def-repl-test lookup-op
   (doseq [op [{:op "lookup" :sym "map" :ns "clojure.core"}
+              {:op "lookup" :sym "let" :ns "clojure.core"}
               {:op "lookup" :sym "map" :ns "nrepl.core"}
               {:op "lookup" :sym "future" :ns "nrepl.core"}]]
     (let [result (-> (nrepl/message session op)

--- a/test/clojure/nrepl/util/lookup_test.clj
+++ b/test/clojure/nrepl/util/lookup_test.clj
@@ -23,6 +23,12 @@
             :macro "true"}
            (select-keys (lookup 'clojure.core 'future) [:ns :name :macro]))))
 
+  (testing "special form lookup"
+    (is (= {:ns "clojure.core"
+            :name "let"
+            :special-form "true"}
+           (select-keys (lookup 'clojure.core 'let) [:ns :name :special-form]))))
+
   (testing "Java sym lookup"
     (is (empty? (lookup 'clojure.core 'String)))))
 


### PR DESCRIPTION
`let` is a special form, but not a special symbol. That is, the `special-symbol?` fn returns `false` on `let`.

(`let*` is the special symbol that backs `let`.)

A lookup on `let` returns the `:special-form` key. Its value is a boolean, which cannot be Bencoded. We therefore convert the boolean into a string first, the same way as with the `:macro` key.