### PR TITLE
Sideloader+dynload dogfooding

### DIFF
--- a/src/clojure/nrepl/middleware/completion.clj
+++ b/src/clojure/nrepl/middleware/completion.clj
@@ -32,9 +32,9 @@
      (update (walk/keywordize-keys options) :extra-metadata (comp set (partial map keyword))))))
 
 (defn completion-reply
-  [{:keys [session prefix ns complete-fn options] :as msg}]
+  [{:keys [session prefix ns complete-fn options session] :as msg}]
   (let [ns (if ns (symbol ns) (symbol (str (@session #'*ns*))))
-        completion-fn (or (and complete-fn (misc/requiring-resolve (symbol complete-fn))) *complete-fn*)]
+        completion-fn (or (and complete-fn (misc/session-resolve session (symbol complete-fn))) *complete-fn*)]
     (try
       (response-for msg {:status :done :completions (completion-fn prefix ns (parse-options options))})
       (catch Exception _e

--- a/src/clojure/nrepl/middleware/lookup.clj
+++ b/src/clojure/nrepl/middleware/lookup.clj
@@ -30,7 +30,7 @@
   (try
     (let [ns (if ns (symbol ns) (symbol (str (@session #'*ns*))))
           sym (symbol sym)
-          lookup-fn (or (and lookup-fn (misc/requiring-resolve (symbol lookup-fn))) *lookup-fn*)]
+          lookup-fn (or (and lookup-fn (misc/session-resolve session (symbol lookup-fn))) *lookup-fn*)]
       (response-for msg {:status :done :info (lookup-fn ns sym)}))
     (catch Exception _e
       (if (nil? ns)

--- a/src/clojure/nrepl/middleware/print.clj
+++ b/src/clojure/nrepl/middleware/print.clj
@@ -177,8 +177,7 @@
 (defn- resolve-print
   [{:keys [::print transport session] :as msg}]
   (when-let [var-sym (some-> print (symbol))]
-    (let [print-var (misc/with-session-classloader session
-                      (misc/requiring-resolve var-sym :log))]
+    (let [print-var (misc/session-resolve session var-sym)]
       (when-not print-var
         (let [resp {:status ::error
                     ::error (str "Couldn't resolve var " var-sym)}]
@@ -234,7 +233,7 @@
                  (update ::stream? #(if (= [] %) false (boolean %))))]
       (handler (assoc msg :transport (printing-transport msg opts))))))
 
-(set-descriptor! #'wrap-print {:requires #{}
+(set-descriptor! #'wrap-print {:requires #{"clone"}
                                :expects #{}
                                :handles {}})
 

--- a/src/clojure/nrepl/middleware/print.clj
+++ b/src/clojure/nrepl/middleware/print.clj
@@ -175,9 +175,10 @@
       this)))
 
 (defn- resolve-print
-  [{:keys [::print transport] :as msg}]
+  [{:keys [::print transport session] :as msg}]
   (when-let [var-sym (some-> print (symbol))]
-    (let [print-var (misc/requiring-resolve var-sym)]
+    (let [print-var (misc/with-session-classloader session
+                      (misc/requiring-resolve var-sym :log))]
       (when-not print-var
         (let [resp {:status ::error
                     ::error (str "Couldn't resolve var " var-sym)}]


### PR DESCRIPTION
With the work that's been done it's becoming possible to use the sideloader+dynamic loading of middleware to upgrade an nREPL connection to use the cider-nrepl middleware. Now I'm starting to "dogfood" this, i.e. use it to develop on real world projects. This PR is an assortment of changes that I'm doing to try to get to a point where it's actually usable.

- Make sure any remaining dynamic requires (e.g. in the print middleware) use the session classloader
- cache classloading results, so we don't endlessly (re-)fetch the same resources
- add prefix-based filtering, to prevent lots of no-op network round trips.

Draft and open for discussion, I'll probably split this into smaller PRs that will then be accompanied with tests and changelog updates etc.

--------

- Part of: https://github.com/clojure-emacs/cider/issues/3037
- Related: https://github.com/clojure-emacs/cider/issues/3049

-------

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)
