### PR TITLE
safe-write-bencode: unify OutputStreams and channels via Writable protocol

### DIFF
--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -40,7 +40,7 @@
 
 (defn has-dcl?
   "Is this classloader or any of its ancestors a DynamicClassLoader?"
-  ^DynamicClassLoader
+  ^clojure.lang.DynamicClassLoader
   [^ClassLoader cl]
   (loop [loader cl]
     (when loader

--- a/src/clojure/nrepl/transport.clj
+++ b/src/clojure/nrepl/transport.clj
@@ -16,8 +16,7 @@
             EOFException
             Flushable
             PushbackInputStream
-            PushbackReader
-            OutputStream)
+            PushbackReader)
    [java.net Socket SocketException]
    [java.util.concurrent BlockingQueue LinkedBlockingQueue SynchronousQueue TimeUnit]))
 
@@ -110,7 +109,7 @@
   [output thing]
   (let [buffer (ByteArrayOutputStream.)]
     (bencode/write-bencode buffer thing)
-    (.write ^OutputStream output (.toByteArray buffer))))
+    (socket/write output (.toByteArray buffer))))
 
 (defn bencode
   "Returns a Transport implementation that serializes messages


### PR DESCRIPTION
See the commit messages for more info -- hopefully fixes https://github.com/nrepl/nrepl/issues/245

I'm seeing one failure here with JDK 8 and `lein with-profile +1.10 test`.  If that's not expected on the current branch, then we'll have to figure it out.

```
lein test :only nrepl.core-test/dynamic-middleware+sideloading-interleaved

FAIL in (dynamic-middleware+sideloading-interleaved) (core_test.clj:1066)
edn transport sideloader state persists across middleware changes
expected: (= [:added-middleware :provided-ns :provided-ns [:eval-ok "\"Hello!\""]] (reduce (fn [resu
lt {:keys [id status type name value], :as msg}] (cond (status? :unexpected-provide status) (throw (
ex-info "Unexpected provide" msg)) (and (= name (str "foo/" ns ".clj")) (status? :sideloader-lookup
status) (not (some #{:added-middleware} result))) (do (send {:id 3, :op "add-middleware", :session s
l-session, :middleware []}) (conj result :added-middleware)) (or (and (= 3 id) (status? :done status
)) (and (= name (str "foo/" ns ".clj")) (status? :sideloader-lookup status))) (do (send {:session sl
-session, :id 1, :op "sideloader-provide", :content (string->content (str "(prn 'xx) (ns foo." ns ")
 (prn 'yy) (defn hello [] \"Hello!\")")), :type "resource", :name (str "foo/" ns ".clj")}) (conj res
ult :provided-ns)) (status? :sideloader-lookup status) (do (send {:session sl-session, :id 1, :op "s
ideloader-provide", :content "", :type type, :name name}) result) (and (= 2 id) (status? :done statu
s)) (do (send {:id 4, :op "eval", :session sl-session, :code (str "(foo." ns "/hello)")}) result) (a
nd (= 4 id) value) (conj result [:eval-ok value]) (and (= 4 id) (status? :done status)) (reduced res
ult) :else result)) [] res))
  actual: (not (= [:added-middleware :provided-ns :provided-ns [:eval-ok "\"Hello!\""]] []))
```