### PR TITLE
Refactor CI and bump dev dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,19 +22,19 @@ defaults: &defaults
 executors:
   openjdk8:
     docker:
-      - image: clojure:temurin-8-lein-2.10.0-jammy
+      - image: clojure:temurin-8-lein-2.11.2-jammy
     <<: *defaults
   openjdk11:
     docker:
-      - image: clojure:temurin-11-lein-2.10.0-jammy
+      - image: clojure:temurin-11-lein-2.11.2-jammy
     <<: *defaults
   openjdk17:
     docker:
-      - image: clojure:temurin-17-lein-2.10.0-jammy
+      - image: clojure:temurin-17-lein-2.11.2-jammy
     <<: *defaults
   openjdk21:
     docker:
-      - image: clojure:temurin-21-lein-2.10.0-jammy
+      - image: clojure:temurin-21-lein-2.11.2-jammy
     <<: *defaults
 
 # Runs a given set of steps, with some standard pre- and post-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ orbs:
 defaults: &defaults
   working_directory: ~/repo
   environment:
-    LEIN_ROOT: "true"   # we intended to run lein as root
     JVM_OPTS: -Xmx3200m # limit the maximum heap size to prevent out of memory errors
   resource_class: large # default is medium. large (may) give us more consistent CI results
 
@@ -117,15 +116,12 @@ commands:
 #
 ######################################################################
 
-# The jobs are relatively simple. One runs utility commands against
-# latest stable JDK + Clojure, the other against specified versions
-
 jobs:
 
   util_job:
     description: |
       Running utility commands/checks (linter etc.)
-      Always uses Java21 and Clojure 1.11
+      Always uses Java 21 and Clojure 1.11
     parameters:
       steps:
         type: steps
@@ -135,9 +131,8 @@ jobs:
     steps:
       - checkout
       - with_cache:
-          cache_version: "1.11"
+          cache_version: $VERSION
           steps: << parameters.steps >>
-
 
   test_code:
     description: |
@@ -155,7 +150,7 @@ jobs:
     steps:
       - checkout
       - with_cache:
-          cache_version: << parameters.clojure_version >>
+          cache_version: $VERSION
           steps:
             - run:
                 name: Running tests
@@ -163,7 +158,7 @@ jobs:
             - store_test_results:
                 path: test-results
 
-  test_code_win_java_system:
+  test_code_windows:
     description: |
       Run tests on MS-Windows using the system's JDK version and given
       CLOJURE_VERSION.
@@ -180,84 +175,22 @@ jobs:
             java -version; if(-not $?){exit 9}
             bb test      ; if(-not $?){exit 9}
 
-# The ci-test-matrix does the following:
-#
-# - Linux
-#   - run tests against the target matrix
-#     - Java 8, 11, 17, and 21
-#     - Clojure 1.7, 1.8, 1.9, 1.10, 1.11 master
-#     - Clojure 1.7-1.9 are only tested against Java 8.
-#   - linter, eastwood and cljfmt
-#   - verifies cljdoc config
-#   - runs code coverage report
-# - MS-Windows
-#   - run tests against installed java version and Clojure 1.11
-
 workflows:
-  version: 2.1
   ci-test-matrix:
     jobs:
       - test_code:
-          name: Lnx, Java 8, Clj 1.7
-          clojure_version: "1.7"
-          jdk_version: openjdk8
+          matrix:
+            parameters:
+              # Clojure versions 1.7-1.9 are tested only against JDK8 because of
+              # multiple incompatibilities of those versions with JDK9+.
+              clojure_version: ["1.7", "1.8", "1.9", "1.10", "1.11", "master"]
+              jdk_version: ["openjdk8"]
       - test_code:
-          name: Lnx, Java 8, Clj 1.8
-          clojure_version: "1.8"
-          jdk_version: openjdk8
-      - test_code:
-          name: Lnx, Java 8, Clj 1.9
-          clojure_version: "1.9"
-          jdk_version: openjdk8
-      - test_code:
-          name: Lnx, Java 8, Clj 1.10
-          clojure_version: "1.10"
-          jdk_version: openjdk8
-      - test_code:
-          name: Lnx, Java 8, Clj 1.11
-          clojure_version: "1.11"
-          jdk_version: openjdk8
-      - test_code:
-          name: Lnx, Java 8, Clj master
-          clojure_version: "master"
-          jdk_version: openjdk8
-      - test_code:
-          name: Lnx, Java 11, Clj 1.10
-          clojure_version: "1.10"
-          jdk_version: openjdk11
-      - test_code:
-          name: Lnx, Java 11, Clj 1.11
-          clojure_version: "1.11"
-          jdk_version: openjdk11
-      - test_code:
-          name: Lnx, Java 11, Clj master
-          clojure_version: "master"
-          jdk_version: openjdk11
-      - test_code:
-          name: Lnx, Java 17, Clj 1.10
-          clojure_version: "1.10"
-          jdk_version: openjdk17
-      - test_code:
-          name: Lnx, Java 17, Clj 1.11
-          clojure_version: "1.11"
-          jdk_version: openjdk17
-      - test_code:
-          name: Lnx, Java 17, Clj master
-          clojure_version: "master"
-          jdk_version: openjdk17
-      - test_code:
-          name: Lnx, Java 21, Clj 1.10
-          clojure_version: "1.10"
-          jdk_version: openjdk21
-      - test_code:
-          name: Lnx, Java 21, Clj 1.11
-          clojure_version: "1.11"
-          jdk_version: openjdk21
-      - test_code:
-          name: Lnx, Java 21, Clj master
-          clojure_version: "master"
-          jdk_version: openjdk21
-      # - test_code_win_java_system:
+          matrix:
+            parameters:
+              clojure_version: ["1.10", "1.11", "master"]
+              jdk_version: ["openjdk11", "openjdk17", "openjdk21"]
+      # - test_code_windows:
       #     name: Win, Java sys, Clj 1.11
       #     clojure_version: "1.11"
       - util_job:

