### PR TITLE
BufferedOutputChannel/write: fix SocketChannel/write call

### DIFF
--- a/src/clojure/nrepl/socket.clj
+++ b/src/clojure/nrepl/socket.clj
@@ -204,7 +204,7 @@
     (if (> length (.capacity buffer))
       (do
         (.flush this)
-        (.write channel (ByteBuffer/wrap byte-array) offset length))
+        (.write channel (ByteBuffer/wrap byte-array offset length)))
       (do
         (when (> length (.remaining buffer))
           (.flush this))


### PR DESCRIPTION
The offset and length (.write channel ...) variant is a gathering
operation, and so expects a vector of ByteBuffers.  Switch to the
non-gathering variant, and handle the offset and length in the
ByteBuffer wrapper.

Without the fix, cider connections would cause exceptions like this:
```
  Exception updating the ns-cache #error {
   :cause class java.nio.HeapByteBuffer cannot be cast to class [Ljava.nio.ByteBuffer; (java.nio.HeapByteBuffer and [Ljava.nio.ByteBuffer; are in module java.base of loader 'bootstrap')
   :via
   [{:type java.lang.ClassCastException
     :message class java.nio.HeapByteBuffer cannot be cast to class [Ljava.nio.ByteBuffer; (java.nio.HeapByteBuffer and [Ljava.nio.ByteBuffer; are in module java.base of loader 'bootstrap')
     :at [nrepl.socket.BufferedOutputChannel write socket.clj 207]}]
   :trace
   [[nrepl.socket.BufferedOutputChannel write socket.clj 207]
    [nrepl.socket.BufferedOutputChannel write socket.clj 202]
    [nrepl.transport$safe_write_bencode invokeStatic transport.clj 112]
  ...
```

Thanks to Herwig Hochleitner for reporting the problem.
