### PR TITLE
Introduce custom REPL implementation instead clojure.main/repl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#335](https://github.com/nrepl/nrepl/pull/335): Remove support for sideloading and `wrap-sideloader` middleware.
+* [#339](https://github.com/nrepl/nrepl/pull/339): Introduce custom REPL implementation instead `clojure.main/repl`.
 
 ### Bugs fixed
 

--- a/doc/modules/ROOT/pages/design/middleware.adoc
+++ b/doc/modules/ROOT/pages/design/middleware.adoc
@@ -142,6 +142,17 @@ unhandled messages will always produce a response message with an `:unknown-op`
 `linearize-middleware-stack` to obtain a ordered sequence of middleware vars)
 should do the same, or use a similar alternative base handler.
 
+== Evaluation
+
+Core evaluation functionality is provided by
+`nrepl.middleware.interruptible-eval/interruptible-eval` middleware. It drives
+the REPL process using custom implementation instead of `clojure.main/repl`.
+When a message with `eval` op reaches this middleware, the forms in `:code` are
+read (the code can contain multiple forms), evaluated, and the result sent to
+the transport. If an error happens at any point during read phase, the whole
+evaluation is stopped. Otherwise, each separate form in the message is evaluated
+and printed even if some of them throw an exception.
+
 == Sessions
 
 Each nREPL message is evaluated within a session. There are two types of sessions:

--- a/project.clj
+++ b/project.clj
@@ -89,4 +89,5 @@
                                     :ignored-faults {:non-dynamic-earmuffs {nrepl.middleware.load-file true}
                                                      :unused-ret-vals {nrepl.util.completion-test true
                                                                        nrepl.bencode true}
-                                                     :reflection {nrepl.socket.dynamic true}}}}]})
+                                                     :reflection {nrepl.socket.dynamic true}
+                                                     :implicit-dependencies {nrepl.middleware.interruptible-eval true}}}}]})

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -410,8 +410,8 @@
   (let [{:keys [out status value]} (clean-response (combine-responses (repl-eval session "(missing paren")))]
     (is (nil? value))
     (is (= #{:done :eval-error} status))
-    ;; TODO avoid regex error if there's no exception found. Can be misleading
-    (is (re-seq #"EOF while reading" (first (repl-values session "(-> *e Throwable->map :cause)"))))))
+    (is (some->> (first (repl-values session "(-> *e Throwable->map :cause)"))
+                 (re-find #"EOF while reading")))))
 
 (def-repl-test switch-ns
   (is (= "otherns" (-> (repl-eval session "(ns otherns) (defn function [] 12)")


### PR DESCRIPTION
See #330 for context.

The introduction of custom REPL is split into two commits:

1. The first one inlines `clojure.main/repl` into `nrepl.middleware.interruptible-eval/evaluate` almost as is.
2. The second commit refactors the inlined implementation to remove redundant parts and make it more idiomatic as a whole.

This approach makes it easier to see which exact changes we made to`clojure.main/repl`. There is only one meaningful change so far:
- Don't touch the context classloader, as it is already correctly managed by session middleware (see note below).

The PR is just the first step in rethinking the eval pipeline, yet it can be merged as an independent part.

**NOTE BELOW**

By looking at how interruptible-eval is implemented and how it is tied to `session` middleware, it seems like it was made  so that `interruptible-eval` can work without `session` in the middleware chain, albeit poorly. Is this compatibility mode still desired? The two middleware are very intertwined, and it makes sense to make one depend on the other in order to make further improvements.

**COMPATIBILITY NOTICE**

This PR should not break any public APIs of ours. However, some development tooling might rely on `clojure.main/repl` being on the stack to tell if the code is running in a REPL context. I know at least one place which does that. Anyway, relying on such things is expected to be unstable. Clojure 1.12 is about to introduce `*repl*` dynvar to make the notion of REPL more explicit, but until everyone upgrades to it in 10 years, I would expect tooling authors to be aware that the look of the stacktrace is not part of the API contract.

--- 

Before submitting a PR make sure the following things have been done:

- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)