### PR TITLE
Elaborate on filesystem socket permission issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,10 +67,6 @@ commands:
           command: |
             sudo apt-get install make
       - run:
-          name: Install clj-kondo
-          command: |
-           sudo curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo && sudo chmod +x install-clj-kondo && sudo ./install-clj-kondo
-      - run:
           name: Generate Cache Checksum
           command: |
             for file in << parameters.files >>

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ test:
 
 ifeq ($(VERSION),$(filter $(VERSION),1.9 1.10 master))
 	lein with-profile -user,+$(VERSION),+test run -m kaocha.runner
+	lein with-profile -user,+$(VERSION),+test,+junixsocket run -m kaocha.runner
 else
 	lein with-profile -user,+$(VERSION),+test test
+	lein with-profile -user,+$(VERSION),+test,+junixsocket test
 endif
 
 eastwood:

--- a/doc/modules/ROOT/pages/usage/server.adoc
+++ b/doc/modules/ROOT/pages/usage/server.adoc
@@ -216,7 +216,8 @@ You can also ask nREPL to listen on a UNIX domain (filesystem) socket
 with the `:socket` keyword (if you're using JDK 16 or newer add a
 https://kohlschutter.github.io/junixsocket/[junixsocket] dependency),
 which should be as secure as the access to the socket\'s parent
-directories:
+directories (POSIX doesn't specify the effect of the socket file's
+permissions (if any), and some systems have ignored them):
 
 [source,clojure]
 ----

--- a/project.clj
+++ b/project.clj
@@ -84,4 +84,5 @@
                          :global-vars {*warn-on-reflection* true}
                          :eastwood {:config-files ["eastwood.clj"]
                                     :ignored-faults {:non-dynamic-earmuffs {nrepl.middleware.load-file true}
-                                                     :unused-ret-vals {nrepl.util.completion-test true}}}}]})
+                                                     :unused-ret-vals {nrepl.util.completion-test true}
+                                                     :reflection {nrepl.socket.dynamic true}}}}]})

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -149,7 +149,10 @@
 
    * :port — defaults to 0, which autoselects an open port
    * :bind — bind address, by default \"127.0.0.1\"
-   * :socket - filesystem socket path (alternative to :port and :bind)
+   * :socket — filesystem socket path (alternative to :port and :bind).
+       Note that POSIX does not specify the effect (if any) of the
+       socket file's permissions (and some systems have ignored them),
+       so any access control should be arranged via parent directories.
    * :handler — the nREPL message handler to use for each incoming connection;
        defaults to the result of `(default-handler)`
    * :transport-fn — a function that, given a java.net.Socket corresponding

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -144,7 +144,7 @@
   java.io.Closeable
   (close [this] (stop-server this)))
 
-(defn start-server
+(defn ^Server start-server
   "Starts a socket-based nREPL server.  Configuration options include:
 
    * :port — defaults to 0, which autoselects an open port

--- a/src/clojure/nrepl/socket.clj
+++ b/src/clojure/nrepl/socket.clj
@@ -6,7 +6,8 @@
   https://bugs.openjdk.java.net/browse/JDK-4509080."
   (:require
    [clojure.java.io :as io]
-   [nrepl.misc :refer [log]])
+   [nrepl.misc :refer [log]]
+   [nrepl.socket.dynamic :refer [get-path]])
   (:import
    (java.io BufferedInputStream BufferedOutputStream File)
    (java.net InetSocketAddress ProtocolFamily ServerSocket Socket SocketAddress
@@ -15,8 +16,6 @@
    (java.nio.file Path)
    (java.nio.channels Channels ClosedChannelException NetworkChannel
                       ServerSocketChannel SocketChannel)))
-
-(def orig-warn-on-reflection *warn-on-reflection*)
 
 (defmacro find-class [full-path]
   `(try
@@ -88,16 +87,6 @@
     (let [msg "Support for filesystem sockets requires JDK 16+ or a junixsocket dependency"]
       (log msg)
       (throw (ex-info msg {:nrepl/kind ::no-filesystem-sockets})))))
-
-(set! *warn-on-reflection* false)
-
-;; SocketAddress doesn't have .getPath until JDK 16, and we can't refer to
-;; AFUnixSocketAddress unconditionally in the junixsocket cases.  Also note that
-;; the former returns a Path, and the latter returns a string.
-
-(defn- get-path [addr] (.getPath addr))
-
-(set! *warn-on-reflection* orig-warn-on-reflection)
 
 (def jdk-unix-server-socket
   ;; Dynamic because one argument open doesn't exist until jvm 15, nor UNIX

--- a/src/clojure/nrepl/socket/dynamic.clj
+++ b/src/clojure/nrepl/socket/dynamic.clj
@@ -1,0 +1,14 @@
+(ns nrepl.socket.dynamic
+  "Socket-related code that depends on classes that are only known at
+  run time, not complile time.  This just allows us to isolate
+  reflections we can't avoid, so that we can easily ask eastwood to
+  ignore them.  This namespace should only be needed until JDK 16+ can
+  be assumed.")
+
+(set! *warn-on-reflection* false)
+
+;; SocketAddress doesn't have .getPath until JDK 16, and we can't refer to
+;; AFUnixSocketAddress unconditionally in the junixsocket cases.  Also note that
+;; the former returns a Path, and the latter returns a string.
+
+(defn get-path [addr] (.getPath addr))


### PR DESCRIPTION
I wondered if we might want to elaborate a bit on the filesystem socket permission constraints, also discussed in Linux's `unix(7)`.  I also didn't know if having non-ascii "dashes" in the `start-server` docstring was intentional, but I hadn't noticed before, and ao changed `:socket` to match the others.

From the manpage:
```
Pathname socket ownership and permissions
    In  the  Linux  implementation,  pathname sockets honor the permissions of the directory
    they are in.  Creation of a new socket fails if the process  does  not  have  write  and
    search (execute) permission on the directory in which the socket is created.

    On Linux, connecting to a stream socket object requires write permission on that socket;
    sending a datagram to a datagram socket  likewise  requires  write  permission  on  that
    socket.   POSIX  does  not  make  any statement about the effect of the permissions on a
    socket file, and on some systems (e.g., older BSDs), the socket permissions are ignored.
    Portable programs should not rely on this feature for security.
