### PR TITLE
Fix for latest version of cider-nrepl/Java8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,10 +32,13 @@
   :profiles {:fastlane {:dependencies [[nrepl/fastlane "0.1.0"]]}
              :test {:dependencies [[com.hypirion/io "0.3.1"]
                                    [commons-net/commons-net "3.6"]
-                                   [lambdaisland/kaocha "1.0-612"]
-                                   [lambdaisland/kaocha-junit-xml "0.0-70"]]
+                                   [lambdaisland/kaocha "1.0.672"]
+                                   [lambdaisland/kaocha-junit-xml "0.0.76"]]
                     :plugins      [[test2junit "1.4.2"]]
                     :test2junit-output-dir "test-results"
+                    ;; This skips any tests that doesn't work on all java versions
+                    ;; TODO: replicate koacha's version filter logic here
+                    :test-selectors {:default (complement :min-java-version)}
                     :aliases {"test" "test2junit"}}
              ;; Clojure versions matrix
              :provided {:dependencies [[org.clojure/clojure "1.10.1"]]}

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -9,7 +9,7 @@
    [nrepl.middleware :refer [set-descriptor!]]
    [nrepl.middleware.caught :as caught]
    [nrepl.middleware.print :as print]
-   [nrepl.misc :refer [response-for with-session-classloader]]
+   [nrepl.misc :as misc :refer [response-for with-session-classloader]]
    [nrepl.transport :as t])
   (:import
    (clojure.lang Compiler$CompilerException LineNumberingPushbackReader)
@@ -131,7 +131,8 @@
                                    :root-ex (str (class (clojure.main/root-cause e)))}]
                          (t/send transport (response-for msg resp))))))
           (finally
-            (.setContextClassLoader (Thread/currentThread) ctxcl)
+            (when (misc/java-8?)
+              (.setContextClassLoader (Thread/currentThread) ctxcl))
             (.flush err)
             (.flush out)))))))
 

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -87,4 +87,5 @@
   "Util to check if we are using Java 8. Useful for features that behave
   differently after version 8"
   []
-  (boolean (re-matches #"^1\.8.*" (System/getProperty "java.runtime.version"))))
+  (.startsWith (System/getProperty "java.runtime.version")
+               "1.8"))

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -87,4 +87,4 @@
   "Util to check if we are using Java 8. Useful for features that behave
   differently after version 8"
   []
-  (str/starts-with? (System/getProperty "java.runtime.version") "1.8"))
+  (boolean (re-matches #"^1\.8.*" (System/getProperty "java.runtime.version"))))

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -2,7 +2,8 @@
   "Misc utilities used in nREPL's implementation (potentially also
   useful for anyone extending it)."
   {:author "Chas Emerick"}
-  (:refer-clojure :exclude [requiring-resolve]))
+  (:refer-clojure :exclude [requiring-resolve])
+  (:require [clojure.string :as str]))
 
 (defn log
   [ex & msgs]
@@ -81,3 +82,9 @@
          ~@body)
        (finally
          (.setContextClassLoader (Thread/currentThread) ctxcl#)))))
+
+(defn java-8?
+  "Util to check if we are using Java 8. Useful for features that behave
+  differently after version 8"
+  []
+  (str/starts-with? (System/getProperty "java.runtime.version") "1.8"))

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -1060,20 +1060,21 @@
         (iterate #(.getParent %))
         (take-while boolean))))
 
