### PR TITLE
[completion] Use compliment-lite for code completion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,9 +289,9 @@ workflows:
       #     name: Lnx, Java 18, Clj master
       #     clojure_version: "master"
       #     jdk_version: openjdk18
-      - test_code_win_java_system:
-          name: Win, Java sys, Clj 1.11
-          clojure_version: "1.11"
+      # - test_code_win_java_system:
+      #     name: Win, Java sys, Clj 1.11
+      #     clojure_version: "1.11"
       - util_job:
           name: Code Linting
           steps:

--- a/project.clj
+++ b/project.clj
@@ -76,6 +76,7 @@
 
              :cljfmt {:plugins [[lein-cljfmt "0.8.0"]]
                       :cljfmt {:indents {as-> [[:inner 0]]
+                                         cache-last-result [[:block 2]]
                                          with-debug-bindings [[:inner 0]]
                                          merge-meta [[:inner 0]]
                                          returning [[:inner 0]]

--- a/src/clojure/nrepl/util/completion.clj
+++ b/src/clojure/nrepl/util/completion.clj
@@ -1,319 +1,688 @@
 (ns nrepl.util.completion
   "Code completion functionality.
 
-  The functionality here is experimental and
-  the API is subject to changes."
-  {:author "Bozhidar Batsov"
+  This namespace is based on compliment-lite.
+  (https://github.com/alexander-yakushev/compliment/tree/master/lite)
+
+  The functionality here is experimental and the API is subject to changes."
+  {:author "Oleksandr Yakushev, Bozhidar Batsov"
    :added  "0.8"}
-  (:require [clojure.main]
-            [nrepl.misc :as misc])
-  (:import [java.util.jar JarFile]
-           [java.io File]
-           [java.lang.reflect Field Member]
-           [java.util.jar JarEntry]
-           [java.util.concurrent ConcurrentHashMap]))
+  (:import java.io.File
+           java.nio.file.Files
+           (java.util.function Function Predicate)
+           java.util.concurrent.locks.ReentrantLock
+           (java.util.jar JarEntry JarFile)
+           java.util.stream.Collectors
+           (java.lang.reflect Field Member Method Modifier)
+           (java.util Comparator HashSet)))
 
-;; Code adapted from Compliment (https://github.com/alexander-yakushev/compliment)
+;; Compliment lite was generated at Tue Nov 14 01:00:10 EET 2023
+;; SPDX-License-Identifier: EPL-1.0
 
-(defn annotate-keyword
-  [kw]
-  {:candidate kw :type :keyword})
+;; compliment/utils.clj
 
-(defn all-keywords
-  []
-  (let [^Field field (.getDeclaredField clojure.lang.Keyword "table")]
-    (.setAccessible field true)
-    (.keySet ^ConcurrentHashMap (.get field nil))))
+(def ^{:dynamic true} *extra-metadata*
+  "Signals to downstream sources which additional information about completion\n  candidates they should attach . Should be a set of keywords."
+  nil)
 
-(defn- resolve-namespace
+(defn split-by-leading-literals
+  "Separate quote/var/deref qualifiers from a var name."
+  [symbol-str]
+  (next (re-matches #"(@{0,2}#'|'|@)?(.*)" symbol-str)))
+
+(set! *unchecked-math* true)
+
+(defn fuzzy-matches?
+  "Tests if symbol matches the prefix when symbol is split into parts on\n  separator."
+  [^String prefix ^String symbol ^Character separator]
+  (let [pn (.length prefix)
+        sn (.length symbol)]
+    (or (= pn 0)
+        (and (> sn 0)
+             (= (.charAt prefix 0) (.charAt symbol 0))
+             (loop [pi 1
+                    si 1
+                    skipping false]
+               (cond (>= pi pn) true
+                     (>= si sn) false
+                     :else (let [pc (.charAt prefix pi)
+                                 sc (.charAt symbol si)
+                                 match (= pc sc)]
+                             (cond skipping (if (= sc separator)
+                                              (recur (if match (inc pi) pi)
+                                                     (inc si)
+                                                     false)
+                                              (recur pi (inc si) true))
+                                   match (recur (inc pi) (inc si) false)
+                                   :else (recur pi
+                                                (inc si)
+                                                (not (= pc separator)))))))))))
+
+(defn fuzzy-matches-no-skip?
+  "Tests if symbol matches the prefix where separator? checks whether character\n  is a separator. Unlike `fuzzy-matches?` requires separator characters to be\n  present in prefix."
+  [^String prefix ^String symbol separator?]
+  (let [pn (.length prefix)
+        sn (.length symbol)]
+    (or (= pn 0)
+        (and (> sn 0)
+             (= (.charAt prefix 0) (.charAt symbol 0))
+             (loop [pi 1
+                    si 1
+                    skipping false]
+               (cond (>= pi pn) true
+                     (>= si sn) false
+                     :else (let [pc (.charAt prefix pi)
+                                 sc (.charAt symbol si)]
+                             (cond skipping (if (separator? sc)
+                                              (recur pi si false)
+                                              (recur pi (inc si) true))
+                                   (= pc sc) (recur (inc pi) (inc si) false)
+                                   :else (recur pi (inc si) true)))))))))
+
+(set! *unchecked-math* false)
+
+(defn resolve-class
+  "Tries to resolve a classname from the given symbol, or returns nil\n  if classname can't be resolved."
+  [ns sym]
+  (when-let [val (try (ns-resolve ns sym)
+                      (catch ClassNotFoundException _))]
+    (when (class? val) val)))
+
+(defn resolve-namespace
+  "Tries to resolve a namespace from the given symbol, either from a\n  fully qualified name or an alias in the given namespace."
   [sym ns]
-  (get (ns-aliases ns) sym (find-ns sym)))
+  (or ((ns-aliases ns) sym) (find-ns sym)))
 
-(defn qualified-auto-resolved-keywords
-  "Given a namespace alias, a prefix, and a namespace, return completion
-  candidates for qualified, auto-resolved keywords (e.g. ::foo/bar)."
-  [ns-alias prefix ns]
-  (let [ns-alias-name (str (resolve-namespace (symbol ns-alias) ns))]
-    (sequence
-     (comp
-      (filter #(= (namespace %) ns-alias-name))
-      (filter #(.startsWith (name %) prefix))
-      (map #(str "::" ns-alias "/" (name %)))
-      (map annotate-keyword))
-     (all-keywords))))
+(def primitive-cache (atom {}))
 
-(defn unqualified-auto-resolved-keywords
-  "Given a prefix and a namespace, return completion candidates for
-  keywords that belong to the given namespace."
-  [prefix ns]
-  (sequence
-   (comp
-    (filter #(= (namespace %) (str ns)))
-    (filter #(.startsWith (name %) (subs prefix 2)))
-    (map #(str "::" (name %)))
-    (map annotate-keyword))
-   (all-keywords)))
+(let [lock (ReentrantLock.)]
+  (defn cache-last-result*
+    [name key value-fn]
+    (try (.lock lock)
+         (let [[cached-key cached-value :as t] (@primitive-cache name)]
+           (if (and t (= cached-key key))
+             cached-value
+             (let [value (value-fn)]
+               (swap! primitive-cache assoc name [key value])
+               value)))
+         (finally (.unlock lock)))))
 
-(defn keyword-namespace-aliases
-  "Given a prefix and a namespace, return completion candidates for namespace
-  aliases as auto-resolved keywords."
-  [prefix ns]
-  (sequence
-   (comp
-    (map (comp name first))
-    (filter (fn [^String alias-name] (.startsWith alias-name (subs prefix 2))))
-    (map #(str "::" (name %)))
-    (map annotate-keyword))
-   (ns-aliases ns)))
+(defmacro cache-last-result
+  "If cache for `name` is absent, or `key` doesn't match the key in the cache,
+  calculate `v` and return it. Else return value from cache."
+  {:style/indent 2}
+  [name key value]
+  `(cache-last-result* ~name ~key (fn [] ~value)))
 
-(defn single-colon-keywords
-  "Given a prefix, return completion candidates for keywords that are either
-  unqualified or qualified with a synthetic namespace."
-  [prefix]
-  (sequence
-   (comp
-    (filter #(.startsWith (str %) (subs prefix 1)))
-    (map #(str ":" %))
-    (map annotate-keyword))
-   (all-keywords)))
+(defn- classpath
+  "Returns a sequence of File objects of the elements on the classpath."
+  []
+  (mapcat #(some-> (System/getProperty %) (.split File/pathSeparator))
+          ["sun.boot.class.path" "java.ext.dirs" "java.class.path"
+           "fake.class.path"]))
 
-(defn keyword-candidates
-  [^String prefix ns]
-  (assert (string? prefix))
-  (let [double-colon? (.startsWith prefix "::")
-        single-colon? (.startsWith prefix ":")
-        slash-pos (.indexOf prefix "/")]
-    (cond
-      (and double-colon? (pos? slash-pos))
-      (let [ns-alias (subs prefix 2 slash-pos)
-            prefix (subs prefix (inc slash-pos))]
-        (qualified-auto-resolved-keywords ns-alias prefix ns))
+(defn- file-seq-nonr
+  "A tree seq on java.io.Files, doesn't resolve symlinked directories to avoid\n  infinite sequence resulting from recursive symlinked directories."
+  [dir]
+  (tree-seq (fn [^File f]
+              (and (.isDirectory f) (not (Files/isSymbolicLink (.toPath f)))))
+            (fn [^File d] (seq (.listFiles d)))
+            dir))
 
-      double-colon?
-      (into
-       (unqualified-auto-resolved-keywords prefix ns)
-       (keyword-namespace-aliases prefix ns))
+(defn- list-files
+  "Given a path (either a jar file, directory with classes or directory with\n  paths) returns all files under that path."
+  [^String path scan-jars?]
+  (cond (.endsWith path "/*") (for [^File jar (.listFiles (File. path))
+                                    :when (.endsWith (.getName jar) ".jar")
+                                    file (list-files (.getPath jar) scan-jars?)]
+                                file)
+        (.endsWith path ".jar")
+        (if scan-jars?
+          (try (-> (.stream (JarFile. path))
+                   (.filter (reify
+                              Predicate
+                              (test [_ entry]
+                                (not (.isDirectory ^JarEntry entry)))))
+                   (.map (reify
+                           Function
+                           (apply [_ entry] (.getName ^JarEntry entry))))
+                   (.collect (Collectors/toList)))
+               (catch Exception _))
+          ())
+        (= path "") ()
+        (.exists (File. path))
+        (let [root (File. path)
+              root-path (.toPath root)]
+          (for [^File file (file-seq-nonr root)
+                :when (not (.isDirectory file))]
+            (let [filename (str (.relativize root-path (.toPath file)))]
+              (cond-> filename
+                (not= File/separator "/") (.replace File/separator "/")
+                (.startsWith filename "/") (.substring filename 1)))))))
 
-      single-colon?
-      (single-colon-keywords prefix))))
+(defmacro list-jdk9-base-classfiles
+  "Because on JDK9+ the classfiles are stored not in rt.jar on classpath, but in
+  modules, we have to do extra work to extract them."
+  []
+  (if (resolve-class *ns* 'java.lang.module.ModuleFinder)
+    `(try (-> (.findAll (java.lang.module.ModuleFinder/ofSystem))
+              (.stream)
+              (.flatMap (reify Function
+                          (apply [_ mref#]
+                            (.list (.open ^java.lang.module.ModuleReference mref#)))))
+              (.collect (Collectors/toList)))
+          ;; Due to a bug in Clojure before 1.10, the above may fail.
+          (catch IncompatibleClassChangeError _# []))
+    ()))
 
-;; Code adapted from clojure-complete (https://github.com/ninjudd/clojure-complete)
-;; The results follow compliment's format, as it's richer and gives more useful
-;; data to clients.
+(defn- all-files-on-classpath
+  "Given a list of files on the classpath, returns the list of all files,\n  including those located inside jar files."
+  [classpath]
+  (cache-last-result :all-files-on-classpath classpath
+    (let [seen (java.util.HashMap.)
+          seen? (fn [x] (.putIfAbsent seen x x))]
+      (-> []
+          (into (comp (map #(list-files % true)) cat (remove seen?)) classpath)
+          (into (remove seen?) (list-jdk9-base-classfiles))))))
 
-;;; Utility functions
-(defn namespaces
-  "Returns a list of potential namespace completions for a given namespace"
-  [ns]
-  (concat (map ns-name (all-ns)) (keys (ns-aliases ns))))
+(defn classes-on-classpath
+  "Returns a map of all classes that can be located on the classpath. Key\n  represent the root package of the class, and value is a list of all classes\n  for that package."
+  []
+  (let [classpath (classpath)]
+    (cache-last-result :classes-on-classpath classpath
+      (let [roots (volatile! #{})
+            classes
+            (vec (for [^String file (all-files-on-classpath classpath)
+                       :when (and (.endsWith file ".class")
+                                  (not (.contains file "__"))
+                                  (not (.contains file "$"))
+                                  (not= file "module-info.class"))
+                       :let [c (-> (subs file 0 (- (.length file) 6))
+                                   (.replace "/" "."))
+                             _ (vswap!
+                                roots
+                                conj
+                                (subs c 0 (max (.indexOf ^String c ".") 0)))]]
+                   c))]
+        (swap! primitive-cache assoc
+               :root-packages-on-classpath
+               (set (remove empty? @roots)))
+        classes))))
 
-(defn ns-public-vars
-  "Returns a list of potential public var name completions for a given namespace"
-  [ns]
-  (vals (ns-publics ns)))
+(defn root-packages-on-classpath
+  "Return a set of all classname \"TLDs\" on the classpath."
+  []
+  (classes-on-classpath)
+  (@primitive-cache :root-packages-on-classpath))
 
-(defn ns-vars
-  "Returns a list of all potential var name completions for a given namespace"
-  [ns]
-  (filter var? (vals (ns-map ns))))
+(defn namespaces&files-on-classpath
+  "Returns a collection of maps (e.g. `{:ns-str \"some.ns\", :file\n  \"some/ns.cljs\"}`) of all clj/cljc/cljs namespaces obtained by classpath\n  scanning."
+  []
+  (let [classpath (classpath)]
+    (cache-last-result :namespaces-on-classpath classpath
+      (for [^String file (all-files-on-classpath classpath)
+            :when (or (.endsWith file ".clj")
+                      (.endsWith file ".cljs")
+                      (.endsWith file ".cljc"))]
+        (let [ns-str (.. (subs file 0 (.lastIndexOf file "."))
+                         (replace "/" ".")
+                         (replace "_" "-"))]
+          {:ns-str ns-str, :file file})))))
 
-(defn ns-classes
-  "Returns a list of potential class name completions for a given namespace"
-  [ns]
-  (keys (ns-imports ns)))
+;; compliment/sources.clj
 
-(def special-forms
-  '[def if do let quote var fn loop recur throw try monitor-enter monitor-exit dot new set!])
+(def ^{:doc "Stores defined sources.", :private true} sources (atom nil))
 
-(defn- static? [#^java.lang.reflect.Member member]
-  (java.lang.reflect.Modifier/isStatic (.getModifiers member)))
+(defn all-sources
+  "Returns the list of all completion sources, or the selected once specified by\n  `source-kws`."
+  ([] @sources)
+  ([source-kws] (select-keys @sources source-kws)))
 
-(defn ns-java-methods
-  "Returns a list of Java method names for a given namespace."
-  [ns]
-  (distinct ; some methods might exist in multiple classes
-   (for [class (vals (ns-imports ns)) method (.getMethods ^Class class) :when (static? method)]
-     (str "." (.getName ^Member method)))))
+(defn defsource
+  "Defines a source with the given name and argument map. Map must\n  contain two keys - `:candidates` and `:doc`.\n\n  Value of `:candidates`should be a function of prefix, namespace and\n  context.\n\n  Value of `:doc` latter should be a function of symbol name and\n  namespace."
+  [name & {:as kw-args}]
+  {:pre [(:candidates kw-args)]}
+  (swap! sources assoc name (assoc kw-args :enabled true)))
+
+;; compliment/sources/class_members.clj
+
+(defn static?
+  "Tests if class member is static."
+  [^Member member]
+  (Modifier/isStatic (.getModifiers member)))
+
+(def members-cache
+  "Stores cache of all non-static members for every namespace."
+  (atom {}))
+
+(defn- demunge-deftype-field-name
+  "If the member is a deftype field, change .x_y to .x-y for compatibility. See\n  https://github.com/alexander-yakushev/compliment/issues/33."
+  [^Member m ^Class c ^String name]
+  (if (and (instance? Field m) (.isAssignableFrom clojure.lang.IType c))
+    (.replaceAll name "_" "-")
+    name))
+
+(defn populate-members-cache
+  "Populate members cache of class members for `ns` from the given list of\n  classes. `imported-classes-cnt` is a number that indicates the current number\n  of imported classes in this namespace."
+  [ns classes imported-classes-cnt]
+  (let [members
+        (for [^Class class classes
+              ^Member member (concat (.getMethods class) (.getFields class))
+              :when (not (static? member))]
+          (let [dc (.getDeclaringClass member)
+                name (.getName member)
+                demunged-name (demunge-deftype-field-name member dc name)]
+            [demunged-name
+             (if (= dc class)
+               member
+               (if (instance? Method member)
+                 (.getMethod dc name (.getParameterTypes ^Method member))
+                 (.getField dc name)))]))
+        cache (reduce (fn [cache [full-name m]]
+                        (assoc! cache full-name (conj (cache full-name []) m)))
+                      (transient {})
+                      members)]
+    (swap! members-cache assoc
+           ns
+           {:classes (set classes),
+            :imported-classes-cnt imported-classes-cnt,
+            :members (persistent! cache)})))
+
+(defn update-cache
+  "Updates members cache for a given namespace if necessary."
+  ([ns] (update-cache ns nil))
+  ([ns context-class]
+   (let [imported-classes (reduce-kv
+                           (fn [acc _ mapping]
+                             (if (class? mapping) (conj acc mapping) acc))
+                           []
+                           (ns-map ns))
+         imported-classes-cnt (count imported-classes)
+         cache (@members-cache ns)]
+     (when (or (nil? cache)
+               (not= (:imported-classes-cnt cache) imported-classes-cnt)
+               (and context-class
+                    (not (contains? (:classes cache) context-class))))
+       (let [classes (cond-> (into (set imported-classes) (:classes cache))
+                       context-class (conj context-class))]
+         (populate-members-cache ns classes imported-classes-cnt))))))
+
+(defn get-all-members
+  "Returns all non-static members for a given namespace."
+  [ns context-class]
+  (update-cache ns context-class)
+  (get-in @members-cache [ns :members]))
+
+(defn class-member-symbol?
+  "Tests if a symbol name looks like a non-static class member."
+  [^String x]
+  (.startsWith x "."))
+
+(defn camel-case-matches?
+  "Tests if prefix matches the member name following camel case rules.\n  Thus, prefix `getDeF` matches member `getDeclaredFields`."
+  [prefix member-name]
+  (fuzzy-matches-no-skip? prefix
+                          member-name
+                          (fn [ch] (Character/isUpperCase ^char ch))))
+
+(defn members-candidates
+  "Returns a list of Java non-static fields and methods candidates."
+  [prefix ns _]
+  (when (class-member-symbol? prefix)
+    (let [prefix (subs prefix 1)
+          inparts? (re-find #"[A-Z]" prefix)
+          klass nil]
+      (for [[member-name members] (get-all-members ns klass)
+            :when (and (if inparts?
+                         (camel-case-matches? prefix member-name)
+                         (.startsWith ^String member-name prefix))
+                       true)]
+        {:candidate (str "." member-name),
+         :type (if (instance? Method (first members)) :method :field)}))))
+
+(defsource :compliment.lite/members :candidates #'members-candidates)
+
+(defn static-member-symbol?
+  "Tests if prefix looks like a static member symbol, returns parsed parts."
+  [x]
+  (re-matches #"([^\/\:\.][^\:]*)\/(.*)" x))
+
+(def static-members-cache
+  "Stores cache of all static members for every class."
+  (atom {}))
+
+(defn populate-static-members-cache
+  "Populates static members cache for a given class."
+  [^Class class]
+  (swap! static-members-cache assoc
+         class
+         (reduce (fn [cache ^Member c]
+                   (if (static? c)
+                     (update cache (.getName c) (fnil conj []) c)
+                     cache))
+                 {}
+                 (concat (.getMethods class) (.getFields class)))))
 
 (defn static-members
-  "Returns a list of potential static members for a given class"
+  "Returns all static members for a given class."
   [^Class class]
-  (->> (concat (.getMethods class) (.getDeclaredFields class))
-       (filter static?)
-       (map #(.getName ^Member %))
-       (distinct)))
+  (or (@static-members-cache class)
+      (get (populate-static-members-cache class) class)))
 
-(defn path-files
-  "Returns a list of relative paths to the files under PATH. All relative paths
-  are returned with '/' as their subpath separator.
+(defn static-members-candidates
+  "Returns a list of static member candidates."
+  [^String prefix ns _]
+  (when-let [[_ cl-name member-prefix] (static-member-symbol? prefix)]
+    (when-let [cl (resolve-class ns (symbol cl-name))]
+      (let [inparts? (re-find #"[A-Z]" member-prefix)]
+        (for [[^String member-name members] (static-members cl)
+              :when (if inparts?
+                      (camel-case-matches? member-prefix member-name)
+                      (.startsWith member-name member-prefix))]
+          {:candidate (str cl-name "/" member-name),
+           :type (if (instance? Method (first members))
+                   :static-method
+                   :static-field)})))))
 
-  When PATH ends with
+(defsource :compliment.lite/static-members
+  :candidates
+  #'static-members-candidates)
 
-  - `.jar` the relative paths to the files in the jar are returned instead.
+;; compliment/sources/namespaces.clj
 
-  - `/*` only examine jar files in the PATH."
-  [^String path]
-  (cond (.endsWith path "/*")
-        (for [^File jar (.listFiles (File. path)) :when (.endsWith ^String (.getName jar) ".jar")
-              file (path-files (.getPath jar))]
-          file)
+(defn nscl-symbol?
+  "Tests if prefix looks like a namespace or classname."
+  [^String x]
+  (and (re-matches #"[^\/\:]+" x) (not (= (.charAt x 0) \.))))
 
-        ;; jar files entries are returned with '/' as their default separator
-        ;; across all architectures.
-        (.endsWith path ".jar")
-        (try (for [^JarEntry entry (enumeration-seq (.entries (JarFile. path)))]
-               (.getName entry))
-             (catch Exception _e))
+(defn nscl-matches?
+  "Tests if prefix partially matches a namespace or classname with periods as\n  separators."
+  [prefix namespace]
+  (fuzzy-matches? prefix namespace \.))
 
-        :else
-        ;; use `java.net.URI/relativize`. to return with '/' as the subpath
-        ;; separator.
-        (let [dir (File. path)
-              dir-uri (.toURI dir)]
-          (for [^File file (file-seq  dir)]
-            (-> (.relativize dir-uri (.toURI file))
-                .getPath
-                str)))))
+(defn namespaces-candidates
+  "Returns a list of namespace and classname completions."
+  [^String prefix ns _]
+  (when (nscl-symbol? prefix)
+    (let [has-dot (> (.indexOf prefix ".") -1)
+          [literals prefix] (split-by-leading-literals prefix)
+          cands-from-classpath
+          (for [{:keys [^String ns-str file]} (namespaces&files-on-classpath)
+                :when (and (re-find #"\.cljc?$" file)
+                           (if has-dot
+                             (nscl-matches? prefix ns-str)
+                             (.startsWith ns-str prefix)))]
+            {:candidate (str literals ns-str), :type :namespace, :file file})
+          ns-names (set (map :candidate cands-from-classpath))
+          ns-sym->cand #(let [ns-str (name %)]
+                          (when (and (nscl-matches? prefix ns-str)
+                                     (not (ns-names ns-str)))
+                            {:candidate (str literals ns-str),
+                             :type :namespace}))]
+      (-> cands-from-classpath
+          (into (keep ns-sym->cand) (keys (ns-aliases ns)))
+          (into (comp (map ns-name) (keep ns-sym->cand)) (all-ns))))))
 
-(def java-class-paths-properties
-  "The java properties to look for locating java classes."
-  ["sun.boot.class.path" "java.ext.dirs" "java.class.path"])
+(defsource :compliment.lite/namespaces :candidates #'namespaces-candidates)
 
-(def classfiles
-  "The list of all subpaths paths to `.class` files relative to the
-  paths found in the `java-class-paths-properties` values.
+;; compliment/sources/classes.clj
 
-  Relative paths:
+(defn- all-classes-short-names
+  "Returns a map where short classnames are matched with vectors with\n  package-qualified classnames."
+  []
+  (let [all-classes (classes-on-classpath)]
+    (cache-last-result :all-classes-short-names all-classes
+      (group-by (fn [^String s]
+                  (.substring s (inc (.lastIndexOf s "."))))
+                all-classes))))
 
-  - containing `__` are filtered out.
+(defn- get-classes-by-package-name
+  "Returns simple classnames that match the `prefix` and belong to `pkg-name`."
+  [prefix pkg-name]
+  (reduce-kv (fn [l ^String short-name full-names]
+               (if (and (.startsWith short-name prefix)
+                        (some (fn [^String fn] (.startsWith fn pkg-name))
+                              full-names))
+                 (conj l {:candidate short-name, :type :class})
+                 l))
+             []
+             (all-classes-short-names)))
 
-  - use '/' as their subpath separator."
-  (for [prop (filter #(System/getProperty %1) java-class-paths-properties)
-        path (.split (System/getProperty prop) File/pathSeparator)
-        ^String file (path-files path) :when (and (.endsWith file ".class") (not (.contains file "__")))]
-    file))
+(defn classes-candidates
+  "Returns a list of classname completions."
+  [^String prefix ns _]
+  (when (nscl-symbol? prefix)
+    (if-let [import-ctx (get {} :nil)]
+      (get-classes-by-package-name prefix import-ctx)
+      (let [has-dot (.contains prefix ".")
+            seen (HashSet.)
+            include? (fn
+                       ([class-str remember?]
+                        (when-not (.contains seen class-str)
+                          (when remember? (.add seen class-str))
+                          true)))
+            str->cand (fn [s] {:candidate s, :type :class})
+            all-classes (classes-on-classpath)
+            it (.iterator ^Iterable all-classes)
+            roots (root-packages-on-classpath)]
+        (as-> (transient []) result
+          (reduce-kv
+           (fn [result _ v]
+             (if (class? v)
+               (let [fqname (.getName ^Class v)
+                     sname (.getSimpleName ^Class v)]
+                 (cond-> result
+                   (and (nscl-matches? prefix fqname) (include? fqname true))
+                   (conj! (str->cand fqname))
+                   (and (nscl-matches? prefix sname) (include? sname true))
+                   (conj! {:candidate sname,
+                           :type :class,
+                           :package (when-let [pkg (.getPackage ^Class v)]
+                                      (.getName ^Package pkg))})))
+               result))
+           result
+           (ns-map ns))
+          (if (Character/isUpperCase (.charAt prefix 0))
+            (reduce-kv (fn [result ^String short-name full-names]
+                         (if (.startsWith short-name prefix)
+                           (reduce (fn [result cl]
+                                     (cond-> result
+                                       (include? cl true) (conj! (str->cand
+                                                                  cl))))
+                                   result
+                                   full-names)
+                           result))
+                       result
+                       (all-classes-short-names))
+            result)
+          (if (or has-dot (contains? roots prefix))
+            (loop [result result]
+              (if (.hasNext it)
+                (let [^String cl (.next it)]
+                  (recur (cond-> result
+                           (and (.startsWith cl prefix) (include? cl false))
+                           (conj! (str->cand cl)))))
+                result))
+            (reduce conj!
+                    result
+                    (for [^String root-pkg roots
+                          :when (and (.startsWith root-pkg prefix)
+                                     (include? root-pkg false))]
+                      (str->cand (str root-pkg ".")))))
+          (persistent! result))))))
 
-(defn- classname [^String file]
-  (.. file (replace ".class" "") (replace "/" ".")))
+(defsource :compliment.lite/classes :candidates #'classes-candidates)
 
-(def top-level-classes
-  ;; Avoid using future directly on top-level for graalvm compatibility
-  (delay
-   @(misc/noisy-future
-     (doall
-      (for [file classfiles :when (re-find #"^[^\$]+\.class" file)]
-        (classname file))))))
+;; compliment/sources/vars.clj
 
-(def nested-classes
-  ;; Avoid using future directly on top-level for graalvm compatibility
-  (delay
-   @(misc/noisy-future
-     (doall
-      (for [file classfiles :when (re-find #"^[^\$]+(\$[^\d]\w*)+\.class" file)]
-        (classname file))))))
+(defn var-symbol?
+  "Test if prefix resembles a var name."
+  [x]
+  (re-matches #"(?:([^\/\:][^\/]*)\/)?(|[^/:][^/]*)" x))
 
-(defn resolve-class [ns sym]
-  (try (let [val (ns-resolve ns sym)]
-         (when (class? val) val))
-       (catch Exception e
-         (when (not= ClassNotFoundException
-                     (class (clojure.main/repl-exception e)))
-           (throw e)))))
+(defn dash-matches?
+  "Tests if prefix partially matches a var name with dashes as\n  separators."
+  [prefix var]
+  (fuzzy-matches? prefix var \-))
 
-;;; Candidates
+(defn vars-candidates
+  "Returns a list of namespace-bound candidates, with namespace being\n  either the scope (if prefix is scoped), `ns` arg or the namespace\n  extracted from context if inside `ns` declaration."
+  [^String prefix ns _]
+  (let [[literals prefix] (split-by-leading-literals prefix)]
+    (when-let [[_ scope-name prefix] (var-symbol? prefix)]
+      (let [scope (some-> scope-name
+                          symbol
+                          (resolve-namespace ns))
+            ns-form-namespace (get {} :nil)
+            vars (cond scope (if (and literals (re-find #"#'$" literals))
+                               (ns-interns scope)
+                               (ns-publics scope))
+                       (and scope-name (nil? scope)) ()
+                       ns-form-namespace (ns-publics ns-form-namespace)
+                       :else (ns-map ns))]
+        (for [[var-sym var] vars
+              :let [var-name (name var-sym)]
+              :when (and (var? var) (dash-matches? prefix var-name))
+              :let [{:keys [arglists doc private deprecated], :as var-meta}
+                    (meta var)]
+              :when (not (:completion/hidden var-meta))]
+          (cond-> {:candidate
+                   (str literals
+                        (if scope (str scope-name "/" var-name) var-name)),
+                   :type (cond (:macro var-meta) :macro
+                               arglists :function
+                               :else :var),
+                   :ns (str (or (:ns var-meta) ns))}
+            (and private (:private *extra-metadata*)) (assoc :private
+                                                             (boolean private))
+            (and deprecated (:deprecated *extra-metadata*))
+            (assoc :deprecated (boolean deprecated))
+            (and arglists (:arglists *extra-metadata*))
+            (assoc :arglists (apply list (map pr-str arglists)))
+            (and doc (:doc *extra-metadata*)) (assoc :doc doc)))))))
 
-(defn annotate-var [var {:keys [extra-metadata]}]
-  (let [{macro :macro arglists :arglists var-name :name doc :doc} (-> var meta misc/sanitize-meta)
-        type (cond macro :macro
-                   arglists :function
-                   :else :var)]
-    (cond-> {:candidate (name var-name) :type type}
-      (and (contains? extra-metadata :doc) doc) (assoc :doc doc)
-      (and (contains? extra-metadata :arglists) arglists) (assoc :arglists arglists))))
+(defsource :compliment.lite/vars :candidates #'vars-candidates)
 
-(defn annotate-class
-  [cname]
-  {:candidate cname :type :class})
+;; compliment/sources/keywords.clj
 
-(def special-form-candidates
-  (map #(hash-map :candidate (name %) :type :special-form :ns "clojure.core") special-forms))
+(def ^{:private true} keywords-table
+  (delay (let [^Field field (.getDeclaredField clojure.lang.Keyword "table")]
+           (.setAccessible field true)
+           (.get field nil))))
 
-(defn ns-candidates
-  [ns {:keys [extra-metadata]}]
-  ;; Calling meta on sym that names a namespace only returns doc if the ns form
-  ;; uses the docstring arg, but not if it uses the ^{:doc "..."} meta form.
-  ;;
-  ;; find-ns returns the namespace the sym names. Calling meta on it returns
-  ;; the docstring, no matter which way it's defined.
-  (map #(let [doc (some-> % find-ns meta :doc)]
-          (cond-> {:candidate (name %)
-                   :type :namespace}
-            (and (contains? extra-metadata :doc) doc) (assoc :doc doc)))
-       (namespaces ns)))
+(defn- tagged-candidate [c] {:candidate c, :type :keyword})
 
-(defn ns-var-candidates
-  [ns options]
-  (map #(annotate-var % options) (ns-vars ns)))
+(defn qualified-candidates
+  "Returns a list of namespace-qualified double-colon keywords (like ::foo)\n  resolved for the given namespace."
+  [prefix ns]
+  (let [prefix (subs prefix 2)
+        ns-name (str ns)]
+    (for [[kw _] @keywords-table
+          :when (= (namespace kw) ns-name)
+          :when (.startsWith (name kw) prefix)]
+      (tagged-candidate (str "::" (name kw))))))
 
-(defn ns-public-var-candidates
-  [ns options]
-  (map #(annotate-var % options) (ns-public-vars ns)))
+(defn namespace-alias-candidates
+  "Returns a list of namespace aliases prefixed by double colon required in the\n  given namespace."
+  [prefix ns]
+  (let [prefix (subs prefix 2)]
+    (for [[alias _] (ns-aliases ns)
+          :let [aname (name alias)]
+          :when (.startsWith aname prefix)]
+      (tagged-candidate (str "::" aname)))))
 
-(defn ns-class-candidates
-  [ns]
-  (map #(hash-map :candidate (name %) :type :class) (ns-classes ns)))
+(defn aliased-candidates
+  "Returns a list of alias-qualified double-colon keywords (like ::str/foo),\n  where alias has to be registered in the given namespace."
+  [prefix ns]
+  (when-let [[_ alias prefix] (re-matches #"::([^/]+)/(.*)" prefix)]
+    (let [alias-ns-name (str (resolve-namespace (symbol alias) ns))]
+      (for [[kw _] @keywords-table
+            :when (= (namespace kw) alias-ns-name)
+            :when (.startsWith (name kw) prefix)]
+        (tagged-candidate (str "::" alias "/" (name kw)))))))
 
-(defn ns-java-method-candidates
-  [ns]
-  (for [method (ns-java-methods ns)]
-    {:candidate method :type :method}))
+(defn keyword-candidates
+  [^String prefix ns _]
+  (let [single-colon? (.startsWith prefix ":")
+        double-colon? (.startsWith prefix "::")
+        has-slash? (> (.indexOf prefix "/") -1)]
+    (cond (and double-colon? has-slash?) (aliased-candidates prefix ns)
+          double-colon? (concat (qualified-candidates prefix ns)
+                                (namespace-alias-candidates prefix ns))
+          single-colon? (for [[kw _] @keywords-table
+                              :when (.startsWith (str kw) (subs prefix 1))]
+                          (tagged-candidate (str ":" kw))))))
 
-(defn static-member-candidates
-  [class]
-  (for [name (static-members class)]
-    {:candidate name :type :static-method}))
+(defsource :compliment.lite/keywords :candidates #'keyword-candidates)
 
-(defn scoped-candidates
-  [^String prefix ns options]
-  (when-let [prefix-scope (first (.split prefix "/"))]
-    (let [scope (symbol prefix-scope)]
-      (map #(update % :candidate (fn [c] (str scope "/" c)))
-           (if-let [class (resolve-class ns scope)]
-             (static-member-candidates class)
-             (when-let [ns (or (find-ns scope) (scope (ns-aliases ns)))]
-               (ns-public-var-candidates ns options)))))))
+;; compliment/sources/special_forms.clj
 
-(defn class-candidates
-  [^String prefix _ns]
-  (map annotate-class
-       (if (.contains prefix "$")
-         @nested-classes
-         @top-level-classes)))
+(def ^{:private true} special-forms
+  (set (map name
+            '[def if do quote var recur throw try catch monitor-enter monitor-exit
+              new set!])))
 
-(defn generic-candidates
-  [ns options]
-  (concat special-form-candidates
-          (ns-candidates ns options)
-          (ns-var-candidates ns options)
-          (ns-class-candidates ns)))
+(defn special-candidates
+  "Returns list of completions for special forms."
+  [prefix _ _]
+  (when (and (var-symbol? prefix) true)
+    (for [form special-forms
+          :when (dash-matches? prefix form)]
+      {:candidate form, :type :special-form})))
 
-(defn completion-candidates
-  [^String prefix ns options]
-  (cond
-    (.startsWith prefix ":") (keyword-candidates prefix ns)
-    (.startsWith prefix ".") (ns-java-method-candidates ns)
-    (.contains prefix "/")  (scoped-candidates prefix ns options)
-    (.contains prefix ".")  (concat (ns-candidates ns options) (class-candidates prefix ns))
-    :else                   (generic-candidates ns options)))
+(defsource :compliment.lite/special-forms :candidates #'special-candidates)
+
+(defn literal-candidates
+  "We define `true`, `false`, and `nil` in a separate source because they are\n  not context-dependent (don't have to be first items in the list)."
+  [prefix _ __]
+  (for [^String literal ["true" "false" "nil"]
+        :when (.startsWith literal prefix)]
+    {:candidate literal, :type :special-form}))
+
+(defsource :compliment.lite/literals :candidates #'literal-candidates)
+
+;; compliment/core.clj
+
+(def ^{:private true} by-length-comparator
+  "Sorts list of strings by their length first, and then alphabetically if length\n  is equal."
+  (reify
+    Comparator
+    (compare [_ s1 s2]
+      (let [res (Integer/compare (.length ^String s1) (.length ^String s2))]
+        (if (zero? res) (.compareTo ^String s1 s2) res)))))
+
+(defn ensure-ns
+  "Takes either a namespace object or a symbol and returns the corresponding\n  namespace if it exists, otherwise returns `user` namespace."
+  [nspc]
+  (cond (instance? clojure.lang.Namespace nspc) nspc
+        (symbol? nspc) (or (find-ns nspc) (find-ns 'user) *ns*)
+        :else *ns*))
 
 (defn completions
-  "Return a sequence of matching completion candidates given a prefix string and an optional current namespace.
-  You can also provide an additional `options` map to tweak the candidate list to your needs.
-  E.g. you can pass {:extra-metadata #{:arglists :doc}} to request additional metadata for the candidates."
-  ([prefix]
-   (completions prefix *ns*))
-  ([prefix ns]
-   (completions prefix ns nil))
-  ([^String prefix ns options]
-   (let [candidates (completion-candidates prefix ns options)]
-     (sort-by :candidate (filter #(.startsWith ^String (:candidate %) prefix) candidates)))))
+  "Returns a list of completions for the given prefix.
+
+  Options map can contain the following options:
+  - :ns - namespace where completion is initiated;
+  - :sort-order (either :by-length or :by-name);
+  - :plain-candidates - if true, returns plain strings instead of maps;
+  - :extra-metadata - set of extra fields to add to the maps;
+  - :sources - list of source keywords to use."
+  ([prefix] (completions prefix *ns* {}))
+  ([prefix ns] (completions prefix ns {}))
+  ([prefix ns
+    {:keys [sort-order sources extra-metadata plain-candidates],
+     :or {sort-order :by-name}}]
+   (let [nspc (ensure-ns ns)
+         ctx nil]
+     (binding [*extra-metadata* extra-metadata]
+       (let [candidate-fns
+             (keep (fn [[_ src]] (when (:enabled src) (:candidates src)))
+                   (if sources (all-sources sources) (all-sources)))
+             candidates (mapcat (fn [f] (f prefix nspc ctx)) candidate-fns)
+             sorted-cands
+             (if (= sort-order :by-name)
+               (sort-by :candidate candidates)
+               (sort-by :candidate by-length-comparator candidates))
+             cands
+             (if plain-candidates (map :candidate sorted-cands) sorted-cands)]
+         (doall cands))))))

--- a/test/clojure/nrepl/util/completion_test.clj
+++ b/test/clojure/nrepl/util/completion_test.clj
@@ -26,7 +26,7 @@
 
 (deftest completions-test
   (testing "var completion"
-    (is (= '("alength" "alias" "all-ns" "alter" "alter-meta!" "alter-var-root")
+    (is (= '("alength" "alias" "all-ns" "alter" "alter-meta!" "alter-var-root" "aset-long")
            (candidates "al" 'clojure.core)))
 
     (is (= '("jio/make-input-stream" "jio/make-output-stream" "jio/make-parents" "jio/make-reader" "jio/make-writer")
@@ -72,53 +72,56 @@
 
   (testing "candidate types"
     (is (some #{{:candidate "t-var"
+                 :ns "nrepl.util.completion-test"
                  :type :var}}
               (completions "t-var" 'nrepl.util.completion-test)))
     (is (some #{{:candidate "t-var"
                  :type :var
+                 :ns "nrepl.util.completion-test"
                  :doc "var"}}
               (completions "t-var" 'nrepl.util.completion-test {:extra-metadata #{:arglists :doc}})))
     (is (some #{{:candidate "t-fn"
+                 :ns "nrepl.util.completion-test"
                  :type :function}}
               (completions "t-fn" 'nrepl.util.completion-test)))
     (is (some #{{:candidate "t-fn"
                  :type :function
-                 :arglists "([x])"
+                 :ns "nrepl.util.completion-test"
+                 :arglists '("[x]")
                  :doc "fn"}}
               (completions "t-fn" 'nrepl.util.completion-test {:extra-metadata #{:arglists :doc}})))
     (is (some #{{:candidate "t-macro"
+                 :ns "nrepl.util.completion-test"
                  :type :macro}}
               (completions "t-macro" 'nrepl.util.completion-test)))
     (is (some #{{:candidate "t-macro"
                  :type :macro
-                 :arglists "([y])"
+                 :ns "nrepl.util.completion-test"
+                 :arglists '("[y]")
                  :doc "macro"}}
               (completions "t-macro" 'nrepl.util.completion-test {:extra-metadata #{:arglists :doc}})))
-    (is (some #{{:candidate "unquote" :type :var}}
+    (is (some #{{:candidate "unquote" :type :var, :ns "clojure.core"}}
               (completions "unquote" 'clojure.core)))
-    (is (some #{{:candidate "if" :ns "clojure.core" :type :special-form}}
+    (is (some #{{:candidate "if" :type :special-form}}
               (completions "if" 'clojure.core)))
-    (is (some #{{:candidate "UnsatisfiedLinkError" :type :class}}
+    (is (some #(#{{:candidate "UnsatisfiedLinkError" :type :class}} (select-keys % [:candidate :type]))
               (completions "Unsatisfied" 'clojure.core)))
     ;; ns with :doc meta
     (is (some #{{:candidate "clojure.core"
+                 :file "clojure/core.clj"
                  :type :namespace}}
               (completions "clojure.core" 'clojure.core)))
     (is (some #{{:candidate "clojure.core"
                  :type :namespace
-                 :doc "Fundamental library of the Clojure language"}}
-              (completions "clojure.core" 'clojure.core {:extra-metadata #{:doc}})))
+                 :file "clojure/core.clj"}}
+              (completions "clojure.core" 'clojure.core)))
     ;; ns with docstring argument
-    (is (some #{{:candidate "nrepl.util.completion-test"
-                 :type :namespace}}
+    (is (some #(#{{:candidate "nrepl.util.completion-test" :type :namespace}}
+                (select-keys % [:candidate :type]))
               (completions "nrepl.util.completion-test" 'clojure.core)))
-    (is (some #{{:candidate "nrepl.util.completion-test"
-                 :type :namespace
-                 :doc "Unit tests for completion utilities."}}
-              (completions "nrepl.util.completion-test" 'clojure.core {:extra-metadata #{:doc}})))
     (is (some #{{:candidate "Integer/parseInt" :type :static-method}}
               (completions "Integer/parseInt" 'clojure.core)))
-    (is (some #{{:candidate "File/separator", :type :static-method}}
+    (is (some #{{:candidate "File/separator", :type :static-field}}
               (completions "File/" 'nrepl.util.completion)))
     (is (some #{{:candidate ".toString" :type :method}}
               (completions ".toString" 'clojure.core)))))


### PR DESCRIPTION
First attempt.

I replaced the existing code with [Compliment-lite](https://github.com/alexander-yakushev/compliment/tree/master/lite) but kept the compatibility with the current call signature of `completions` in nREPL.