### PR TITLE
Fix lookup op errors

### DIFF
--- a/doc/modules/ROOT/pages/usage/misc.adoc
+++ b/doc/modules/ROOT/pages/usage/misc.adoc
@@ -49,6 +49,9 @@ user=> (set! nrepl.middleware.completion/*complete-fn* my.namespace/my-completio
 NOTE: Symbol look support was added in nREPL 0.8 and the API is still
 considered experimental.
 
+NOTE: In nREPL 0.8.1 and older, xref:ops.adoc#lookup[the `lookup` op] fails for some symbols
+because the result contains data that the xref:design/transports.adoc#bencode-transport[Bencode transport] does not support (see https://github.com/nrepl/nrepl/issues/207[nrepl/nrepl#207]). In versions newer than 0.8.1, `:arglists` and `:arglists-str` have identical string values. `:arglists-str` is subject to removal.
+
 nREPL bundles a lookup middleware with a flexible interface. By default it will use nREPL's own
 lookup logic in `nrepl.util.lookup`, but you can instruct nREPL to use
 another lookup function (e.g. `info` from `orchard`).
@@ -68,10 +71,9 @@ The function should ideally return results in the following format:
  :file
  "jar:file:/Users/bozhidar/.m2/repository/org/clojure/clojure/1.10.1/clojure-1.10.1.jar!/clojure/core.clj",
  :static true,
- :arglists-str "([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls])",
  :column 1,
  :line 2727,
- :arglists ([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls]),
+ :arglists "([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls])",
  :doc
  "Returns a lazy sequence consisting of the result of applying f to\n  the set of first items of each coll, followed by applying f to the\n  set of second items in each coll, until any one of the colls is\n  exhausted.  Any remaining items in other colls are ignored. Function\n  f should accept number-of-colls arguments. Returns a transducer when\n  no collection is provided."}
 ----

--- a/src/clojure/nrepl/util/lookup.clj
+++ b/src/clojure/nrepl/util/lookup.clj
@@ -56,7 +56,8 @@
       (update :file resolve-file)
       (cond-> (:macro m) (update :macro str))
       (cond-> (:special-form m) (update :special-form str))
-      (assoc :arglists-str (str (:arglists m)))))
+      (assoc :arglists-str (str (:arglists m)))
+      (update :arglists str)))
 
 (defn lookup
   "Lookup the metadata for `sym`.

--- a/src/clojure/nrepl/util/lookup.clj
+++ b/src/clojure/nrepl/util/lookup.clj
@@ -45,9 +45,7 @@
 
 (defn resolve-file
   [path]
-  (if-let [resource (io/resource path)]
-    (str resource)
-    path))
+  (or (some-> path io/resource str) path))
 
 (defn normalize-meta
   [m]

--- a/src/clojure/nrepl/util/lookup.clj
+++ b/src/clojure/nrepl/util/lookup.clj
@@ -34,8 +34,7 @@
 
 (defn normal-sym-meta
   [ns sym]
-  (if-let [var (ns-resolve ns sym)]
-    (meta var)))
+  (some-> (ns-resolve ns sym) meta))
 
 (defn sym-meta
   [ns sym]
@@ -63,5 +62,4 @@
   If the `sym` is not qualified than it will be resolved in the context
   of `ns`."
   [ns sym]
-  (if-let [m (sym-meta ns sym)]
-    (normalize-meta m)))
+  (some-> (sym-meta ns sym) normalize-meta))

--- a/src/clojure/nrepl/util/lookup.clj
+++ b/src/clojure/nrepl/util/lookup.clj
@@ -52,6 +52,7 @@
       (select-keys var-meta-whitelist)
       (update :ns str)
       (update :name str)
+      (update :protocol str)
       (update :file resolve-file)
       (cond-> (:macro m) (update :macro str))
       (cond-> (:special-form m) (update :special-form str))

--- a/test/clojure/nrepl/middleware/lookup_test.clj
+++ b/test/clojure/nrepl/middleware/lookup_test.clj
@@ -16,13 +16,18 @@
 (defprotocol MyProtocol
   (protocol-method [_]))
 
+(defn fn-with-coll-in-arglist
+  [{{bar :bar} :baz}]
+  bar)
+
 (def-repl-test lookup-op
   (doseq [op [{:op "lookup" :sym "map" :ns "clojure.core"}
               {:op "lookup" :sym "let" :ns "clojure.core"}
               {:op "lookup" :sym "*assert*" :ns "clojure.core"}
               {:op "lookup" :sym "map" :ns "nrepl.core"}
               {:op "lookup" :sym "future" :ns "nrepl.core"}
-              {:op "lookup" :sym "protocol-method" :ns "nrepl.middleware.lookup-test"}]]
+              {:op "lookup" :sym "protocol-method" :ns "nrepl.middleware.lookup-test"}
+              {:op "lookup" :sym "fn-with-coll-in-arglist" :ns "nrepl.middleware.lookup-test"}]]
     (let [result (-> (nrepl/message session op)
                      nrepl/combine-responses
                      clean-response)]

--- a/test/clojure/nrepl/middleware/lookup_test.clj
+++ b/test/clojure/nrepl/middleware/lookup_test.clj
@@ -13,12 +13,16 @@
   {:foo 1
    :bar 2})
 
+(defprotocol MyProtocol
+  (protocol-method [_]))
+
 (def-repl-test lookup-op
   (doseq [op [{:op "lookup" :sym "map" :ns "clojure.core"}
               {:op "lookup" :sym "let" :ns "clojure.core"}
               {:op "lookup" :sym "*assert*" :ns "clojure.core"}
               {:op "lookup" :sym "map" :ns "nrepl.core"}
-              {:op "lookup" :sym "future" :ns "nrepl.core"}]]
+              {:op "lookup" :sym "future" :ns "nrepl.core"}
+              {:op "lookup" :sym "protocol-method" :ns "nrepl.middleware.lookup-test"}]]
     (let [result (-> (nrepl/message session op)
                      nrepl/combine-responses
                      clean-response)]

--- a/test/clojure/nrepl/middleware/lookup_test.clj
+++ b/test/clojure/nrepl/middleware/lookup_test.clj
@@ -16,6 +16,7 @@
 (def-repl-test lookup-op
   (doseq [op [{:op "lookup" :sym "map" :ns "clojure.core"}
               {:op "lookup" :sym "let" :ns "clojure.core"}
+              {:op "lookup" :sym "*assert*" :ns "clojure.core"}
               {:op "lookup" :sym "map" :ns "nrepl.core"}
               {:op "lookup" :sym "future" :ns "nrepl.core"}]]
     (let [result (-> (nrepl/message session op)

--- a/test/clojure/nrepl/util/lookup_test.clj
+++ b/test/clojure/nrepl/util/lookup_test.clj
@@ -15,7 +15,13 @@
 
   (testing "non-qualified lookup"
     (is (not-empty (lookup 'clojure.core 'map)))
-    (is (not-empty (lookup 'nrepl.util.lookup 'map))))
+
+    (is (= {:ns "clojure.core"
+            :name "map"
+            :arglists "([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls])"
+            :arglists-str "([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls])"}
+           (select-keys (lookup 'nrepl.util.lookup 'map) [:ns :name :arglists :arglists-str])
+           (select-keys (lookup 'clojure.core 'map) [:ns :name :arglists :arglists-str]))))
 
   (testing "macro lookup"
     (is (= {:ns "clojure.core"


### PR DESCRIPTION
The lookup op currently fails in these scenarios:

- The result includes the `:protocol` key (`clojure.core.protocols/datafy`)
- The result does not contain the `:file` key or the value of `:file` is `nil`
- The result has `:arglists` that is not serializable as Bencode

This PR should fix all of these issues. It also adds a test that looks up every public var in and ensures they can be serialized into a Bencode string. There's probably a smarter or a more exhaustive way to do that, though. I'm certainly open to suggestions on how to improve it.

With `:arglists`, I've chosen to retain `:arglists-str`, because that's what the only consumers of the lookup API that I know of use at the moment. Another option might be to convert `:arglists` into a string and drop `:arglists-str`.

Regarding this point from the comments in #207:

>Yeah, that's a good point. I've been using :arglists-str only as well in CIDER. Probably it's best to make both keys the same and add some notes explaining how this happened.

I'm not sure what's the best place to have a note like that. Ideas?