-#_(def-repl-test hotloading-common-classloader-test
-    (testing "Check if RT/baseLoader and ContexClassLoader have a common DCL ancestor"
-      (let [dcls (fn [str] ;; parses the string output of classloader-hierarch
-                   (set (map (fn [[_ id]] id)
-                             (re-seq #"DynamicClassLoader@([0-9a-f]{8})" (or str "")))))]
-        (let [resp1 (->> (message session {:op   "eval"
-                                           :code "(#'nrepl.core-test/classloader-hierarchy (clojure.lang.RT/baseLoader))"})
-                         (map clean-response)
-                         combine-responses)
-              resp2 (->> (message session {:op   "eval"
-                                           :code "(#'nrepl.core-test/classloader-hierarchy (.. Thread currentThread getContextClassLoader))"})
-                         (map clean-response)
-                         combine-responses)]
-          (is (not-empty
-               (set/intersection
-                (dcls (first (:value resp2)))
-                (dcls (first (:value resp1))))))))))
+;; This test is broken for Java 8 at the moment.
+(def-repl-test ^{:min-java-version "11"} hotloading-common-classloader-test
+  (testing "Check if RT/baseLoader and ContexClassLoader have a common DCL ancestor"
+    (let [dcls (fn [str] ;; parses the string output of classloader-hierarch
+                 (set (map (fn [[_ id]] id)
+                           (re-seq #"DynamicClassLoader@([0-9a-f]{8})" (or str "")))))]
+      (let [resp1 (->> (message session {:op   "eval"
+                                         :code "(#'nrepl.core-test/classloader-hierarchy (clojure.lang.RT/baseLoader))"})
+                       (map clean-response)
+                       combine-responses)
+            resp2 (->> (message session {:op   "eval"
+                                         :code "(#'nrepl.core-test/classloader-hierarchy (.. Thread currentThread getContextClassLoader))"})
+                       (map clean-response)
+                       combine-responses)]
+        (is (not-empty
+             (set/intersection
+              (dcls (first (:value resp2)))
+              (dcls (first (:value resp1))))))))))

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -1061,19 +1061,19 @@
         (take-while boolean))))
 
 #_(def-repl-test hotloading-common-classloader-test
-  (testing "Check if RT/baseLoader and ContexClassLoader have a common DCL ancestor"
-    (let [dcls (fn [str] ;; parses the string output of classloader-hierarch
-                 (set (map (fn [[_ id]] id)
-                           (re-seq #"DynamicClassLoader@([0-9a-f]{8})" (or str "")))))]
-      (let [resp1 (->> (message session {:op   "eval"
-                                         :code "(#'nrepl.core-test/classloader-hierarchy (clojure.lang.RT/baseLoader))"})
-                       (map clean-response)
-                       combine-responses)
-            resp2 (->> (message session {:op   "eval"
-                                         :code "(#'nrepl.core-test/classloader-hierarchy (.. Thread currentThread getContextClassLoader))"})
-                       (map clean-response)
-                       combine-responses)]
-        (is (not-empty
-             (set/intersection
-              (dcls (first (:value resp2)))
-              (dcls (first (:value resp1))))))))))
+    (testing "Check if RT/baseLoader and ContexClassLoader have a common DCL ancestor"
+      (let [dcls (fn [str] ;; parses the string output of classloader-hierarch
+                   (set (map (fn [[_ id]] id)
+                             (re-seq #"DynamicClassLoader@([0-9a-f]{8})" (or str "")))))]
+        (let [resp1 (->> (message session {:op   "eval"
+                                           :code "(#'nrepl.core-test/classloader-hierarchy (clojure.lang.RT/baseLoader))"})
+                         (map clean-response)
+                         combine-responses)
+              resp2 (->> (message session {:op   "eval"
+                                           :code "(#'nrepl.core-test/classloader-hierarchy (.. Thread currentThread getContextClassLoader))"})
+                         (map clean-response)
+                         combine-responses)]
+          (is (not-empty
+               (set/intersection
+                (dcls (first (:value resp2)))
+                (dcls (first (:value resp1))))))))))

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -1060,7 +1060,7 @@
         (iterate #(.getParent %))
         (take-while boolean))))
 
-(def-repl-test hotloading-common-classloader-test
+#_(def-repl-test hotloading-common-classloader-test
   (testing "Check if RT/baseLoader and ContexClassLoader have a common DCL ancestor"
     (let [dcls (fn [str] ;; parses the string output of classloader-hierarch
                  (set (map (fn [[_ id]] id)

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -1061,7 +1061,7 @@
         (take-while boolean))))
 
 ;; This test is broken for Java 8 at the moment.
-(def-repl-test ^{:min-java-version "11"} hotloading-common-classloader-test
+(def-repl-test ^{:min-java-version "11.0"} hotloading-common-classloader-test
   (testing "Check if RT/baseLoader and ContexClassLoader have a common DCL ancestor"
     (let [dcls (fn [str] ;; parses the string output of classloader-hierarch
                  (set (map (fn [[_ id]] id)

--- a/tests.edn
+++ b/tests.edn
@@ -4,7 +4,8 @@
  :reporter                            #profile {:ci      kaocha.report/documentation
                                                 :default kaocha.report/dots}
  :plugins                             [:kaocha.plugin/profiling
-                                       :kaocha.plugin/junit-xml]
+                                       :kaocha.plugin/junit-xml
+                                       :kaocha.plugin/version-filter]
  :kaocha.plugin.randomize/randomize?  false
  :kaocha.plugin.junit-xml/target-file "test-results/junit.xml"
  :bindings {kaocha.stacktrace/*stacktrace-filters* ["clojure.core"


### PR DESCRIPTION
Fixes #206, but breaks #113 (Edit: only breaks it for Java 8)

Given that Java 8 + Latest Cider support is kinda important, this feels like a reasonable tradeoff.

In terms of a more robust fix for #113, I think more research would be in order.

Tested by follow repro steps in #206 + lein install of this branch.