--- a/project.clj
+++ b/project.clj
@@ -30,11 +30,11 @@
                                     :sign-releases false}]]
 
   :profiles {:fastlane {:dependencies [[nrepl/fastlane "0.1.0"]]}
-             :test {:dependencies [[com.github.ivarref/locksmith "0.1.6"]
+             :test {:dependencies [[com.github.ivarref/locksmith "0.1.9"]
                                    [com.hypirion/io "0.3.1"]
-                                   [commons-net/commons-net "3.6"]
-                                   [lambdaisland/kaocha "1.0.672"]
-                                   [lambdaisland/kaocha-junit-xml "0.0.76"]]
+                                   [commons-net/commons-net "3.10.0"]
+                                   [lambdaisland/kaocha "1.89.1380"]
+                                   [lambdaisland/kaocha-junit-xml "1.17.101"]]
                     :java-source-paths ["test/java"]
                     :plugins      [[test2junit "1.4.2"]]
                     :test2junit-output-dir "test-results"
@@ -43,16 +43,16 @@
                     :test-selectors {:default (complement :min-java-version)}
                     :aliases {"test" "test2junit"}}
              :junixsocket {:jvm-opts ["-Dnrepl.test.junixsocket=true"]
-                           :dependencies [[com.kohlschutter.junixsocket/junixsocket-core "2.5.1" :extension "pom"]]}
-             :clj-kondo {:dependencies [[clj-kondo "2022.01.15"]]}
+                           :dependencies [[com.kohlschutter.junixsocket/junixsocket-core "2.9.1" :extension "pom"]]}
+             :clj-kondo {:dependencies [[clj-kondo "2024.03.13"]]}
              ;; Clojure versions matrix
-             :provided {:dependencies [[org.clojure/clojure "1.11.1"]]}
+             :provided {:dependencies [[org.clojure/clojure "1.11.3"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.2"]]
                     :source-paths ["src/spec"]}
-             :1.11 {:dependencies [[org.clojure/clojure "1.11.1"]]
+             :1.11 {:dependencies [[org.clojure/clojure "1.11.3"]]
                     :source-paths ["src/spec"]}
              :master {:repositories [["snapshots"
                                       "https://oss.sonatype.org/content/repositories/snapshots"]]
@@ -64,11 +64,11 @@
              ;; generates the nREPL ops documentation from their descriptor
              ;; metadata.
              :maint {:source-paths ["src/maint"]
-                     :dependencies [[org.clojure/tools.cli "1.0.194"]]}
+                     :dependencies [[org.clojure/tools.cli "1.1.230"]]}
 
              ;; CI tools
-             :cloverage {:plugins [[lein-cloverage "1.2.2"]]
-                         :dependencies [[cloverage "1.2.2"]]
+             :cloverage {:plugins [[lein-cloverage "1.2.4"]]
+                         :dependencies [[cloverage "1.2.4"]]
                          :cloverage {:codecov? true
                                      ;; Cloverage can't handle some of the code
                                      ;; in this project

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -178,7 +178,7 @@
   java.io.Closeable
   (close [this] (stop-server this)))
 
-(defn ^Server start-server
+(defn start-server
   "Starts a socket-based nREPL server.  Configuration options include:
 
    * :port — defaults to 0, which autoselects an open port
@@ -209,6 +209,7 @@
    either via `stop-server`, (.close server), or automatically via `with-open`.
    The port that the server is open on is available in the :port slot of the
    server map (useful if the :port option is 0 or was left unspecified."
+  ^nrepl.server.Server
   [& {:keys [port bind socket tls? tls-keys-str tls-keys-file transport-fn handler ack-port greeting-fn consume-exception]
       :or {consume-exception (fn [_] nil)}}]
   (when (and socket (or port bind tls?))

--- a/src/clojure/nrepl/tls_client_proxy.clj
+++ b/src/clojure/nrepl/tls_client_proxy.clj
@@ -50,8 +50,8 @@
   (Thread/setDefaultUncaughtExceptionHandler
    (reify Thread$UncaughtExceptionHandler
      (uncaughtException [_ thread ex]
-       (.print (System/err) "Uncaught exception on ")
-       (.println (System/err) (.getName ^Thread thread))
+       (.print System/err "Uncaught exception on ")
+       (.println System/err (.getName ^Thread thread))
        (.printStackTrace ^Throwable ex)
        (error "Uncaught exception on" (.getName ^Thread thread))
        nil))))


### PR DESCRIPTION
We did this for Orchard and cider-nrepl before, and I'd argue that the rules look more apparent this way (and there is less room for error).