### PR TITLE
Update CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,10 @@ executors:
     docker:
       - image: clojure:temurin-17-lein-2.10.0-jammy
     <<: *defaults
+  openjdk21:
+    docker:
+      - image: clojure:temurin-21-lein-2.10.0-jammy
+    <<: *defaults
 
 # Runs a given set of steps, with some standard pre- and post-
 # steps, including restoring of cache, saving of cache.
@@ -121,17 +125,17 @@ jobs:
   util_job:
     description: |
       Running utility commands/checks (linter etc.)
-      Always uses Java17 and Clojure 1.10
+      Always uses Java21 and Clojure 1.11
     parameters:
       steps:
         type: steps
-    executor: openjdk17
+    executor: openjdk21
     environment:
-      VERSION: "1.10"
+      VERSION: "1.11"
     steps:
       - checkout
       - with_cache:
-          cache_version: "1.10"
+          cache_version: "1.11"
           steps: << parameters.steps >>
 
 
@@ -180,7 +184,7 @@ jobs:
 #
 # - Linux
 #   - run tests against the target matrix
-#     - Java 8, 11 and 17
+#     - Java 8, 11, 17, and 21
 #     - Clojure 1.7, 1.8, 1.9, 1.10, 1.11 master
 #   - linter, eastwood and cljfmt
 #   - verifies cljdoc config
@@ -264,31 +268,30 @@ workflows:
           name: Lnx, Java 17, Clj master
           clojure_version: "master"
           jdk_version: openjdk17
-      # Add back in when Java 18 is released
-      # - test_code:
-      #     name: Lnx, Java 18, Clj 1.7
-      #     clojure_version: "1.7"
-      #     jdk_version: openjdk18
-      # - test_code:
-      #     name: Lnx, Java 18, Clj 1.8
-      #     clojure_version: "1.8"
-      #     jdk_version: openjdk18
-      # - test_code:
-      #     name: Lnx, Java 18, Clj 1.9
-      #     clojure_version: "1.9"
-      #     jdk_version: openjdk18
-      # - test_code:
-      #     name: Lnx, Java 18, Clj 1.10
-      #     clojure_version: "1.10"
-      #     jdk_version: openjdk18
-      # - test_code:
-      #     name: Lnx, Java 18, Clj 1.11
-      #     clojure_version: "1.11"
-      #     jdk_version: openjdk18
-      # - test_code:
-      #     name: Lnx, Java 18, Clj master
-      #     clojure_version: "master"
-      #     jdk_version: openjdk18
+      - test_code:
+          name: Lnx, Java 21, Clj 1.7
+          clojure_version: "1.7"
+          jdk_version: openjdk21
+      - test_code:
+          name: Lnx, Java 21, Clj 1.8
+          clojure_version: "1.8"
+          jdk_version: openjdk21
+      - test_code:
+          name: Lnx, Java 21, Clj 1.9
+          clojure_version: "1.9"
+          jdk_version: openjdk21
+      - test_code:
+          name: Lnx, Java 21, Clj 1.10
+          clojure_version: "1.10"
+          jdk_version: openjdk21
+      - test_code:
+          name: Lnx, Java 21, Clj 1.11
+          clojure_version: "1.11"
+          jdk_version: openjdk21
+      - test_code:
+          name: Lnx, Java 21, Clj master
+          clojure_version: "master"
+          jdk_version: openjdk21
       # - test_code_win_java_system:
       #     name: Win, Java sys, Clj 1.11
       #     clojure_version: "1.11"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,6 +186,7 @@ jobs:
 #   - run tests against the target matrix
 #     - Java 8, 11, 17, and 21
 #     - Clojure 1.7, 1.8, 1.9, 1.10, 1.11 master
+#     - Clojure 1.7-1.9 are only tested against Java 8.
 #   - linter, eastwood and cljfmt
 #   - verifies cljdoc config
 #   - runs code coverage report
@@ -221,18 +222,6 @@ workflows:
           clojure_version: "master"
           jdk_version: openjdk8
       - test_code:
-          name: Lnx, Java 11, Clj 1.7
-          clojure_version: "1.7"
-          jdk_version: openjdk11
-      - test_code:
-          name: Lnx, Java 11, Clj 1.8
-          clojure_version: "1.8"
-          jdk_version: openjdk11
-      - test_code:
-          name: Lnx, Java 11, Clj 1.9
-          clojure_version: "1.9"
-          jdk_version: openjdk11
-      - test_code:
           name: Lnx, Java 11, Clj 1.10
           clojure_version: "1.10"
           jdk_version: openjdk11
