### PR TITLE
Add explicit opt-out for libnrepl agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#318](https://github.com/nrepl/nrepl/pull/318): Introduce custom JVMTI agent to restore `Thread.stop()` (needed by the `interrupt` op) on JDK20+.
+  - [#326](https://github.com/nrepl/nrepl/pull/326): Add explicit opt-out for libnrepl agent.
 * [#323](https://github.com/nrepl/nrepl/pull/323): Rewrite `nrepl.bencode` implementation to be more performant and use Clojure 1.7 features.
 
 ## 1.1.2 (2024-05-22)

--- a/doc/modules/ROOT/pages/installation.adoc
+++ b/doc/modules/ROOT/pages/installation.adoc
@@ -102,6 +102,16 @@ If `-Djdk.attach.allowAttachSelf` is not enabled, nREPL will not try to load the
 native agent and will not try to stop threads on Java 20 and newer if the
 regular `Thread.interrupt()` did not succeed.
 
-NOTE: Prior to Java 20, nREPL will not try to load libnrepl native agent regardless of
-the state of `-Djdk.attach.allowAttachSelf` flag and will use `Thread.stop()` to
+You can explicitly disable the JVMTI agent so that it does not load even with
+`-Djdk.attach.allowAttachSelf` enabled. To do that, add this line to
+xref:usage/server.adoc#server-configuration[nREPL config]:
+
+[source,clojure]
+----
+ :enable-jvmti-agent false
+----
+
+NOTE: Prior to Java 20, nREPL will not try to load libnrepl native agent
+regardless of the state of `-Djdk.attach.allowAttachSelf` flag or
+`:enable-jvmti-agent` configuration option, and will use `Thread.stop()` to
 interrupt the evaluating thread.

--- a/src/clojure/nrepl/config.clj
+++ b/src/clojure/nrepl/config.clj
@@ -22,12 +22,12 @@
   "nREPL's configuration directory.
   By default it's ~/.nrepl, but this can be overridden
   with the NREPL_CONFIG_DIR env variable."
-  (or (System/getenv "NREPL_CONFIG_DIR")
-      (str home-dir java.io.File/separator ".nrepl")))
+  (or (some-> (System/getenv "NREPL_CONFIG_DIR") io/file)
+      (io/file home-dir ".nrepl")))
 
 (def config-file
   "nREPL's config file."
-  (str config-dir java.io.File/separator "nrepl.edn"))
+  (io/file config-dir "nrepl.edn"))
 
 (defn- load-edn
   "Load edn from an io/reader source (filename or io/resource)."
@@ -36,14 +36,13 @@
     (edn/read (java.io.PushbackReader. r))))
 
 (defn- load-config
-  "Load the configuration file identified by `filename`.
+  "Load the configuration file identified by `file`.
   Return its contents as EDN if the file exists,
   or an empty map otherwise."
-  [filename]
-  (let [file (io/file filename)]
-    (if (.exists file)
-      (load-edn file)
-      {})))
+  [^java.io.File file]
+  (if (.exists file)
+    (load-edn file)
+    {}))
 
 (def config
   "Configuration map.
@@ -53,4 +52,4 @@
   nREPL."
   (merge
    (load-config config-file)
-   (load-config ".nrepl.edn")))
+   (load-config (io/file ".nrepl.edn"))))

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -206,7 +206,7 @@
        ;; Whether this is more dangerous than calling Thread.stop() in earlier
        ;; JDKs is unknown, but assume the worst and never use this if you can't
        ;; take the risk!
-       (if (misc/attach-self-enabled?)
+       (if (misc/jvmti-agent-enabled?)
          (jvmti-stop-thread t)
          (misc/log "Cannot stop thread on JDK20+ without jdk.attach.allowAttachSelf enabled."))
 

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -4,7 +4,8 @@
   {:author "Chas Emerick"}
   (:refer-clojure :exclude [requiring-resolve])
   (:require [clojure.java.io :as io]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [nrepl.config :refer [config]]))
 
 (defn log
   [ex-or-msg & msgs]
@@ -128,6 +129,15 @@
   ;; -Djdk.attach.allowAttachSelf sets the property to "" if it is present,
   ;; otherwise that property will be nil.
   (boolean (System/getProperty "jdk.attach.allowAttachSelf")))
+
+(defn jvmti-agent-enabled?
+  "Return true if nREPL is allowed to load its JVMTI agent at runtime."
+  []
+  (and (attach-self-enabled?)
+       ;; JVMTI agent is a "soft opt-in" — if attachSelf is enabled, then we
+       ;; consider this a permission to load the agent, UNLESS the user
+       ;; explicitly opts out of it in the config.
+       (boolean (:enable-jvmti-agent config true))))
 
 (def safe-var-metadata
   "A list of var metadata attributes are safe to return to the clients.


### PR DESCRIPTION
Context: https://clojurians.slack.com/archives/C0617A8PQ/p1716406878253329

I would think that it would be quite rare for the user to enable allowAttachSelf for unrelated reasons (but most probably to load other native agents at runtime) but bail out of this one. Still, this PR gives them the ability to do so.
