### PR TITLE
Fix bugged TLS accept loop logic, fixes issue #306

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#307](https://github.com/nrepl/nrepl/pull/307): Fix issue where TLS accept loop could sometimes exit prematurely. This caused tests to hang sometimes.
+
 ## 1.1.0 (2023-11-01)
 
 ### New Features

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -64,9 +64,10 @@
                       nil)
                     (catch Throwable t
                       (consume-exception t)
-                      (if (.isClosed ^ServerSocket server-socket)
-                        nil
-                        (throw t))))]
+                      (when-not (.isClosed ^ServerSocket server-socket)
+                        (log "Unexpected exception of class" (class t) "with message" (.getMessage t))
+                        (safe-close server-socket) ; is this a good idea?
+                        (log "Shutting down server abruptly"))))]
     (if (= sock :tls-exception)
       ; if there was a TLS exception, e.g. bad client cert,
       ; we simply recur: accept new connections on the same thread.


### PR DESCRIPTION
Fix bugged TLS accept loop logic. TLS server accept loop should continue in the presence of non-SSL exceptions such as SocketException. The TLS accept method will now wrap any non SSL exceptions in SSLException. The server accept loop will close the server socket upon encountering an unexpected exception. This was not the case earlier, and this lead to a lingering, open server socket where the OS would continue to accept new connections. It seems that .connect, which includes a connect-timeout-ms parameter, on a TLS socket does *not* include the handshake. Thus, in the tests, if the server first encountered a SocketException and this lead to a lingering socket, the next TLS connect would succeed, but the handshake would never finish (and there was no timeout specified). Thus, the test became stuck given a non SSL exception, and caused the CI system to time out after 10 minutes.

Before submitting a PR make sure the following things have been done:

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [X] All tests are passing
- [X] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)