### PR TITLE
circleci win and clj 1.11 support, fix completion issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ version: 2.1
 
 # Default settings for executors
 
+orbs:
+  win: circleci/windows@5.0.0
+
 defaults: &defaults
   working_directory: ~/repo
   environment:
@@ -34,8 +37,6 @@ executors:
 # Runs a given set of steps, with some standard pre- and post-
 # steps, including restoring of cache, saving of cache.
 #
-# we also install `make` here.
-#
 # Adapted from https://github.com/lambdaisland/meta/blob/master/circleci/clojure_orb.yml
 
 commands:
@@ -60,9 +61,11 @@ commands:
         default: "1"
     steps:
       - run:
-          name: Install make
+          name: Install babashka latest
           command: |
-            sudo apt-get install make
+            bash <(curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install) --dir ~
+            sudo mv ~/bb /usr/local/bin/bb
+
       - run:
           name: Generate Cache Checksum
           command: |
@@ -79,6 +82,30 @@ commands:
             - .cpcache
             - repo
           key: clojure-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
+
+  setup-windows:
+    steps:
+      - checkout
+      - run:
+          name: Install scoop latest
+          command: |
+            iwr get.scoop.sh -outfile 'install.ps1'                                          ; if(-not $?){exit 9}
+            .\install.ps1 -RunAsAdmin                                                        ; if(-not $?){exit 9}
+            scoop bucket add scoop-clojure https://github.com/littleli/scoop-clojure         ; if(-not $?){exit 9}
+            scoop bucket add extras                                                          ; if(-not $?){exit 9}
+            New-Item -Path $PROFILE -ItemType "file" -Force                                  ; if(-not $?){exit 9}
+            add-content $PROFILE $("`$env:PATH=""$(Resolve-Path ~\scoop\shims);`$env:PATH"""); if(-not $?){exit 9}
+            Write-host $env:PATH                                                             ; if(-not $?){exit 9}
+
+      - run:
+          name: Install babashka latest
+          command:
+            scoop install babashka
+
+      - run:
+          name: Install lein latest
+          command:
+            scoop install leiningen
 
 ######################################################################
 #
@@ -128,123 +155,162 @@ jobs:
           steps:
             - run:
                 name: Running tests
-                command: make test
+                command: bb test
             - store_test_results:
                 path: test-results
 
+  test_code_win_java_system:
+    description: |
+      Run tests on MS-Windows using the system's JDK version and given
+      CLOJURE_VERSION.
+    executor: win/default
+    parameters:
+      clojure_version:
+        description: Version of Clojure to test against
+        type: string
+    steps:
+      - setup-windows
+      - run:
+          name: run tests
+          command: |
+            java -version; if(-not $?){exit 9}
+            bb test      ; if(-not $?){exit 9}
+
 # The ci-test-matrix does the following:
 #
-# - run tests against the target matrix
-#   - Java 8, 11 and 15
-#   - Clojure 1.7, 1.8, 1.9, 1.10, master
-# - linter, eastwood and cljfmt
-# - verifies cljdoc config
-# - runs code coverage report
+# - Linux
+#   - run tests against the target matrix
+#     - Java 8, 11 and 15
+#     - Clojure 1.7, 1.8, 1.9, 1.10, 1.11 master
+#   - linter, eastwood and cljfmt
+#   - verifies cljdoc config
+#   - runs code coverage report
+# - MS-Windows
+#   - run tests against installed java version and Clojure 1.11
 
 workflows:
   version: 2.1
   ci-test-matrix:
     jobs:
       - test_code:
-          name: Java 8, Clojure 1.7
+          name: Lnx, Java 8, Clj 1.7
           clojure_version: "1.7"
           jdk_version: openjdk8
       - test_code:
-          name: Java 8, Clojure 1.8
+          name: Lnx, Java 8, Clj 1.8
           clojure_version: "1.8"
           jdk_version: openjdk8
       - test_code:
-          name: Java 8, Clojure 1.9
+          name: Lnx, Java 8, Clj 1.9
           clojure_version: "1.9"
           jdk_version: openjdk8
       - test_code:
-          name: Java 8, Clojure 1.10
+          name: Lnx, Java 8, Clj 1.10
           clojure_version: "1.10"
           jdk_version: openjdk8
       - test_code:
-          name: Java 8, Clojure master
+          name: Lnx, Java 8, Clj 1.11
+          clojure_version: "1.11"
+          jdk_version: openjdk8
+      - test_code:
+          name: Lnx, Java 8, Clj master
           clojure_version: "master"
           jdk_version: openjdk8
       - test_code:
