### PR TITLE
Use provided host in server-started-message

### DIFF
--- a/doc/modules/ROOT/pages/hacking_on_nrepl.adoc
+++ b/doc/modules/ROOT/pages/hacking_on_nrepl.adoc
@@ -16,7 +16,7 @@ nREPL shouldn't ever be necessary (unless you're hacking on it).
 Building nREPL locally is a very simple process:
 
 . Clone the repo
-. Make sure you have Leingingen installed
+. Make sure you have Leiningen installed
 . Run the build:
 
 [source,shell]

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -14,9 +14,7 @@
    [nrepl.server :as nrepl-server]
    [nrepl.socket :as socket]
    [nrepl.transport :as transport]
-   [nrepl.version :as version])
-  (:import
-   [java.net URI]))
+   [nrepl.version :as version]))
 
 (defn- clean-up-and-exit
   "Performs any necessary clean up and calls `(System/exit status)`."
@@ -440,16 +438,15 @@ Exit:      Control+D or (exit) or (quit)"
   connection details from.
   Takes nREPL server map and processed CLI options map.
   Returns connection header string."
-  [server options]
-  (let [transport (:transport options)
-        ^java.net.ServerSocket ssocket (:server-socket server)
-        ^URI uri (socket/as-nrepl-uri ssocket (transport/uri-scheme transport))]
-    ;; The format here is important, as some tools (e.g. CIDER) parse the string
-    ;; to extract from it the host and the port to connect to
-    (if-let [host (.getHost uri)]
+  [{:keys [host port socket] :as server}
+   {:keys [transport]}]
+  (let [uri (socket/as-nrepl-uri server (transport/uri-scheme transport))]
+    ;; The format here is important, as some tools (e.g. CIDER) parse the
+    ;; string to extract from it the host and the port to connect to
+    (if socket
+      (str "nREPL server started on socket " (.toASCIIString uri))
       (format "nREPL server started on port %d on host %s - %s"
-              (.getPort uri) host uri)
-      (str "nREPL server started on socket " (.toASCIIString uri)))))
+              port host uri))))
 
 (defn save-port-file
   "Writes a file relative to project classpath with port number so other tools

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -218,6 +218,11 @@
       (log msg)
       (throw (ex-info msg {:nrepl/kind ::invalid-start-request}))))
   (let [transport-fn (or transport-fn t/bencode)
+        port (or port 0)
+        ;; We fallback to 127.0.0.1 instead of to localhost to avoid a
+        ;; dependency on the order of IPv4 and IPv6 records for localhost in
+        ;; /etc/hosts
+        bind (or bind "127.0.0.1")
         ss (cond socket
                  (unix-server-socket socket)
                  (or tls? (or tls-keys-str tls-keys-file))

--- a/src/clojure/nrepl/socket.clj
+++ b/src/clojure/nrepl/socket.clj
@@ -29,22 +29,11 @@
 
 (defn inet-socket
   ([bind port]
-   (let [port (or port 0)
-         addr (fn [^String bind port] (InetSocketAddress. bind (int port)))
-         ;; We fallback to 127.0.0.1 instead of to localhost to avoid
-         ;; a dependency on the order of ipv4 and ipv6 records for
-         ;; localhost in /etc/hosts
-         bind (or bind "127.0.0.1")]
-     (doto (ServerSocket.)
-       (.setReuseAddress true)
-       (.bind (addr bind port)))))
+   (doto (ServerSocket.)
+     (.setReuseAddress true)
+     (.bind (InetSocketAddress. bind (int port)))))
   ([bind port tls-context]
-   (let [port (or port 0)
-         ;; We fallback to 127.0.0.1 instead of to localhost to avoid
-         ;; a dependency on the order of ipv4 and ipv6 records for
-         ;; localhost in /etc/hosts
-         bind (or bind "127.0.0.1")]
-     (tls/server-socket tls-context bind port))))
+   (tls/server-socket tls-context bind port)))
 
 ;; Unix domain sockets
 

