### PR TITLE
Unify configuration

### DIFF
--- a/src/clojure/nrepl/config.clj
+++ b/src/clojure/nrepl/config.clj
@@ -88,6 +88,11 @@
    :tls-keys-str       {:type :string}
    :tls-keys-file      {:type :string}
 
+   :lookup-fn          {:type :var-delay
+                        :default 'nrepl.util.lookup/lookup}
+   :complete-fn        {:type :var-delay
+                        :default 'nrepl.util.completion/completions}
+
    :enable-jvmti-agent {:type :boolean, :default true}})
 
 (def ^:private config-state "Configuration state." (atom {}))

--- a/src/clojure/nrepl/config.clj
+++ b/src/clojure/nrepl/config.clj
@@ -1,55 +1,168 @@
 (ns nrepl.config
   "Server configuration utilities.
-  Some server options can be configured via configuration
-  files (local or global).  This namespace provides
-  convenient API to work with them.
 
-  The config resolution algorithm is the following:
-  The global config file .nrepl/nrepl.edn is merged with
-  any local config file (.nrepl.edn) if present.
-  The values in the local config file take precedence."
-  {:author "Bozhidar Batsov"
+  Most server options can be configured via configuration files (local or
+  global), env variables, and Java properties. This namespace provides convenient
+  API to work with them.
+
+  The config resolution algorithm considers values in the following order:
+  - global config file .nrepl/nrepl.edn
+  - local config file (.nrepl.edn)
+  - Java properties starting with `nrepl.`
+  - env variables starting with `NREPL_`"
+  {:author "Bozhidar Batsov, Oleksandr Yakushev"
    :added  "0.5"}
+  (:refer-clojure :exclude [parse-boolean parse-long])
   (:require
+   [clojure.string :as str]
    [clojure.java.io :as io]
-   [clojure.edn :as edn]))
+   [clojure.edn :as edn]
+   [nrepl.misc :as misc]))
 
-(def ^:private home-dir
-  "The user's home directory."
-  (System/getProperty "user.home"))
+(defn- fail
+  "Throws an exception with a message specified by `fmt` and `args`."
+  [fmt & args]
+  (throw (ex-info (apply format fmt args) {:nrepl/kind ::config-error})))
 