-          name: Java 11, Clojure 1.7
+          name: Lnx, Java 11, Clj 1.7
           clojure_version: "1.7"
           jdk_version: openjdk11
       - test_code:
-          name: Java 11, Clojure 1.8
+          name: Lnx, Java 11, Clj 1.8
           clojure_version: "1.8"
           jdk_version: openjdk11
       - test_code:
-          name: Java 11, Clojure 1.9
+          name: Lnx, Java 11, Clj 1.9
           clojure_version: "1.9"
           jdk_version: openjdk11
       - test_code:
-          name: Java 11, Clojure 1.10
+          name: Lnx, Java 11, Clj 1.10
           clojure_version: "1.10"
           jdk_version: openjdk11
       - test_code:
-          name: Java 11, Clojure master
+          name: Lnx, Java 11, Clj 1.11
+          clojure_version: "1.11"
+          jdk_version: openjdk11
+      - test_code:
+          name: Lnx, Java 11, Clj master
           clojure_version: "master"
           jdk_version: openjdk11
       - test_code:
-          name: Java 17, Clojure 1.7
+          name: Lnx, Java 17, Clj 1.7
           clojure_version: "1.7"
           jdk_version: openjdk17
       - test_code:
-          name: Java 17, Clojure 1.8
+          name: Lnx, Java 17, Clj 1.8
           clojure_version: "1.8"
           jdk_version: openjdk17
       - test_code:
-          name: Java 17, Clojure 1.9
+          name: Lnx, Java 17, Clj 1.9
           clojure_version: "1.9"
           jdk_version: openjdk17
       - test_code:
-          name: Java 17, Clojure 1.10
+          name: Lnx, Java 17, Clj 1.10
           clojure_version: "1.10"
           jdk_version: openjdk17
       - test_code:
-          name: Java 17, Clojure master
+          name: Lnx, Java 17, Clj 1.11
+          clojure_version: "1.11"
+          jdk_version: openjdk17
+      - test_code:
+          name: Lnx, Java 17, Clj master
           clojure_version: "master"
           jdk_version: openjdk17
       # Add back in when Java 18 is released
       # - test_code:
-      #     name: Java 18, Clojure 1.7
+      #     name: Lnx, Java 18, Clj 1.7
       #     clojure_version: "1.7"
       #     jdk_version: openjdk18
       # - test_code:
-      #     name: Java 18, Clojure 1.8
+      #     name: Lnx, Java 18, Clj 1.8
       #     clojure_version: "1.8"
       #     jdk_version: openjdk18
       # - test_code:
-      #     name: Java 18, Clojure 1.9
+      #     name: Lnx, Java 18, Clj 1.9
       #     clojure_version: "1.9"
       #     jdk_version: openjdk18
       # - test_code:
-      #     name: Java 18, Clojure 1.10
+      #     name: Lnx, Java 18, Clj 1.10
       #     clojure_version: "1.10"
       #     jdk_version: openjdk18
       # - test_code:
-      #     name: Java 18, Clojure master
+      #     name: Lnx, Java 18, Clj 1.11
+      #     clojure_version: "1.11"
+      #     jdk_version: openjdk18
+      # - test_code:
+      #     name: Lnx, Java 18, Clj master
       #     clojure_version: "master"
       #     jdk_version: openjdk18
+      - test_code_win_java_system:
+          name: Win, Java sys, Clj 1.11
+          clojure_version: "1.11"
       - util_job:
           name: Code Linting
           steps:
             - run:
                 name: Running Eastwood
                 command: |
-                  make eastwood
+                  bb eastwood
             - run:
                 name: Running cljfmt
                 command: |
-                  make cljfmt
+                  bb cljfmt
             - run:
                 name: Running clj-kondo
                 command: |
-                  make kondo
+                  bb kondo
       - util_job:
           name: Checking Cljdoc
           steps:
             - run:
                 name: Verifying Cljdoc
                 command: |
-                  make verify_cljdoc
+                  bb verify_cljdoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#266](https://github.com/nrepl/nrepl/pull/266): Add TLS support.
 
