### PR TITLE
Fix dropped accept-connection promise recursion

### DIFF
--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -197,17 +197,23 @@
                         (atom #{})
                         transport-fn
                         greeting-fn
-                        (or handler (default-handler)))]
-    (noisy-future
-     (try
-       (accept-connection server)
-       (catch Throwable t
-         (cond consume-exception
-               (consume-exception t)
-               (instance? SocketException t)
-               nil
-               :else
-               (throw t)))))
+                        (or handler (default-handler)))
+        accept-connections (fn accept-connections []
+                             (noisy-future
+                              (try
+                                (accept-connection server)
+                                (catch Throwable t
+                                  (cond consume-exception
+                                        (consume-exception t)
+                                        (instance? SocketException t)
+                                        nil
+                                        :else
+                                        (throw t)))
+                                (finally (accept-connections)))))]
+    (try
+      (accept-connections)
+      (catch SocketException _
+        nil))
     (when ack-port
       (ack/send-ack (:port server) ack-port transport-fn))
     server))


### PR DESCRIPTION
When TLS was introduced in https://github.com/nrepl/nrepl/pull/283 the ability to consume an exception was introduced so that we could catch SSL related exceptions. This introduced an issue where the first failed SSL connection would be handled, but further connections would no longer be accepted.

This PR introduces a recursive function accept-connections in start-server so that the first caught SSL connection does not prevent future good connections from being handled.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

Thanks!

*If you're just starting out to hack on nREPL you might find this [section of its
manual][1] extremely useful.*

[1]: https:/nrepl.org/nrepl/hacking_on_nrepl.html
