### PR TITLE
Improved reliability of TTY cmdline tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ target
 pom.xml
 build.xml
 /test-results
+/.clj-kondo/
+/.lsp/

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -225,6 +225,10 @@
                                (.redirectOutput ProcessBuilder$Redirect/INHERIT)
                                (.redirectError ProcessBuilder$Redirect/INHERIT)))]
           (try
+            ;; we want to ensure the server is up before trying to connect to it
+            ;; this is done by waiting till the socket file is created, and then
+            ;; waiting an extra 1s. (extra wait seems to help with test reliability
+            ;; in CI. Question: why are we not using ack to do this? To investigate
             (while (not (.exists sock-file))
               (Thread/sleep 100))
             (Thread/sleep 1000)

--- a/test/clojure/nrepl/cmdline_tty_test.clj
+++ b/test/clojure/nrepl/cmdline_tty_test.clj
@@ -1,0 +1,61 @@
+(ns nrepl.cmdline-tty-test
+  "TTY is not a full-featured transport (e.g. doesn't support ack), so are tested
+   separately here."
+  (:require [clojure.test :refer [deftest is testing]]
+            [nrepl.cmdline :as cmd]
+            [nrepl.server :as server]
+            [nrepl.transport :as transport])
+  (:import [com.hypirion.io ClosingPipe Pipe]
+           nrepl.server.Server))
+
+(defn- sh
+  "A version of clojure.java.shell/sh that streams in/out/err.
+  Taken and edited from https://github.com/technomancy/leiningen/blob/f7e1adad6ff5137d6ea56bc429c3b620c6f84128/leiningen-core/src/leiningen/core/eval.clj"
+  ^Process
+  [& cmd]
+  (let [proc (.exec (Runtime/getRuntime) ^"[Ljava.lang.String;" (into-array String cmd))]
+    (.addShutdownHook (Runtime/getRuntime)
+                      (Thread. (fn [] (.destroy proc))))
+    (with-open [out (.getInputStream proc)
+                err (.getErrorStream proc)
+                in (.getOutputStream proc)]
+      (let [pump-out (doto (Pipe. out System/out) .start)
+            pump-err (doto (Pipe. err System/err) .start)
+            pump-in (ClosingPipe. System/in in)]
+        proc))))
+
+(deftest ^:slow tty-server
+  (let [^int free-port (with-open [ss (java.net.ServerSocket.)]
+                         (.bind ss nil)
+                         (.getLocalPort ss))
+        ^Process
+        server-process (apply sh ["java" "-Dnreplacktest=y"
+                                  "-cp" (System/getProperty "java.class.path")
+                                  "nrepl.main"
+                                  "--port" (str free-port)
+                                  "--transport" "nrepl.transport/tty"])]
+    ;; We can't use ack, so Wait for server to come up before trying to connect.
+    (Thread/sleep 10000)
+    (try
+      (let [c    (org.apache.commons.net.telnet.TelnetClient.)
+            _    (.connect c "localhost" free-port)
+            out  (java.io.PrintStream. (.getOutputStream c))
+            br   (java.io.BufferedReader. (java.io.InputStreamReader. (.getInputStream c)))
+            _    (doto out
+                   (.println "(System/getProperty \"nreplacktest\")")
+                   (.flush))
+            resp (doall (repeatedly 3 #(.readLine br)))
+            _    (.disconnect c)]
+        (is (= "user=> \"y\""
+               (last resp))))
+      (finally
+        (.destroy server-process)))))
+
+(deftest no-tty-client
+  (testing "Trying to connect with the tty transport should fail."
+    (with-open [^Server server (server/start-server :transport-fn #'transport/tty)]
+      (let [options (cmd/connection-opts {:port      (:port server)
+                                          :host      "localhost"
+                                          :transport 'nrepl.transport/tty})]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (cmd/interactive-repl server options)))))))


### PR DESCRIPTION
- TTY is not a fully fledged transport, and significantly, does not handle ack.
- `cmdline-test` uses a test fixture that loops between all the transports (typically bencode + edn). This doesn't make sense with TTY tests 

I think these have been a contributing factor to `tty-server` being flaky. Moving the tty tests into its own ns seems to have helped, with no error over about ~5 runs on CI in my branch.

I've also added an extra delay into the socket test, which also seems to have helped with consistency.

Most remaining flaky tests have to do with sideloader tests stalling and eventually timing out.