### PR TITLE
[bencode] Further reduce the span of generative testing

### DIFF
--- a/test/clojure/nrepl/bencode_test.clj
+++ b/test/clojure/nrepl/bencode_test.clj
@@ -219,7 +219,7 @@
                                                           :max-elements 20})])
                      (gen/one-of [gen/string gen/large-integer])))
 
-(defspec generative-roundtrip-test {:num-tests 150}
+(defspec generative-roundtrip-test {:num-tests 100}
   (tc.prop/for-all
    [value valid-bencode-input-generator]
    (= value (>input (>output value :writer write-bencode) :reader read-bencode))))


### PR DESCRIPTION
The `num-tests` influences how "big" the generated values will be. I don't have any good intuition about which value would prevent OOMs so we'll have to trial-and-error it.