### PR TITLE
Fix namespace resolution in the cmdline repl (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * [#227](https://github.com/nrepl/nrepl/pull/227): Fix completion for static class members.
 * [#231](https://github.com/nrepl/nrepl/issues/231): Fix sanitize error when file is `java.net.URL`.
+* [#208](https://github.com/nrepl/nrepl/issues/208): Fix namespace resolution in nrepl cmdline
 
 ## 0.8.3 (2020-10-25)
 

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -2,6 +2,7 @@
   {:author "Chas Emerick"}
   (:require
    [clojure.java.io :refer [as-file]]
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [nrepl.ack :as ack]
    [nrepl.bencode :refer [write-bencode]]
@@ -280,3 +281,23 @@
         (finally
           (.delete sock-file)
           (Files/delete tmpdir))))))
+
+(deftest ^:slow cmdline-namespace-resolution
+  (testing "Ensuring that namespace resolution works in the cmdline repl"
+    (let [test-input (str/join \newline ["::a"
+                                         "(ns a)" "::a"
+                                         "(ns b)" "::a"
+                                         "(ns user)" "::a"
+                                         "(require '[a :as z])" "::z/a"])
+          expected-output [":user/a"
+                           "nil" ":a/a"
+                           "nil" ":b/a"
+                           "nil" ":user/a"
+                           "nil" ":a/a"]
+          >devnull (fn [& _] nil)]
+      (binding [*in* (java.io.PushbackReader. (java.io.StringReader. test-input))]
+        (with-redefs [cmd/clean-up-and-exit >devnull]
+          (with-open [server (server/start-server)]
+            (let [results (atom [])]
+              (#'cmd/run-repl (:host server) (:port server) {:prompt >devnull :err >devnull :out >devnull :value #(swap! results conj %)})
+              (is (= expected-output @results)))))))))


### PR DESCRIPTION
The namespace resolution in `nrepl.cmdline/run-repl` was broken due to
usage of `clojure.core/read` which was performing all namespace
resolution in the user namespace. This has been fixed by rebinding the
`*ns*` var in the main loop any time that the nrepl server changes
namespaces.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

Thanks!

*If you're just starting out to hack on nREPL you might find this [section of its
manual][1] extremely useful.*

[1]: https:/nrepl.org/nrepl/hacking_on_nrepl.html
