### PR TITLE
Add and populate :socket key on nrepl.server.Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [TKTKTK](TKTKTK): Fix `--interactive` option when used with `--socket PATH`.
+
 ## 1.1.0 (2023-11-01)
 
 ### New Features

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -157,7 +157,7 @@
       (binding [dynamic-loader/*state* state]
         ((:handler @state) msg)))))
 
-(defrecord Server [server-socket port open-transports transport greeting handler]
+(defrecord Server [server-socket port socket open-transports transport greeting handler]
   java.io.Closeable
   (close [this] (stop-server this)))
 
@@ -211,6 +211,7 @@
                  (inet-socket bind port))
         server (Server. ss
                         (when-not socket (.getLocalPort ^java.net.ServerSocket ss))
+                        socket
                         (atom #{})
                         transport-fn
                         greeting-fn

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -308,6 +308,6 @@
           (with-redefs [cmd/clean-up-and-exit >devnull]
             (with-open [server (server/start-server :socket sock-path)]
               (let [results (atom [])]
-                (#'cmd/run-repl {:server  {:socket sock-path}
+                (#'cmd/run-repl {:server  server
                                  :options {:prompt >devnull :err >devnull :out >devnull :value #(swap! results conj %)}})
                 (is (= expected-output @results))))))))))


### PR DESCRIPTION
This fixes [an issue](https://github.com/nrepl/nrepl/issues/309) that occurs when using the `--interactive` option in concert with `--socket PATH`. Since the Server object has no :socket key, nrepl.cmdline/interactive-repl won't recognize that it should connect to the socket and will exit with an error message.

Also adjusts an existing test to exercise the code path in question.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

Thanks!

*If you're just starting out to hack on nREPL you might find this [section of its
manual][1] extremely useful.*

[1]: https:/nrepl.org/nrepl/hacking_on_nrepl.html
