### PR TITLE
Sideloader state in session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   is version 16 or newer or
   [junixsocket](https://kohlschutter.github.io/junixsocket/) is
   available as a dependency.
+* [#243](https://github.com/nrepl/nrepl/pull/243): Keep the sideloader state in the session so it persists across middleware changes. Sanitize the input in base64-decode.
 
 ### Bugs fixed
 

--- a/src/clojure/nrepl/middleware/sideloader.clj
+++ b/src/clojure/nrepl/middleware/sideloader.clj
@@ -42,13 +42,16 @@
     (loop [bits 0 buf 0]
       (let [got (.read in)]
         (when-not (or (neg? got) (= 61 got))
-          (let [buf (bit-or (.indexOf table got) (bit-shift-left buf 6))
-                bits (+ bits 6)]
-            (if (<= 8 bits)
-              (let [bits (- bits 8)]
-                (.write bos (bit-shift-right buf bits))
-                (recur bits (bit-and 63 buf)))
-              (recur bits buf))))))
+          (let [table-idx (.indexOf table got)]
+            (if (= -1 table-idx)
+              (recur bits buf)
+              (let [buf (bit-or table-idx (bit-shift-left buf 6))
+                    bits (+ bits 6)]
+                (if (<= 8 bits)
+                  (let [bits (- bits 8)]
+                    (.write bos (bit-shift-right buf bits))
+                    (recur bits (bit-and 63 buf)))
+                  (recur bits buf))))))))
     (.toByteArray bos)))
 
 (defn- sideloader


### PR DESCRIPTION
Pending resources in the sideloader are kept in an atom, which currently is
defined in a closure which closes over the classloader and sideloader ops. When
the middleware stack is rebuilt (e.g. via an `add-middleware` op), this atom
gets re-initialized, and the state is lost, causing the side loader to respond
to previously requested resources with `:unexpected-provide`.

The only state that does persist is the session. We already use the session to
store the classloader itself, it makes sense to also keep the `pending` atom in
the session, so that the pending state that we see always corresponds with the
current session classloader.

This fixes an issue which was pointed out in the PR that adds dynamic middleware
loading: https://github.com/nrepl/nrepl/pull/185#issuecomment-624317912

This also makes the base64-decode implementation more conservative (see also https://github.com/clojure-emacs/cider/pull/3038)

Part of https://github.com/clojure-emacs/cider/issues/3037


- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)
