### PR TITLE
[graalvm] Make compatible with graalvm native image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#231](https://github.com/nrepl/nrepl/issues/231): Fix sanitize error when file is `java.net.URL`.
 * [#208](https://github.com/nrepl/nrepl/issues/208): Fix namespace resolution in the cmdline REPL.
 * [#248](https://github.com/nrepl/nrepl/pull/248): Create fewer new classloaders
+* [#258](https://github.com/nrepl/nrepl/pull/258): Make compatible with graalvm native image.
 
 ## 0.8.3 (2020-10-25)
 

--- a/src/clojure/nrepl/bencode.clj
+++ b/src/clojure/nrepl/bencode.clj
@@ -10,8 +10,7 @@
   "A netstring and bencode implementation for Clojure."
   {:author "Meikel Brandmeyer"}
   (:require [clojure.java.io :as io])
-  (:import clojure.lang.RT
-           [java.io ByteArrayOutputStream
+  (:import [java.io ByteArrayOutputStream
             EOFException
             InputStream
             IOException
@@ -313,14 +312,16 @@
   'namespace/name'."
   (fn [_output thing]
     (cond
-      (instance? (RT/classForName "[B") thing) :bytes
+      (nil? thing) :list
+      ;; borrowed from Clojure 1.9's bytes? predicate:
+      (-> thing class .getComponentType (= Byte/TYPE)) :bytes
       (instance? InputStream thing) :input-stream
       (integer? thing) :integer
       (string? thing)  :string
       (symbol? thing)  :named
       (keyword? thing) :named
       (map? thing)     :map
-      (or (nil? thing) (coll? thing) (.isArray (class thing))) :list
+      (or (coll? thing) (.isArray (class thing))) :list
       :else (type thing))))
 
 (defmethod write-bencode :default

--- a/src/clojure/nrepl/util/completion.clj
+++ b/src/clojure/nrepl/util/completion.clj
@@ -168,16 +168,18 @@
   (.. file (replace ".class" "") (replace File/separator ".")))
 
 (def top-level-classes
-  (misc/noisy-future
-   (doall
-    (for [file classfiles :when (re-find #"^[^\$]+\.class" file)]
-      (classname file)))))
+  (delay
+   @(misc/noisy-future
+     (doall
+      (for [file classfiles :when (re-find #"^[^\$]+\.class" file)]
+        (classname file))))))
 
 (def nested-classes
-  (misc/noisy-future
-   (doall
-    (for [file classfiles :when (re-find #"^[^\$]+(\$[^\d]\w*)+\.class" file)]
-      (classname file)))))
+  (delay
+   @(misc/noisy-future
+     (doall
+      (for [file classfiles :when (re-find #"^[^\$]+(\$[^\d]\w*)+\.class" file)]
+        (classname file))))))
 
 (defn resolve-class [ns sym]
   (try (let [val (ns-resolve ns sym)]

--- a/src/clojure/nrepl/util/completion.clj
+++ b/src/clojure/nrepl/util/completion.clj
@@ -168,6 +168,7 @@
   (.. file (replace ".class" "") (replace File/separator ".")))
 
 (def top-level-classes
+  ;; Avoid using future directly on top-level for graalvm compatibility
   (delay
    @(misc/noisy-future
      (doall
@@ -175,6 +176,7 @@
         (classname file))))))
 
 (def nested-classes
+  ;; Avoid using future directly on top-level for graalvm compatibility
   (delay
    @(misc/noisy-future
      (doall


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [X] All tests are passing
- [X] The new code is not generating reflection warnings
- [ ] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)


I was hacking to use nrepl on clojure-lsp as an enhancement, and for that would be necessary to nrepl be graalvm compile compatible, I realized that to achieve that would need only a few changes, so this PR addresses that:
- Change some top-level `def`s to `defn` as graal tries to analyze that code at build time instead of runtime as this is a recommendation for Clojure graalvm compiled libraries.

I tested a simple `nrepl.core/connect` and sent a simple eval and everything worked, maybe we may need to tweak a little more later for full nrepl compatibility 