### PR TITLE
Extend timeouts in cmdline tests to accommodate slower hosts

### DIFF
--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -152,7 +152,7 @@
                                   "nrepl.main"
                                   "--ack" (str ack-port)
                                   "--transport" (var->str *transport-fn*)])
-        acked-port (ack/wait-for-ack 10000)]
+        acked-port (ack/wait-for-ack 100000)]
     (try
       (is acked-port "Timed out waiting for ack")
       (when acked-port
@@ -182,7 +182,7 @@
                                   "--port" (str free-port)
                                   "--ack" (str ack-port)
                                   "--transport" (var->str *transport-fn*)])
-        acked-port (ack/wait-for-ack 10000)]
+        acked-port (ack/wait-for-ack 100000)]
     (try
       (is (= acked-port free-port))
       (finally


### PR DESCRIPTION
The tests were failing on the Debian arm64 buildd's, and it turns out that's because those machines take longer to start the subprocesses that the tests need.  To allow the tests to succeed, increase the wait times in cmdline-test and cmdline-tty-test, and rework the tty-server test to be able to detect when the server is available instead of just sleeping unconditionally.  That should also allow the test to run faster on faster machines.

Thanks to Louis-Philippe Véronneau for reporting the problem.