+### Bugs fixed
+
+* [#291](https://github.com/nrepl/nrepl/pull/291): Fix issue with completion middleware not returning values for local class files, or .jar files on windows.
+
 ## 1.0.0 (2022-08-24)
 
 ### New Features

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,62 @@
+{:tasks
+ {:requires [[babashka.fs :as fs]
+             [babashka.process :as p]]
+  :init (do (def clj-version
+              "The clj version to use with lein tasks."
+              (or (first *command-line-args*) (System/getenv "VERSION") "1.11"))
+            (def bump
+              "The release BUMP field."
+              (or (second *command-line-args*) (System/getenv "BUMP") "patch"))
+
+            (def lein
+              "The full path to lein."
+              (str (or (fs/which "lein")
+                       (throw (Exception. "Cannot find lein in PATH."))))))
+
+  *DEFAULTS* {:doc "VERSION: either the VERSION envvar or \"1.11\". BUMP: either the BUMP envvar or \"patch\"."}
+  test  {:doc "Run tests for given Clojure VERSION arg."
+         :task
+         ;; We use kaocha on Clojure 1.9+, but revert to lein's built in
+         ;; runner with Clojure 1.7 and 1.8.
+         (if (#{"1.7" "1.8"} clj-version)
+           (do
+             (shell lein "with-profile" (str "-user,+" clj-version ",+test") "test")
+             (shell lein "with-profile" (str "-user,+" clj-version ",+test,+junixsocket") "test"))
+           (do
+             (shell lein "with-profile" (str "-user,+" clj-version ",+test") "run" "-m" "kaocha.runner")
+             (shell lein
+                    "with-profile" (str "-user,+" clj-version ",+test,+junixsocket") "run" "-m" "kaocha.runner")))}
+
+  eastwood {:doc "Run eastwood for given Clojure VERSION arg."
+            :task (shell lein "with-profile" (str "-user,+" clj-version ",+eastwood") "eastwood")}
+
+  cljfmt {:doc "Run cljfmt for given Clojure VERSION arg."
+          :task (shell lein "with-profile" (str "-user,+" clj-version ",+cljfmt") "cljfmt" "check")}
+
+  kondo {:doc "Run clj-kondo for given Clojure VERSION arg."
+         :task (shell lein "with-profile" "+clj-kondo" "run" "-m" "clj-kondo.main" "--lint" "src")}
+
+  cloverage {:doc "Run cloverage for given Clojure VERSION arg."
+             :task (shell lein "with-profile" (str "-user,+" clj-version ",+cloverage") "cloverage" "--codecov")}
+
+  check {:doc "run all tests and linters for given Clojure VERSION arg."
+         ;; Roughly match what runs in CI using the current JVM check
+         :depends [test eastwood kondo cljfmt cloverage]}
+
+  verify_cljdoc (-> (p/shell {:out :string}
+                             "curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn")
+                    (p/shell "bash -s doc/cljdoc.edn"))
+
+  release  {:doc "Perform lein release tasks for given Clojure VERSION and BUMP field args. BUMP controls which field in the version string will be incremented in the *next* snapshot version. Typically this is either \"major\", \"minor\", or \"patch\"."
+            :tasks (shell lein "with-profile" (str "-user,+" clj-version) "release" bump)}
+
+  deploy  {:doc "Deploy to clojars for given Clojure VERSION arg. Auth is controlled by the `clojars_username` and `clojars_password` envvars."
+           ;; Deploying requires the caller to set environment variables as
+           ;; specified in project.clj to provide a login and password to the
+           ;; artifact repository.
+           :task (shell lein "with-profile" (str "-user,+" clj-version) "deploy" "clojars")}
+
+  clean  {:doc "Clean artifacts."
+          :task (shell lein "clean")}}}
+
+

--- a/doc/modules/ROOT/pages/hacking_on_nrepl.adoc
+++ b/doc/modules/ROOT/pages/hacking_on_nrepl.adoc
@@ -113,11 +113,11 @@ $ lein test-all
 === Running tests on CI
 
 For ease of use/consistency with other nREPL projects, tests are ran on CI
-environments using a `Makefile`, with the command:
+environments using a https://github.com/babashka/babashka[babashka], with the command:
 
 [source,shell]
 ----
-$ make test
+$ bb test
 ----
 
 this will check the `VERSION` environmental variable, and switch between Kaocha

--- a/doc/modules/ROOT/pages/usage/tls.adoc
+++ b/doc/modules/ROOT/pages/usage/tls.adoc
@@ -97,7 +97,7 @@ NOTE: The `openssl` curve parameters do not exactly match the ones used by the `
 
 == Starting the nREPL server
 
-Here's how you can start nREPL programatically with TLS enabled:
+Here's how you can start nREPL programmatically with TLS enabled:
 
 [source,clojure]
 ----

--- a/project.clj
+++ b/project.clj
@@ -35,6 +35,7 @@
                                    [commons-net/commons-net "3.6"]
                                    [lambdaisland/kaocha "1.0.672"]
                                    [lambdaisland/kaocha-junit-xml "0.0.76"]]
+                    :java-source-paths ["test/java"]
                     :plugins      [[test2junit "1.4.2"]]
                     :test2junit-output-dir "test-results"
                     ;; This skips any tests that doesn't work on all java versions

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   :javac-options ["-target" "8" "-source" "8"]
 
   :aliases {"bump-version" ["change" "version" "leiningen.release/bump-version"]
-            "test-all" ["with-profile" "+1.7:+1.8:+1.9:+1.10:+fastlane:+junixsocket" "test"]
+            "test-all" ["with-profile" "+1.7:+1.8:+1.9:+1.10:1.11:+fastlane:+junixsocket" "test"]
             "docs" ["with-profile" "+maint" "run" "-m" "nrepl.impl.docs" "--file"
                     ~(clojure.java.io/as-relative-path
                       (clojure.java.io/file "doc" "modules" "ROOT" "pages" "ops.adoc"))]
@@ -46,15 +46,17 @@
                            :dependencies [[com.kohlschutter.junixsocket/junixsocket-core "2.5.1" :extension "pom"]]}
              :clj-kondo {:dependencies [[clj-kondo "2022.01.15"]]}
              ;; Clojure versions matrix
-             :provided {:dependencies [[org.clojure/clojure "1.10.2"]]}
+             :provided {:dependencies [[org.clojure/clojure "1.11.1"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.2"]]
                     :source-paths ["src/spec"]}
+             :1.11 {:dependencies [[org.clojure/clojure "1.11.1"]]
+                    :source-paths ["src/spec"]}
              :master {:repositories [["snapshots"
                                       "https://oss.sonatype.org/content/repositories/snapshots"]]
-                      :dependencies [[org.clojure/clojure "1.11.0-master-SNAPSHOT"]]}
+                      :dependencies [[org.clojure/clojure "1.12.0-master-SNAPSHOT"]]}
 
              ;;; Maintenance profile
              ;;

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -127,8 +127,8 @@
                                    {:ack-port 8000
                                     :transport #'transport/bencode
                                     :verbose true}))]
-      (is (= "ack'ing my port 6000 to other server running on port 8000\n"
-             output)))
+      (is (th/string= "ack'ing my port 6000 to other server running on port 8000\n"
+                      output)))
     (let [output (with-out-str
                    (cmd/ack-server {:port 6000}
                                    {:ack-port 8000

--- a/test/clojure/nrepl/misc_test.clj
+++ b/test/clojure/nrepl/misc_test.clj
@@ -1,6 +1,7 @@
 (ns nrepl.misc-test
   (:require [clojure.test :refer [deftest is]]
             [nrepl.misc :as misc]
+            [nrepl.test-helpers :as th]
             [clojure.java.io :as io])
   (:import [java.net URL]))
 
@@ -10,7 +11,7 @@
   (is (= "/foo/bar/baz.clj"
          (:file (misc/sanitize-meta {:file "/foo/bar/baz.clj"}))))
 
-  (is (= "/foo/bar/baz.clj"
+  (is (= (th/dir-sep->sys "/foo/bar/baz.clj")
          (:file (misc/sanitize-meta {:file (io/file "/foo/bar/baz.clj")}))))
 
   (is (= "https://foo.bar"

--- a/test/clojure/nrepl/sanity_test.clj
+++ b/test/clojure/nrepl/sanity_test.clj
@@ -6,6 +6,7 @@
    [nrepl.middleware.print :as print]
    [nrepl.middleware.session :as session]
    [nrepl.misc :as misc]
+   [nrepl.test-helpers :as th]
    [nrepl.transport :as transport :refer [piped-transports]])
   (:import
    (java.util.concurrent BlockingQueue LinkedBlockingQueue TimeUnit)))
@@ -98,6 +99,6 @@
 
     (is (= [(str "println" (System/getProperty "line.separator"))
             "abcdefghijm "
-            "\n#{}\n"]
+            (th/newline->sys "\n#{}\n")]
            (->> (nrepl/response-seq local 0)
                 (map :out))))))

--- a/test/clojure/nrepl/test_helpers.clj
+++ b/test/clojure/nrepl/test_helpers.clj
@@ -1,0 +1,37 @@
+(ns nrepl.test-helpers
+  (:require [clojure.string :as str])
+  (:import [java.io File]))
+
+(def sys-newline
+  "The system's newline character sequence."
+  (System/lineSeparator))
+
+(def win?
+  "Whether we are running on MS-Windows."
+  (.startsWith (System/getProperty "os.name") "Windows"))
+
+(defn string=
+  "Like `clojure.core/=` applied on STRING1 and STRING2, but treats
+  all line endings as equal."
+  [string1 string2]
+  (= (str/split-lines string1) (str/split-lines string2)))
+
+(defn newline->sys
+  "Returns TEXT, converting `\n` line endings to those of the underlying
+  system's, if different."
+  [text]
+  (if-not (= sys-newline "\n")
+    (str/replace text "\n" sys-newline)
+    text))
+
+(def sys-file-sep
+  "The character separating components in a path."
+  File/separator)
+
+(defn dir-sep->sys
+  "Replace the `/` separator component used in tests with the one used
+  by the system."
+  [path]
+  (if-not (= sys-file-sep "/")
+    (str/replace path "/" sys-file-sep)
+    path))

--- a/test/clojure/nrepl/util/completion_test.clj
+++ b/test/clojure/nrepl/util/completion_test.clj
@@ -47,6 +47,11 @@
          #{"clojure.core" "clojure.core.ArrayChunk" "clojure.core.ArrayManager" "clojure.core.IVecImpl" "clojure.core.Vec" "clojure.core.VecNode" "clojure.core.VecSeq" "clojure.core.protocols" "clojure.core.protocols.InternalReduce"}
          (set (candidates "clojure.co")))))
 
+  (testing "namespace completion with java classes"
+    (is (set/subset?
+         #{"nrepl.test.Dummy"}
+         (set (candidates "nrepl.t")))))
+
   (testing "Java instance methods completion"
     (is (= '(".toUpperCase")
            (candidates ".toUpper")))

--- a/test/java/nrepl/test/Dummy.java
+++ b/test/java/nrepl/test/Dummy.java
@@ -1,0 +1,5 @@
+package nrepl.test;
+
+public class Dummy extends Throwable {
+
+}


### PR DESCRIPTION
Hi,

could you please review patch to add circleci test support for MS-Windows. It addresses #291.

I've also took the opportunity to move Clojure version to 1.11 in `project.clj` and include that version in ci tests.

Changes are
1. Introduce functions in `test/nrepl/test_helpers.clj` to handle difference in newlines (`\n` vs `\r\n` on windows) and file separators (`/` vs `\` on windows) in test results and use them in failing tests as such.
2. Skipped tests that had to do with unix sockets on windows.
3. Placed `sh` std in/out/err streams in a future because one (all?) are blocking calls on windows (I haven't really looked into the details, but I took it, in my experience, as a legit thing to do).
4. Wrapped the `:transport-fn` in `nrepl.tls-test/bad-keys` in a try catch block because there appears to be a (race?) condition in the nrepl mechanism that the transport layer could try to send data to the a client even though the initial connection has thrown an exception. I haven't looked into the details why that is, but I thought this is a straightforward workaround to catch the exception. @ivarref , could you please assess/review this change in `tls_test.clj` please? There is also another intermittent unix exception seen from bad-keys test as per https://gist.github.com/ikappaki/6958e8d7689eb916a887d78be93b0b87 in this PR that I need your input please. It seems that `nrepl/message` can also throw a `javax.net.ssl.SSLHandshakeExceptio` in addition to `SocketException`?
5. Fixed issues with completion middleware 
  a. local class file paths were returned starting with a dot, i.e.  `.<package>.<classname>`, and added a test for it (subtracting the base directory name from the filename left a `/` at the front of the subtraction result).
  b. .jar file completion did not work on windows (files inside a jar were always returned using `/` but the old code was using the system file separator -- `\` on windows -- to convert them into dots).
7. Added circle ci windows test, but for convenience only using the java version found on the system and the latest Clojure version 1.11.
8. While at it, I've used Clojure 1.11 as the default version in `project.clj` and added it to circle ci tests.
9. Prefixed circle ci test names with `U` (for Unix) and `W` (for Windows) so that we know which one it in the web page, and also shorted the name of `Clojure` to `Clj` because it doesn't fit any more in the output.

I'm also thinking of converting the `Makefile` to babashka `bb.edn` so that the commands can be used seamlessly both on Linux and windows (`make` is not a standard command on windows) . What do you think?

Thanks,

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

