### PR TITLE
Fix completion for static class members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add keyword completion support
 
+### Bugs fixed
+
+* Fix completion for static class members
+
 ## 0.8.3 (2020-10-25)
 
 ### Bugs fixed

--- a/src/clojure/nrepl/util/completion.clj
+++ b/src/clojure/nrepl/util/completion.clj
@@ -178,8 +178,8 @@
      (for [file classfiles :when (re-find #"^[^\$]+(\$[^\d]\w*)+\.class" file)]
        (classname file)))))
 
-(defn resolve-class [sym]
-  (try (let [val (resolve sym)]
+(defn resolve-class [ns sym]
+  (try (let [val (ns-resolve ns sym)]
          (when (class? val) val))
        (catch Exception e
          (when (not= ClassNotFoundException
@@ -233,7 +233,7 @@
   (when-let [prefix-scope (first (.split prefix "/"))]
     (let [scope (symbol prefix-scope)]
       (map #(update % :candidate (fn [c] (str scope "/" c)))
-           (if-let [class (resolve-class scope)]
+           (if-let [class (resolve-class ns scope)]
              (static-member-candidates class)
              (when-let [ns (or (find-ns scope) (scope (ns-aliases ns)))]
                (ns-public-var-candidates ns)))))))

--- a/test/clojure/nrepl/util/completion_test.clj
+++ b/test/clojure/nrepl/util/completion_test.clj
@@ -75,6 +75,8 @@
               (completions "clojure.core" 'clojure.core)))
     (is (some #{{:candidate "Integer/parseInt" :type :static-method}}
               (completions "Integer/parseInt" 'clojure.core)))
+    (is (some #{{:candidate "File/separator", :type :static-method}}
+              (completions "File/" 'nrepl.util.completion)))
     (is (some #{{:candidate ".toString" :type :method}}
               (completions ".toString" 'clojure.core)))))
 


### PR DESCRIPTION
`(resolve sym)` is the same as `(ns-resolve *ns* &env sym)`. That is, prior to this fix, the `resolve-class` fn attempted to resolve the symbol against the ns stored in the `*ns*` var (often the `user` ns), not the ns that was passed in via the completion op.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)