### PR TITLE
[transport] Don't crash with ClassCastException when reconnecting to Unix socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#317](https://github.com/nrepl/nrepl/pull/317): Update vendored `compliment-lite` to 0.5.5 ([changelog](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#055-2024-05-06)).
 
+### Bugs fixed
+
+* [#299](https://github.com/nrepl/nrepl/pull/299): Fix ClassCastException on re-connect to Unix socket.
+
 ## 1.1.1 (2024-02-20)
 
 ### Bugs fixed

--- a/src/clojure/nrepl/socket.clj
+++ b/src/clojure/nrepl/socket.clj
@@ -235,6 +235,17 @@
       (throw (ClosedChannelException.)))
     (.accept s)))
 
+(defprotocol Connectable
+  (is-connected? [s]
+    "Returns true if socket-like thing `s` is currently connected."))
+
+(extend-protocol Connectable
+  SocketChannel
+  (is-connected? [s] (.isConnected s))
+
+  Socket
+  (is-connected? [s] (.isConnected s)))
+
 ;; We have to handle this ourselves for NIO because unfortunately read and write
 ;; hang if we use both Channels/newInputStream and Channels/newOutputStream.
 ;; Read and write deadlock on a shared channel input/output stream lock


### PR DESCRIPTION
Fixes #299.

I've verified that it no longer reproduces after the fix, but I haven't written the tests. Somebody more familiar with this code is welcome to tackle that.