-(def config-dir
-  "nREPL's configuration directory.
-  By default it's ~/.nrepl, but this can be overridden
-  with the NREPL_CONFIG_DIR env variable."
-  (or (some-> (System/getenv "NREPL_CONFIG_DIR") io/file)
-      (io/file home-dir ".nrepl")))
+(defmacro ^:private try-log [& body]
+  `(try ~@body
+        (catch Exception e#
+          (misc/log e#)
+          (fail "nREPL config init failed"))))
 
-(def config-file
-  "nREPL's config file."
-  (io/file config-dir "nrepl.edn"))
+(defn- parse-long
+  "Parses string as a Long. Idempotent."
+  [x]
+  (if (int? x) x (Long/parseLong x)))
 
-(defn- load-edn
-  "Load edn from an io/reader source (filename or io/resource)."
-  [source]
-  (with-open [r (io/reader source)]
-    (edn/read (java.io.PushbackReader. r))))
+(defn- parse-boolean
+  "Parses string as a Boolean. Idempotent."
+  [x]
+  (if (instance? Boolean x)
+    x
+    (not (#{nil "" "0" "false"} x))))
 
-(defn- load-config
-  "Load the configuration file identified by `file`.
-  Return its contents as EDN if the file exists,
-  or an empty map otherwise."
+(defn- parse-string
+  "Parses string as a symbol and resolve it to a var. Idempotent."
+  [x]
+  (if (string? x) x
+      (fail "Bad string value: %s" x)))
+
+(defn- parse-var-delay
+  "Parses string as a symbol and returns a delay that resolves to a var.
+  Idempotent."
+  [x]
+  (if (delay? x)
+    x
+    (let [sym (symbol x)]
+      (delay (misc/requiring-resolve sym)))))
+
+(defn- parse-var-list-delay
+  "Parses string as a comma-separated list of symbols and returns a delay that
+  resolves to a list of. Idempotent."
+  [x]
+  (cond (delay? x) x
+        (symbol? x) (recur [x])
+        (string? x) (recur (mapv symbol (str/split x #",")))
+        (sequential? x) (delay (into [] (keep misc/requiring-resolve) x))
+        :else (fail "Bad value for list of symbols: %s" x)))
+
+(def ^:private parsers
+  {:number         #'parse-long
+   :boolean        #'parse-boolean
+   :string         #'parse-string
+   :var-delay      #'parse-var-delay
+   :var-list-delay #'parse-var-list-delay})
+
+(def ^:private config-blueprint "Configuation blueprint."
+  {:port               {:type :number}
+   :bind               {:type :string}
+   :socket             {:type :string}
+   :middleware         {:type :var-list-delay}
+   :handler            {:type :var-delay}
+   :transport-fn       {:type :var-delay
+                        :default 'nrepl.transport/bencode}
+   :repl-fn            {:type :var-delay
+                        :default 'nrepl.cmdline/run-repl}
+   :ack-port           {:type :number}
+   :tls-keys-str       {:type :string}
+   :tls-keys-file      {:type :string}
+
+   :enable-jvmti-agent {:type :boolean, :default true}})
+
+(def ^:private config-state "Configuration state." (atom {}))
+(def config "Deprecated, left for compatibility. Use (get-config) instead." {})
+
+(defn- reset-state []
+  (reset! config-state
+          (->> (for [[k {:keys [type default] :as spec}] config-blueprint
+                     :when (contains? spec :default)]
+                 [k ((parsers type) default)])
+               (into {})))
+  (.bindRoot #'config @config-state))
+
+(defn set-value
+  "Set the `value` for the `key` in the configuration. Value can either be a
+  string to be parsed or a destination type value."
+  [key value]
+  (if-some [bp (config-blueprint key)]
+    (let [new-value ((parsers (:type bp)) value)]
+      (swap! config-state assoc key new-value)
+      (.bindRoot #'config @config-state))
+    (fail "Unknown nREPL config key: %s" key)))
+
+(defn- fill-from-env []
+  (try-log
+   (doseq [key (keys config-blueprint)
+           :let [env-name (str "NREPL_" (str/replace (str/upper-case (name key)) "-" "_"))
+                 value (System/getenv env-name)]
+           :when value]
+     (set-value key value))))
+
+(defn- fill-from-properties []
+  (try-log
+   (let [env (System/getenv)]
+     (doseq [key (keys config-blueprint)
+             :let [prop-name (str "nrepl." (name key))
+                   value (System/getProperty prop-name)]
+             :when value]
+       (set-value key value)))))
+
+(defn fill-from-map [m]
+  (try-log
+   (doseq [[key value] m]
+     (if (contains? config-blueprint key)
+       (set-value key value)
+       ;; For compatibility, assoc unknown values to config too.
+       (swap! config-state assoc key value)))
+   (.bindRoot #'config @config-state)))
+
+(defn- read-edn-file
+  "Read edn from a file."
   [^java.io.File file]
   (if (.exists file)
-    (load-edn file)
+    (with-open [r (io/reader file)]
+      (edn/read (java.io.PushbackReader. r)))
     {}))
 
-(def config
+(defn get-config
   "Configuration map.
   It's created by merging the global configuration file
   with a local configuration file that would normally
   the placed in the directory in which you're running
   nREPL."
-  (merge
-   (load-config config-file)
-   (load-config (io/file ".nrepl.edn"))))
+  []
+  @config-state)
+
+(def ^:private config-dir
+  "nREPL's configuration directory.
+  By default it's ~/.nrepl, but this can be overridden
+  with the NREPL_CONFIG_DIR env variable."
+  (or (some-> (System/getenv "NREPL_CONFIG_DIR") io/file)
+      (io/file (System/getProperty "user.home") ".nrepl")))
+
+(reset-state)
+(fill-from-map (read-edn-file (io/file config-dir "nrepl.edn"))) ;; Global
+(fill-from-map (read-edn-file (io/file ".nrepl.edn"))) ;; Local
+(fill-from-properties)
+(fill-from-env)

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -181,7 +181,7 @@
        ;; JVMTI agent is a "soft opt-in" — if attachSelf is enabled, then we
        ;; consider this a permission to load the agent, UNLESS the user
        ;; explicitly opts out of it in the config.
-       (boolean (:enable-jvmti-agent config/config true))))
+       (boolean (:enable-jvmti-agent (config/get-config) true))))
 
 (defn- jvmti-stop-thread [t]
   ((misc/requiring-resolve 'nrepl.util.jvmti/stop-thread) t))

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -4,8 +4,7 @@
   {:author "Chas Emerick"}
   (:refer-clojure :exclude [requiring-resolve])
   (:require [clojure.java.io :as io]
-            [clojure.string :as str]
-            [nrepl.config :refer [config]]))
+            [clojure.string :as str]))
 
 (defn log
   [ex-or-msg & msgs]
@@ -112,15 +111,6 @@
   ;; -Djdk.attach.allowAttachSelf sets the property to "" if it is present,
   ;; otherwise that property will be nil.
   (boolean (System/getProperty "jdk.attach.allowAttachSelf")))
-
-(defn jvmti-agent-enabled?
-  "Return true if nREPL is allowed to load its JVMTI agent at runtime."
-  []
-  (and (attach-self-enabled?)
-       ;; JVMTI agent is a "soft opt-in" — if attachSelf is enabled, then we
-       ;; consider this a permission to load the agent, UNLESS the user
-       ;; explicitly opts out of it in the config.
-       (boolean (:enable-jvmti-agent config true))))
 
 (def safe-var-metadata
   "A list of var metadata attributes are safe to return to the clients.

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -189,7 +189,9 @@
    * :tls-keys-str - A string that contains the certificates and private key.
      :tls-keys-file or :tls-keys-str must be given if :tls? is true.
    * :handler — the nREPL message handler to use for each incoming connection;
-       defaults to the result of `(default-handler)`
+       defaults to the result of `(default-handler)`.
+   * :middleware — list of additional middleware to use with `default-handler`,
+       does nothing if explicit `:handler` is specified.
    * :transport-fn — a function that, given a java.net.Socket corresponding
        to an incoming connection, will return a value satisfying the
        nrepl.Transport protocol for that Socket.
@@ -207,7 +209,8 @@
    The port that the server is open on is available in the :port slot of the
    server map (useful if the :port option is 0 or was left unspecified."
   ^nrepl.server.Server
-  [& {:keys [port bind socket tls? tls-keys-str tls-keys-file transport-fn handler ack-port greeting-fn consume-exception]
+  [& {:keys [port bind socket tls? tls-keys-str tls-keys-file transport-fn
+             handler middleware ack-port greeting-fn consume-exception]
       :or {consume-exception (fn [_] nil)}}]
   (when (and socket (or port bind tls?))
     (let [msg "Cannot listen on both port and filesystem socket"]
@@ -231,7 +234,7 @@
                         (atom #{})
                         transport-fn
                         greeting-fn
-                        (or handler (default-handler)))]
+                        (or handler (apply default-handler middleware)))]
     (noisy-future
      (accept-connection server consume-exception))
     (when ack-port

--- a/test/clojure/nrepl/cmdline_tty_test.clj
+++ b/test/clojure/nrepl/cmdline_tty_test.clj
@@ -66,8 +66,7 @@
 (deftest no-tty-client
   (testing "Trying to connect with the tty transport should fail."
     (with-open [^Server server (server/start-server :transport-fn #'transport/tty)]
-      (let [options (cmd/connection-opts {:port      (:port server)
-                                          :host      "localhost"
-                                          :transport 'nrepl.transport/tty})]
+      (let [[options] (cmd/args->options ["-p" (str (:port server)) "-h" "localhost"
+                                          "--transport" "nrepl.transport/tty"])]
         (is (thrown? clojure.lang.ExceptionInfo
                      (cmd/interactive-repl server options)))))))


### PR DESCRIPTION
This is an attempt to make sense of the multitude of ways nrepl can be configured and fix a few tangential issues.

_Consider this is a WIP. There are plenty of things I'm not sure about, need feedback._

So, nREPL can be currently configured using the following (note that most options can be configured by only one or some of the below):

1. Global and local configuration files – which are EDN (data).
2. Command-line options which are strings – need to be parsed.
3. Sporadic dynamic variables which are meant to be `set!` at runtime, usually to resolved functions (vars). Some of those dynvars don't actually work when `set!` because they are not dynamically bound higher up in the stack (`*lookup-fn*`, `*complete-fn*`).
4. There are also dynvars that do work when `set!` but that requires some unobvious preparatory work from nrepl (see discussion in #334).
5. We now also have `:enable-jvmti-agent` which can only be set through config files.

I'd like to unify all those and make it more obvious how the user can change any of the options. The proposed solution upgrades `nrepl.config` to be more than a file reader. It is inspired by https://github.com/grammarly/omniconf (but greatly simplified). The config blueprint is first declared that lists all configuration values that nREPL supports, with types (and parsers) and default values. The blueprint then allows to parse the values from files, from env variables (with `NREPL_` prefix), Java properties (with `-Dnrepl.`prefix), and at runtime using `set-value` function.

Configuration values can be of simple data types (number, boolean), or a deferred resolved var. This is similar to how `nrepl.cmdline` works. The latter is now more tightly integrated `nrepl.config`. The user-supplied CLI args are transformed to config-like keys, merged with config, and then uniformly used throughout `nrepl.cmdline`.

Open questions:

1. Is this approach viable? Is it necessary?
2. Is it useful to be able to configure nREPL with env variables and properties? That part can be easily removed.
3. I wasn't too careful about not breaking compatibility for public functions in `nrepl.cmdline` and `nrepl.config` namespaces. Is compatibility there worth keeping?
4. I also removed `*lookup-fn*` and`*complete-fn*` vars but they were in experimental namespaces, and `set!`ing them by default throws an exception anyway.