### PR TITLE
Add and populate :host and :socket keys on nrepl.server.Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 * [#307](https://github.com/nrepl/nrepl/pull/307): Fix issue where TLS accept loop could sometimes exit prematurely. This caused tests to hang sometimes.
+* [#311](https://github.com/nrepl/nrepl/pull/311): Make `--interactive` option work when starting a server on a filesystem socket with `--socket PATH`.
 
 ### Changes
 

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -158,7 +158,7 @@
       (binding [dynamic-loader/*state* state]
         ((:handler @state) msg)))))
 
-(defrecord Server [server-socket port open-transports transport greeting handler]
+(defrecord Server [server-socket host port socket open-transports transport greeting handler]
   java.io.Closeable
   (close [this] (stop-server this)))
 
@@ -211,7 +211,9 @@
                  :else
                  (inet-socket bind port))
         server (Server. ss
+                        (when-not socket bind)
                         (when-not socket (.getLocalPort ^java.net.ServerSocket ss))
+                        socket
                         (atom #{})
                         transport-fn
                         greeting-fn

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -158,7 +158,23 @@
       (binding [dynamic-loader/*state* state]
         ((:handler @state) msg)))))
 
-(defrecord Server [server-socket host port socket open-transports transport greeting handler]
+(defrecord
+ Server
+ ;;A record representing an nREPL server.
+ [server-socket ;; A java.net.ServerSocket for underlying server connection
+  host ;; When starting an IP server, the hostname the server is bound to
+  port ;; When starting an IP server, the port the servfer is bound to
+  socket ;; When starting a filesystem socket server, the string path to the
+         ;; socket file
+  open-transports ;; An IDeref containing a set of nrepl.transport/Transport
+                  ;; objects representing open connections
+  transport ;; A function that, given a java.net.Socket corresponding to an
+            ;; incoming connection, will return a value satisfying the
+            ;; nrepl.transport/Transport protocol for that Socket
+  greeting  ;; A function called after a client connects but before the
+            ;; handler. Called with the connection's corresponding
+            ;; nrepl.transport/Transport object
+  handler]  ;; The message handler function to use for connected clients
   java.io.Closeable
   (close [this] (stop-server this)))
 

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -308,6 +308,6 @@
           (with-redefs [cmd/clean-up-and-exit >devnull]
             (with-open [server (server/start-server :socket sock-path)]
               (let [results (atom [])]
-                (#'cmd/run-repl {:server  {:socket sock-path}
+                (#'cmd/run-repl {:server  server
                                  :options {:prompt >devnull :err >devnull :out >devnull :value #(swap! results conj %)}})
                 (is (= expected-output @results))))))))))


### PR DESCRIPTION
Like https://github.com/nrepl/nrepl/pull/310, but also provides the `:host` key.

This fixes [an issue](https://github.com/nrepl/nrepl/issues/309) that occurs when using the `--interactive` option in concert with `--socket PATH`. Since the Server object has no :socket key, nrepl.cmdline/interactive-repl won't recognize that it should connect to the socket and will exit with an error message.

Also adjusts an existing test to exercise the code path in question.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)

Thanks!

*If you're just starting out to hack on nREPL you might find this [section of its
manual][1] extremely useful.*

[1]: https:/nrepl.org/nrepl/hacking_on_nrepl.html
