### PR TITLE
Add doc and arglists to completion responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * Add keyword completion support
+* Add doc and arglists to completion responses
 
 ### Bugs fixed
 

--- a/doc/modules/ROOT/pages/ops.adoc
+++ b/doc/modules/ROOT/pages/ops.adoc
@@ -66,9 +66,9 @@ Required parameters::
 
 
 Optional parameters::
-* `:complete` The fully qualified name of a completion function to use instead of the default one (e.g. ``my.ns/completion``).
+* `:complete-fn` The fully qualified name of a completion function to use instead of the default one (e.g. ``my.ns/completion``).
 * `:ns` The namespace in which we want to obtain completion candidates. Defaults to ``\*ns*``.
-* `:options` A map of options supported by the completion function.
+* `:options` A map of options supported by the completion function. Supported keys: ``extra-metadata`` (possible values: ``:arglists``, ``:docs``).
 
 
 Returns::
@@ -290,3 +290,4 @@ Optional parameters::
 Returns::
 * `:status` ``done``, once done, and ``error``, if there's any problems in loading a middleware
 * `:unresolved-middleware` List of middleware that could not be resolved
+

--- a/doc/modules/ROOT/pages/usage/misc.adoc
+++ b/doc/modules/ROOT/pages/usage/misc.adoc
@@ -44,6 +44,28 @@ setting `nrepl.middleware.completion/*complete-fn*`.
 user=> (set! nrepl.middleware.completion/*complete-fn* my.namespace/my-completion)
 ----
 
+=== Options
+
+The default completion function accepts the `extra-metadata` option. It allows clients to request additional metadata about completion items. For example, to request docstrings and argument lists for applicable completion items:
+
+[source,clojure]
+----
+;; -> client sends completion op
+{:op "completions"
+ :prefix "ma"
+ :ns "clojure.core"
+ :options {:extra-metadata ["arglists" "doc"]}}
+
+;; <- server returns completion items
+{:completions
+ [,,,
+  {:candidate "map"
+   :type "function"
+   :arglists "([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls])"
+   :doc "Returns a lazy sequence..."}
+  ,,,]}
+----
+
 == Symbol Lookup
 
 NOTE: Symbol look support was added in nREPL 0.8 and the API is still

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -103,7 +103,8 @@
   [path]
   (or (some-> path io/resource str) path))
 
-(defn normalize-meta
+(defn sanitize-meta
+  "Sanitize a Clojure metadata map such that it can be bencoded."
   [m]
   (-> m
       (select-keys safe-var-metadata)

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -99,10 +99,6 @@
   [:ns :name :doc :file :arglists :forms :macro :special-form
    :protocol :line :column :added :deprecated :resource])
 
-(defn resolve-file
-  [path]
-  (or (some-> path io/resource str) path))
-
 (defn sanitize-meta
   "Sanitize a Clojure metadata map such that it can be bencoded."
   [m]
@@ -111,7 +107,7 @@
       (update :ns str)
       (update :name str)
       (update :protocol str)
-      (update :file resolve-file)
+      (update :file #(or (some-> % io/resource str) %))
       (cond-> (:macro m) (update :macro str))
       (cond-> (:special-form m) (update :special-form str))
       (assoc :arglists-str (str (:arglists m)))

--- a/src/clojure/nrepl/util/completion.clj
+++ b/src/clojure/nrepl/util/completion.clj
@@ -190,7 +190,7 @@
 ;;; Candidates
 
 (defn annotate-var [var]
-  (let [{macro :macro arglists :arglists var-name :name doc :doc} (-> var meta misc/normalize-meta)
+  (let [{macro :macro arglists :arglists var-name :name doc :doc} (-> var meta misc/sanitize-meta)
         type (cond macro :macro
                    arglists :function
                    :else :var)]

--- a/src/clojure/nrepl/util/lookup.clj
+++ b/src/clojure/nrepl/util/lookup.clj
@@ -38,4 +38,4 @@
   If the `sym` is not qualified than it will be resolved in the context
   of `ns`."
   [ns sym]
-  (some-> (sym-meta ns sym) misc/normalize-meta))
+  (some-> (sym-meta ns sym) misc/sanitize-meta))

--- a/test/clojure/nrepl/misc_test.clj
+++ b/test/clojure/nrepl/misc_test.clj
@@ -1,0 +1,9 @@
+(ns nrepl.misc-test
+  (:require [clojure.test :refer [deftest is]]
+            [nrepl.misc :as misc]))
+
+(deftest normalize-meta-test
+  (is (not-empty (:file (misc/normalize-meta {:file "clojure/core.clj"}))))
+
+  (is (= "/foo/bar/baz.clj"
+         (:file (misc/normalize-meta {:file "/foo/bar/baz.clj"})))))

--- a/test/clojure/nrepl/misc_test.clj
+++ b/test/clojure/nrepl/misc_test.clj
@@ -2,8 +2,8 @@
   (:require [clojure.test :refer [deftest is]]
             [nrepl.misc :as misc]))
 
-(deftest normalize-meta-test
-  (is (not-empty (:file (misc/normalize-meta {:file "clojure/core.clj"}))))
+(deftest sanitize-meta-test
+  (is (not-empty (:file (misc/sanitize-meta {:file "clojure/core.clj"}))))
 
   (is (= "/foo/bar/baz.clj"
-         (:file (misc/normalize-meta {:file "/foo/bar/baz.clj"})))))
+         (:file (misc/sanitize-meta {:file "/foo/bar/baz.clj"})))))

--- a/test/clojure/nrepl/util/completion_test.clj
+++ b/test/clojure/nrepl/util/completion_test.clj
@@ -1,7 +1,12 @@
 (ns nrepl.util.completion-test
+  "Unit tests for completion utilities."
   (:require [clojure.set :as set]
             [clojure.test :refer :all]
             [nrepl.util.completion :as completion :refer [completions]]))
+
+(def t-var "var" nil)
+(defn t-fn "fn" [x] x)
+(defmacro t-macro "macro" [y] y)
 
 (defn- candidates
   "Return only the candidate names without any additional
@@ -61,18 +66,36 @@
     (is (not (some #{"String/indexOf" ".indexOf"} (candidates "String/")))))
 
   (testing "candidate types"
-    (is (some #{{:candidate "comment" :type :macro}}
-              (completions "comment" 'clojure.core)))
-    (is (some #{{:candidate "commute" :type :function}}
-              (completions "commute" 'clojure.core)))
+    (is (some #{{:candidate "t-var"
+                 :type :var
+                 :doc "var"}}
+              (completions "t-var" 'nrepl.util.completion-test)))
+    (is (some #{{:candidate "t-fn"
+                 :type :function
+                 :arglists "([x])"
+                 :doc "fn"}}
+              (completions "t-fn" 'nrepl.util.completion-test)))
+    (is (some #{{:candidate "t-macro"
+                 :type :macro
+                 :arglists "([y])"
+                 :doc "macro"}}
+              (completions "t-macro" 'nrepl.util.completion-test)))
     (is (some #{{:candidate "unquote" :type :var}}
               (completions "unquote" 'clojure.core)))
     (is (some #{{:candidate "if" :ns "clojure.core" :type :special-form}}
               (completions "if" 'clojure.core)))
     (is (some #{{:candidate "UnsatisfiedLinkError" :type :class}}
               (completions "Unsatisfied" 'clojure.core)))
-    (is (some #{{:candidate "clojure.core" :type :namespace}}
+    ;; ns with :doc meta
+    (is (some #{{:candidate "clojure.core"
+                 :type :namespace
+                 :doc "Fundamental library of the Clojure language"}}
               (completions "clojure.core" 'clojure.core)))
+    ;; ns with docstring argument
+    (is (some #{{:candidate "nrepl.util.completion-test"
+                 :type :namespace
+                 :doc "Unit tests for completion utilities."}}
+              (completions "nrepl.util.completion-test" 'clojure.core)))
     (is (some #{{:candidate "Integer/parseInt" :type :static-method}}
               (completions "Integer/parseInt" 'clojure.core)))
     (is (some #{{:candidate "File/separator", :type :static-method}}

--- a/test/clojure/nrepl/util/completion_test.clj
+++ b/test/clojure/nrepl/util/completion_test.clj
@@ -67,19 +67,28 @@
 
   (testing "candidate types"
     (is (some #{{:candidate "t-var"
+                 :type :var}}
+              (completions "t-var" 'nrepl.util.completion-test)))
+    (is (some #{{:candidate "t-var"
                  :type :var
                  :doc "var"}}
-              (completions "t-var" 'nrepl.util.completion-test)))
+              (completions "t-var" 'nrepl.util.completion-test {:extra-metadata #{:arglists :doc}})))
+    (is (some #{{:candidate "t-fn"
+                 :type :function}}
+              (completions "t-fn" 'nrepl.util.completion-test)))
     (is (some #{{:candidate "t-fn"
                  :type :function
                  :arglists "([x])"
                  :doc "fn"}}
-              (completions "t-fn" 'nrepl.util.completion-test)))
+              (completions "t-fn" 'nrepl.util.completion-test {:extra-metadata #{:arglists :doc}})))
+    (is (some #{{:candidate "t-macro"
+                 :type :macro}}
+              (completions "t-macro" 'nrepl.util.completion-test)))
     (is (some #{{:candidate "t-macro"
                  :type :macro
                  :arglists "([y])"
                  :doc "macro"}}
-              (completions "t-macro" 'nrepl.util.completion-test)))
+              (completions "t-macro" 'nrepl.util.completion-test {:extra-metadata #{:arglists :doc}})))
     (is (some #{{:candidate "unquote" :type :var}}
               (completions "unquote" 'clojure.core)))
     (is (some #{{:candidate "if" :ns "clojure.core" :type :special-form}}
@@ -88,14 +97,20 @@
               (completions "Unsatisfied" 'clojure.core)))
     ;; ns with :doc meta
     (is (some #{{:candidate "clojure.core"
+                 :type :namespace}}
+              (completions "clojure.core" 'clojure.core)))
+    (is (some #{{:candidate "clojure.core"
                  :type :namespace
                  :doc "Fundamental library of the Clojure language"}}
-              (completions "clojure.core" 'clojure.core)))
+              (completions "clojure.core" 'clojure.core {:extra-metadata #{:doc}})))
     ;; ns with docstring argument
+    (is (some #{{:candidate "nrepl.util.completion-test"
+                 :type :namespace}}
+              (completions "nrepl.util.completion-test" 'clojure.core)))
     (is (some #{{:candidate "nrepl.util.completion-test"
                  :type :namespace
                  :doc "Unit tests for completion utilities."}}
-              (completions "nrepl.util.completion-test" 'clojure.core)))
+              (completions "nrepl.util.completion-test" 'clojure.core {:extra-metadata #{:doc}})))
     (is (some #{{:candidate "Integer/parseInt" :type :static-method}}
               (completions "Integer/parseInt" 'clojure.core)))
     (is (some #{{:candidate "File/separator", :type :static-method}}

--- a/test/clojure/nrepl/util/lookup_test.clj
+++ b/test/clojure/nrepl/util/lookup_test.clj
@@ -40,12 +40,6 @@
   (testing "Java sym lookup"
     (is (empty? (lookup 'clojure.core 'String)))))
 
-(deftest normalize-meta-test
-  (is (not-empty (:file (l/normalize-meta {:file "clojure/core.clj"}))))
-
-  (is (= "/foo/bar/baz.clj"
-         (:file (l/normalize-meta {:file "/foo/bar/baz.clj"})))))
-
 (defn- bencode-str
   "Bencode a thing and write it into a string."
   [thing]


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

What it says on the tin. Allows clients to implement a richer auto-completion experience. Like this:

<img width="1047" alt="Screenshot 2021-01-08 at 23 10 01" src="https://user-images.githubusercontent.com/31859/104064656-f8a86900-5206-11eb-817e-e8f470d3b2e3.png">

One thing to consider is whether we should return `:doc` and `:arglists` by default (as this PR does), or only if the client asks for them. I can't imagine sending them by default causing much harm, unless there's a var with an absolutely massive docstring that causes the client to choke or something.

The `nrepl.util.completion/completions` function does take an options map, which we could leverage to do something like `{:keys #{:doc :arglists}}`. I've left that out for now, but I can certainly implement it if necessary.

Another option is to use the same options map to give the clients the option of opting out of those keys. That would be fairly straightforward to implement later and retain backwards compatibility if necessary, I think.