### PR TITLE
Docs: replace deprecated usage of clj -R

### DIFF
--- a/doc/modules/ROOT/pages/design/transports.adoc
+++ b/doc/modules/ROOT/pages/design/transports.adoc
@@ -131,7 +131,7 @@ You can also start an nREPL with a EDN transport using `clj`:
 
 [source,shell]
 ----
-$ clj -R:nrepl -m nrepl.cmdline -t nrepl.transport/edn
+$ clj -M:nrepl -m nrepl.cmdline -t nrepl.transport/edn
 nREPL server started on port 63266 on host localhost - nrepl+edn://localhost:63266
 ----
 
@@ -165,6 +165,6 @@ Starting with nREPL 0.5 you can also start an nREPL with a TTY transport using `
 
 [source,shell]
 ----
-$ clj -R:nrepl -m nrepl.cmdline -t nrepl.transport/tty
+$ clj -M:nrepl -m nrepl.cmdline -t nrepl.transport/tty
 nREPL server started on port 63266 on host localhost - telnet://localhost:63266
 ----

--- a/doc/modules/ROOT/pages/usage/server.adoc
+++ b/doc/modules/ROOT/pages/usage/server.adoc
@@ -30,7 +30,7 @@ Then you can simply run the nREPL server in headless mode like this:
 
 [source,shell]
 ----
-$ clj -R:nREPL -m nrepl.cmdline
+$ clj -M:nREPL -m nrepl.cmdline
 ----
 
 A good practice is add whatever nREPL middleware you want to use to
@@ -50,7 +50,7 @@ how you can easily start a ClojureScript capable nREPL:
 
 [source,shell]
 ----
-$ clj -R:nREPL -m nrepl.cmdline --middleware "[cider.piggieback/wrap-cljs-repl]"
+$ clj -M:nREPL -m nrepl.cmdline --middleware "[cider.piggieback/wrap-cljs-repl]"
 ----
 
 By default, nREPL listens for connections on a randomly chosen local
@@ -74,7 +74,7 @@ you can ask it to listen on a UNIX domain (filesystem) socket instead:
 [source,shell]
 ----
 $ mkdir -m go-rwx nrepl-test
-$ clj -R:nREPL -m nrepl.cmdline --socket nrepl-test/socket
+$ clj -M:nREPL -m nrepl.cmdline --socket nrepl-test/socket
 ----
 
 Here's a listing of all the options available via nREPL's command-line


### PR DESCRIPTION
`clj -R` raises a deprecation warning, `-M` should be used in these cases
 
Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

Thanks!

*If you're just starting out to hack on nREPL you might find this [section of its
manual][1] extremely useful.*

[1]: https:/nrepl.org/nrepl/hacking_on_nrepl.html
