### PR TITLE
Fewer new loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#227](https://github.com/nrepl/nrepl/pull/227): Fix completion for static class members.
 * [#231](https://github.com/nrepl/nrepl/issues/231): Fix sanitize error when file is `java.net.URL`.
 * [#208](https://github.com/nrepl/nrepl/issues/208): Fix namespace resolution in the cmdline REPL.
+* [#248](https://github.com/nrepl/nrepl/pull/248): Create fewer new classloaders
 
 ## 0.8.3 (2020-10-25)
 

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -90,12 +90,16 @@
          alt-cl# (when-let [classloader# (:classloader (meta ~session))]
                    (classloader#))
          cl#     (or alt-cl# ctxcl#)]
-     (.setContextClassLoader (Thread/currentThread) cl#)
-     (try
+     (if (= ctxcl# cl#)
        (with-bindings {clojure.lang.Compiler/LOADER cl#}
          ~@body)
-       (finally
-         (.setContextClassLoader (Thread/currentThread) ctxcl#)))))
+       (do
+         (.setContextClassLoader (Thread/currentThread) cl#)
+         (try
+           (with-bindings {clojure.lang.Compiler/LOADER cl#}
+             ~@body)
+           (finally
+             (.setContextClassLoader (Thread/currentThread) ctxcl#)))))))
 
 (defn java-8?
   "Util to check if we are using Java 8. Useful for features that behave

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -1116,7 +1116,6 @@
                            :name name})
                     result)
 
-
                   ;; Verify that the sideloading worked
                   (and (= 2 id) (status? :done status))
                   (do


### PR DESCRIPTION
Add a few checks to be more conservative about setting the context classloader. This also prevents us from overwriting/shadowing classloaders set up by other tools.

In middleware.session this only creates and sets up a new DynamicClassLoader when one isn't there yet. In misc/with-session-classloader it only set/unsets the current loader if a session classloader is present and it differs from the context classloader.

----

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)
