### PR TITLE
Add and populate :host and :unix-socket keys on nrepl.server.Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 * [#307](https://github.com/nrepl/nrepl/pull/307): Fix issue where TLS accept loop could sometimes exit prematurely. This caused tests to hang sometimes.
+* [#311](https://github.com/nrepl/nrepl/pull/311): Make `--interactive` option work when starting a server on a filesystem socket with `--socket PATH`.
 
 ### Changes
 

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -120,12 +120,12 @@ Exit:      Control+D or (exit) or (quit)"
 
 (defn- run-repl
   ([{:keys [server options]}]
-   (let [{:keys [host port socket] :or {host "127.0.0.1"}} server
+   (let [{:keys [host port unix-socket] :or {host "127.0.0.1"}} server
          {:keys [transport tls-keys-file tls-keys-str] :or {transport #'transport/bencode}} options]
      (run-repl-with-transport
       (cond
-        socket
-        (nrepl/connect :socket socket :transport-fn transport)
+        unix-socket
+        (nrepl/connect :socket unix-socket :transport-fn transport)
 
         (and host port)
         (nrepl/connect :host host :port port :transport-fn transport :tls-keys-file tls-keys-file :tls-keys-str tls-keys-str)
@@ -395,12 +395,12 @@ Exit:      Control+D or (exit) or (quit)"
   [server options]
   (let [transport (:transport options)
         repl-fn (:repl-fn options)
-        socket (:socket server)
+        unix-socket (:unix-socket server)
         host (:host server)
         port (:port server)]
     (when (= transport #'transport/tty)
       (die "The built-in client does not support the tty transport. Consider using `nc` or `telnet`.\n"))
-    (if socket
+    (if unix-socket
       (repl-fn {:server  server
                 :options (merge (when (:color options) colored-output)
                                 {:transport transport})})
@@ -416,7 +416,7 @@ Exit:      Control+D or (exit) or (quit)"
   [{:keys [host port socket] :as options}]
   (interactive-repl {:host   host
                      :port   port
-                     :socket socket}
+                     :unix-socket socket}
                     options)
   (exit 0))
 

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -158,7 +158,7 @@
       (binding [dynamic-loader/*state* state]
         ((:handler @state) msg)))))
 
-(defrecord Server [server-socket port open-transports transport greeting handler]
+(defrecord Server [server-socket host port unix-socket open-transports transport greeting handler]
   java.io.Closeable
   (close [this] (stop-server this)))
 
@@ -211,7 +211,9 @@
                  :else
                  (inet-socket bind port))
         server (Server. ss
+                        (when-not socket bind)
                         (when-not socket (.getLocalPort ^java.net.ServerSocket ss))
+                        socket
                         (atom #{})
                         transport-fn
                         greeting-fn

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -158,7 +158,23 @@
       (binding [dynamic-loader/*state* state]
         ((:handler @state) msg)))))
 
-(defrecord Server [server-socket host port unix-socket open-transports transport greeting handler]
+(defrecord
+ Server
+ ;;A record representing an nREPL server.
+ [server-socket ;; A java.net.ServerSocket for underlying server connection
+  host ;; When starting an IP server, the hostname the server is bound to
+  port ;; When starting an IP server, the port the servfer is bound to
+  unix-socket ;; When starting a filesystem socket server, the string path to
+              ;; the socket file
+  open-transports ;; An IDeref containing a set of nrepl.transport/Transport
+                  ;; objects representing open connections
+  transport ;; A function that, given a java.net.Socket corresponding to an
+            ;; incoming connection, will return a value satisfying the
+            ;; nrepl.transport/Transport protocol for that Socket
+  greeting  ;; A function called after a client connects but before the
+            ;; handler. Called with the connection's corresponding
+            ;; nrepl.transport/Transport object
+  handler]  ;; The message handler function to use for connected clients
   java.io.Closeable
   (close [this] (stop-server this)))
 

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -308,6 +308,6 @@
           (with-redefs [cmd/clean-up-and-exit >devnull]
             (with-open [server (server/start-server :socket sock-path)]
               (let [results (atom [])]
-                (#'cmd/run-repl {:server  {:socket sock-path}
+                (#'cmd/run-repl {:server  server
                                  :options {:prompt >devnull :err >devnull :out >devnull :value #(swap! results conj %)}})
                 (is (= expected-output @results))))))))))


### PR DESCRIPTION
Like https://github.com/nrepl/nrepl/pull/311, but also renames the :socket key to :unix-socket.

This fixes https://github.com/nrepl/nrepl/issues/309 that occurs when using the --interactive option in concert with --socket PATH. Since the Server object has no :socket key, nrepl.cmdline/interactive-repl won't recognize that it should connect to the socket and will exit with an error message.

Also adjusts an existing test to exercise the code path in question.


- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)