@@ -245,18 +234,6 @@ workflows:
           clojure_version: "master"
           jdk_version: openjdk11
       - test_code:
-          name: Lnx, Java 17, Clj 1.7
-          clojure_version: "1.7"
-          jdk_version: openjdk17
-      - test_code:
-          name: Lnx, Java 17, Clj 1.8
-          clojure_version: "1.8"
-          jdk_version: openjdk17
-      - test_code:
-          name: Lnx, Java 17, Clj 1.9
-          clojure_version: "1.9"
-          jdk_version: openjdk17
-      - test_code:
           name: Lnx, Java 17, Clj 1.10
           clojure_version: "1.10"
           jdk_version: openjdk17
@@ -268,18 +245,6 @@ workflows:
           name: Lnx, Java 17, Clj master
           clojure_version: "master"
           jdk_version: openjdk17
-      - test_code:
-          name: Lnx, Java 21, Clj 1.7
-          clojure_version: "1.7"
-          jdk_version: openjdk21
-      - test_code:
-          name: Lnx, Java 21, Clj 1.8
-          clojure_version: "1.8"
-          jdk_version: openjdk21
-      - test_code:
-          name: Lnx, Java 21, Clj 1.9
-          clojure_version: "1.9"
-          jdk_version: openjdk21
       - test_code:
           name: Lnx, Java 21, Clj 1.10
           clojure_version: "1.10"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,15 +23,15 @@ defaults: &defaults
 executors:
   openjdk8:
     docker:
-      - image: circleci/clojure:openjdk-8-lein-2.9.7-bullseye
+      - image: clojure:temurin-8-lein-2.10.0-jammy
     <<: *defaults
   openjdk11:
     docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.7-bullseye
+      - image: clojure:temurin-11-lein-2.10.0-jammy
     <<: *defaults
   openjdk17:
     docker:
-      - image: circleci/clojure:openjdk-17-lein-2.9.7-bullseye
+      - image: clojure:temurin-17-lein-2.10.0-jammy
     <<: *defaults
 
 # Runs a given set of steps, with some standard pre- and post-
@@ -64,7 +64,7 @@ commands:
           name: Install babashka latest
           command: |
             bash <(curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install) --dir ~
-            sudo mv ~/bb /usr/local/bin/bb
+            mv ~/bb /usr/local/bin/bb
 
       - run:
           name: Generate Cache Checksum
@@ -72,7 +72,7 @@ commands:
             for file in << parameters.files >>
             do
               find . -name $file -exec cat {} +
-            done | shasum | awk '{print $1}' > /tmp/clojure_cache_seed
+            done | sha256sum | awk '{print $1}' > /tmp/clojure_cache_seed
       - restore_cache:
           key: clojure-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
       - steps: << parameters.steps >>
@@ -180,7 +180,7 @@ jobs:
 #
 # - Linux
 #   - run tests against the target matrix
-#     - Java 8, 11 and 15
+#     - Java 8, 11 and 17
 #     - Clojure 1.7, 1.8, 1.9, 1.10, 1.11 master
 #   - linter, eastwood and cljfmt
 #   - verifies cljdoc config

--- a/test/clojure/nrepl/misc_test.clj
+++ b/test/clojure/nrepl/misc_test.clj
@@ -3,7 +3,7 @@
             [nrepl.misc :as misc]
             [nrepl.test-helpers :as th]
             [clojure.java.io :as io])
-  (:import [java.net URL]))
+  (:import [java.net URI]))
 
 (deftest sanitize-meta-test
   (is (not-empty (:file (misc/sanitize-meta {:file "clojure/core.clj"}))))
@@ -15,4 +15,4 @@
          (:file (misc/sanitize-meta {:file (io/file "/foo/bar/baz.clj")}))))
 
   (is (= "https://foo.bar"
-         (:file (misc/sanitize-meta {:file (URL. "https://foo.bar")})))))
+         (:file (misc/sanitize-meta {:file (.toURL (URI. "https://foo.bar"))})))))


### PR DESCRIPTION
Done a couple of things here:

1. Switched from Circle's docker images to [official Clojure Docker images](https://hub.docker.com/_/clojure). It looks like [Circle's images](https://hub.docker.com/r/circleci/clojure) are no longer updated (last update 2 years ago). 
2. Added JDK21 to the test matrix, switched to Clojure 1.11 as a default for linting/etc jobs.
3. Removed testing clj 1.7-1.9 together with JDK higher than 8. The motivation for it is that Clojure 1.10 contains important fixes for compatibility with Java9+ (see https://github.com/clojure/clojure/blob/master/changes.md#11-java). Anyone who cares enough about using newer JDKs must eventually upgrade Clojure as well.