### PR TITLE
Log errors that happen when loading dynamic middleware

### DIFF
--- a/src/clojure/nrepl/middleware/dynamic_loader.clj
+++ b/src/clojure/nrepl/middleware/dynamic_loader.clj
@@ -33,7 +33,7 @@
                             (-> middleware-str-or-var
                                 (str/replace "#'" "")
                                 symbol
-                                misc/requiring-resolve)))
+                                (misc/requiring-resolve :log-errors))))
                         middleware)
           stack    (linearize-middleware-stack resolved)]
       (if (every? some? resolved)

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -67,12 +67,14 @@
   "Resolves namespace-qualified sym per 'resolve'. If initial resolve fails,
   attempts to require sym's namespace and retries. Returns nil if sym could not
   be resolved."
-  [sym]
+  [sym & [log?]]
   (or (resolve sym)
       (try
         (require (symbol (namespace sym)))
         (resolve sym)
-        (catch Exception _))))
+        (catch Exception e
+          (when log?
+            (log e))))))
 
 (defmacro with-session-classloader
   "This macro does two things:


### PR DESCRIPTION
It seems prudent to have these errors at least go *somewhere*, instead of just swallowing them.

Part of https://github.com/clojure-emacs/cider/issues/3037

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)
