### PR TITLE
Fix sideloader race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#213](https://github.com/nrepl/nrepl/pull/213): Fix sideloader race condition
+
 ## 0.8.2 (2020-09-15)
 
 ### Bugs fixed


### PR DESCRIPTION
See the commit message for more information.

I haven't added any tests yet, because its not exactly straightforward to come up with an effective unit test for this change. It's certainly possible, but I think it would require a fairly large effort.

In lieu of a test, here's the REPL session I used to verify the issue:

```clojure
(comment
  (def pending (atom {}))

  ;; This function emulates the "sideloader-provide" branch of nrepl.middleware.sideloader/wrap-sideloader.
  (defn provide
    [{:keys [type name content]}]
    (if-some [p (@pending [type name])]
      (do
        (deliver p content)
        (swap! pending dissoc [type name])
        ;; Simulate sending the "done" response to the client.
        (locking *out*
          (println {:status ["done"]})))
      ;; Simulate sending the "unexpected-provide" response to the client.
      (println {:status ["unexpected-provide"]})))

  (defn emulate-client-response
    [type name]
    ;; Emulate the client taking somewhere between 10 and 100 ms to handle the sideloader lookup
    ;; request.
    (Thread/sleep (+ 10 (rand-int 100)))
    ;; Emulate sending the reply to the nREPL server.
    (provide {:type type :name name :content "SGVsbG8sIHdvcmxkIQo="}))

  ;; This function emulates the resolve-fn function in nrepl.middleware.sideloader/sideloader.
  (def original-resolve-fn
    (fn [type name]
      ;; Emulate sending the client a :sideloader-lookup request.
      (future (emulate-client-response type name))
      (let [p (promise)]
        ;; Emulate contention on the atom.
        (locking pending
          ;; It takes between 0 and 50 ms to swap into the atom.
          (Thread/sleep (rand-int 50))
          (swap! pending assoc [(clojure.core/name type) name] p))
        @p)))

  ;; This function emulates the proposed fix.
  (def new-resolve-fn
    (fn [type name]
      (let [p (promise)]
        ;; Emulate contention on the atom again.
        (locking pending
          (Thread/sleep (rand-int 50))
          ;; We now swap into the atom before sending the client the lookup request.
          (swap! pending assoc [(clojure.core/name type) name] p))
        ;; Emulate sending the client a :sideloader-lookup request.
        (future (emulate-client-response type name))
        @p)))

  ;; Emulate sideloading until failure.
  ;;
  ;; Usually fails after 0-20 tries on my machine.
  (loop [i 0]
    (def f (future (original-resolve-fn "resource" "foo.clj")))
    ;; :timeout means that resolve-fn never delivered anything into the promise.
    (if (not= :timeout (deref f 500 :timeout))
      (recur (inc i))
      [:boom i]))

  ;; Emulate sideloading with the new function.
  ;;
  ;; Works on my machine!
  (loop [i 0]
    (def f (future (new-resolve-fn "resource" "foo.clj")))
    (if (not= :timeout (deref f 500 :timeout))
      (recur (inc i))
      [:boom i]))
  )
```

Let me know if you spot any mistakes there.