--- a/src/clojure/nrepl/socket.clj
+++ b/src/clojure/nrepl/socket.clj
@@ -55,6 +55,16 @@
 (def ^Class jdk-unix-class
   (find-class 'java.nio.channels.SocketChannel))
 
+(defn- junix-server-socket?
+  [x]
+  (boolean (when junixsocket-server-class
+             (instance? junixsocket-server-class x))))
+
+(defn- jdk-unix-server-socket?
+  [x]
+  (boolean (when jdk-unix-server-class
+             (instance? jdk-unix-server-class x))))
+
 (def ^:private test-junixsocket?
   ;; Make it possible to test junixsocket even when JDK >= 16
   (= "true" (System/getProperty "nrepl.test.junixsocket")))
@@ -179,30 +189,29 @@
         (throw (ex-info msg {:nrepl/kind ::no-filesystem-sockets}))))))
 
 (defn as-nrepl-uri ^URI [{:keys [host server-socket]} transport-scheme]
-  (let [sock server-socket
-        get-local-addr (fn [^NetworkChannel c] (.getLocalAddress c))]
-    (if-let [addr (and (some-> jdk-unix-server-class (instance? sock))
-                       (get-local-addr sock))]
-      (URI. (str transport-scheme "+unix")
-            (let [^Path path (get-path addr)]
-              (-> path .toAbsolutePath str))
-            nil)
-      (if-let [addr (and (some-> junixsocket-server-class (instance? sock))
-                         (.getLocalSocketAddress ^ServerSocket sock))]
-        (URI. (str transport-scheme "+unix")
-              (get-path addr)
-              nil)
-        ;; Assume it's an InetAddress socket
-        (let [sock ^ServerSocket sock]
-          (URI. (str transport-scheme
-                     (when (instance? SSLServerSocket sock)
-                       "s"))
-                nil ;; userInfo
-                host
-                (.getLocalPort sock)
-                nil       ;; path
-                nil       ;; query
-                nil)))))) ;; fragment
+  (cond
+    (jdk-unix-server-socket? server-socket)
+    (URI. (str transport-scheme "+unix")
+          (let [addr (.getLocalAddress ^NetworkChannel server-socket)
+                ^Path path (get-path addr)]
+            (str (.toAbsolutePath path)))
+          nil)
+
+    (junix-server-socket? server-socket)
+    (URI. (str transport-scheme "+unix")
+          (get-path (.getLocalSocketAddress ^ServerSocket server-socket))
+          nil)
+
+    :else
+    (URI. (str transport-scheme
+               (when (instance? SSLServerSocket server-socket)
+                 "s"))
+          nil
+          host
+          (.getLocalPort ^ServerSocket server-socket)
+          nil
+          nil
+          nil)))
 
 (defprotocol Acceptable
   (accept [s]

--- a/src/clojure/nrepl/socket.clj
+++ b/src/clojure/nrepl/socket.clj
@@ -189,8 +189,9 @@
         (log msg)
         (throw (ex-info msg {:nrepl/kind ::no-filesystem-sockets}))))))
 
-(defn as-nrepl-uri [sock transport-scheme]
-  (let [get-local-addr (fn [^NetworkChannel c] (.getLocalAddress c))]
+(defn as-nrepl-uri ^URI [{:keys [host server-socket]} transport-scheme]
+  (let [sock server-socket
+        get-local-addr (fn [^NetworkChannel c] (.getLocalAddress c))]
     (if-let [addr (and (some-> jdk-unix-server-class (instance? sock))
                        (get-local-addr sock))]
       (URI. (str transport-scheme "+unix")
@@ -208,7 +209,7 @@
                      (when (instance? SSLServerSocket sock)
                        "s"))
                 nil ;; userInfo
-                (-> sock .getInetAddress .getHostName)
+                host
                 (.getLocalPort sock)
                 nil       ;; path
                 nil       ;; query

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -139,7 +139,37 @@
     (is (re-find #"nREPL server started on port \d+ on host .* - .*//.*:\d+"
                  (cmd/server-started-message
                   server
-                  {:transport #'transport/bencode})))))
+                  {:transport #'transport/bencode}))))
+
+  (with-open [^Server server (server/start-server
+                              :transport-fn #'transport/bencode
+                              :handler server/default-handler
+                              :bind "127.0.0.1"
+                              :port 60000)]
+    (is (= "nREPL server started on port 60000 on host 127.0.0.1 - nrepl://127.0.0.1:60000"
+           (cmd/server-started-message
+            server
+            {:transport #'transport/bencode}))))
+
+  (with-open [^Server server (server/start-server
+                              :transport-fn #'transport/bencode
+                              :handler server/default-handler
+                              :bind "localhost"
+                              :port 60000)]
+    (is (= "nREPL server started on port 60000 on host localhost - nrepl://localhost:60000"
+           (cmd/server-started-message
+            server
+            {:transport #'transport/bencode}))))
+
+  (with-open [^Server server (server/start-server
+                              :transport-fn #'transport/bencode
+                              :handler server/default-handler
+                              :bind "::1"
+                              :port 60000)]
+    (is (= "nREPL server started on port 60000 on host ::1 - nrepl://[::1]:60000"
+           (cmd/server-started-message
+            server
+            {:transport #'transport/bencode})))))
 
 (deftest ^:slow ack
   (let [ack-port (:port *server*)


### PR DESCRIPTION
Fixes #302.

I had to lift the logic that defaults `port` and `bind` from `inet-socket` up into `start-server` – otherwise they were nil on the server record. That does mean that they're now non-nil when `socket` is provided, but it shouldn't cause an issue as we always check `socket` first when it's relevant.

The last commit changes `as-nrepl-uri` to prefer `cond` over multiple nested `if-let`s; I recommend reviewing the commits one-by-one because of this.