### PR TITLE
Make junixdomain integration forward compatible with 2.5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#279](https://github.com/nrepl/nrepl/pull/279): Allow reader conditionals for tty transport.
 * [#217](https://github.com/nrepl/nrepl/pull/270): Add nREPL client support for unix domain sockets.
+* [#281](https://github.com/nrepl/nrepl/pull/281): Make unix domain socket integration compatible with [junixsocket](https://kohlschutter.github.io/junixsocket/) versions >= 2.5.0.
 
 ## 0.9.0 (2021-12-12)
 

--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
                     :test-selectors {:default (complement :min-java-version)}
                     :aliases {"test" "test2junit"}}
              :junixsocket {:jvm-opts ["-Dnrepl.test.junixsocket=true"]
-                           :dependencies [[com.kohlschutter.junixsocket/junixsocket-core "2.3.2"]]}
+                           :dependencies [[com.kohlschutter.junixsocket/junixsocket-core "2.5.1" :extension "pom"]]}
              :clj-kondo {:dependencies [[clj-kondo "2022.01.15"]]}
              ;; Clojure versions matrix
              :provided {:dependencies [[org.clojure/clojure "1.10.2"]]}


### PR DESCRIPTION
Starting from version 2.5.0, the constructor of
`org.newsclub.net.unix.AFUNIXSocketAddress` which was used by
`junix-address-of` is private. However, since 2.4.0 an equivalent `of`
factory method is available. This patch makes the code compatible with
both generations of the library.

Before submitting a PR make sure the following things have been done:

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s): I bumped the `junixsocket` dependency so that the tests now run against that latest version. Alternatively, we could have one test run with the old version and one with the new instead. Let me know if you'd prefer that.
- [X] All tests are passing
- [X] The new code is not generating reflection warnings
- [X] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

Thanks!

*If you're just starting out to hack on nREPL you might find this [section of its
manual][1] extremely useful.*

[1]: https:/nrepl.org/nrepl/hacking_on_nrepl.html
