### PR TITLE
Use Large resource classes in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ defaults: &defaults
   environment:
     LEIN_ROOT: "true"   # we intended to run lein as root
     JVM_OPTS: -Xmx3200m # limit the maximum heap size to prevent out of memory errors
+  resource_class: large # default is medium. large (may) give us more consistent CI results
 
 # Runners for OpenJDK
 


### PR DESCRIPTION
This change makes use of the "Large" resource class that CircleCI recently enabled for free plans.

Based on [~~two~~ three test runs](https://app.circleci.com/pipelines/github/shen-tian/nrepl), this doesn't necessarily run tests faster (our tests are single thread bound?), but I did get ✅  in CI both times, so hope it improved CI consistency.

It does come at the cost of 33% more credits, but I assume the nrepl org is not burning through all our credits as it stands.