### PR TITLE
[bencode] Rewrite nrepl.bencode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#318](https://github.com/nrepl/nrepl/pull/318): Introduce custom JVMTI agent to restore Thread.stop() on JDK20+.
+* [#323](https://github.com/nrepl/nrepl/pull/323): Rewrite `nrepl.bencode` implementation to be more performant and use Clojure 1.7 features.
+
 ## 1.1.2 (2024-05-22)
 
 ### Changes

--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,8 @@
                                    [com.hypirion/io "0.3.1"]
                                    [commons-net/commons-net "3.10.0"]
                                    [lambdaisland/kaocha "1.89.1380"]
-                                   [lambdaisland/kaocha-junit-xml "1.17.101"]]
+                                   [lambdaisland/kaocha-junit-xml "1.17.101"]
+                                   [org.clojure/test.check "1.1.1"]]
                     :java-source-paths ["test/java"]
                     :plugins      [[test2junit "1.4.2"]]
                     :test2junit-output-dir "test-results"
@@ -86,5 +87,6 @@
                         {:plugins [[jonase/eastwood "1.4.0"]]
                          :eastwood {:config-files ["eastwood.clj"]
                                     :ignored-faults {:non-dynamic-earmuffs {nrepl.middleware.load-file true}
-                                                     :unused-ret-vals {nrepl.util.completion-test true}
+                                                     :unused-ret-vals {nrepl.util.completion-test true
+                                                                       nrepl.bencode true}
                                                      :reflection {nrepl.socket.dynamic true}}}}]})


### PR DESCRIPTION
I freshened up the implementation as discussed in #322 and made performance improvements where it made sense to do so. Although the spirit of the implementation remained mostly the same, there are a few significant changes:

- `read-token` is gone, reading dispatch happens within the `read-bencode` function for better efficiency.
- Rewrote writing dispatch from multimethods to protocols. Introduced a separate private protocol function `write-bencode*`, the public `write-bencode` is a public function with old argument order.

I've generated a stress test data structure (~10Mb when serialized as EDN) to benchmark. Here are the results:

##### Encoding
`Before: Time per call: 230.37 ms   Alloc per call: 293,593,739b`
`After:  Time per call: 89.59 ms    Alloc per call: 114,506,367b`
Improvement: 2.5x in time and 2.5x in allocations.

##### Decoding
`Before: Time per call: 263.36 ms   Alloc per call: 374,434,013b`
`After:  Time per call: 49.39 ms    Alloc per call: 76,781,066b`
Improvement: 5.3x in time and 4.9x in allocations.

Overall, I don't think this would influence the UX of e.g. CIDER much because the data structures that go through cider-nrepl are usually small, and the bottleneck would most likely be on the Emacs side, not on the Clojure side. Anyway, a win is a win.
