### PR TITLE
Make session middleware handle all necessary dynamic bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#335](https://github.com/nrepl/nrepl/pull/335): Remove support for sideloading and `wrap-sideloader` middleware.
 * [#339](https://github.com/nrepl/nrepl/pull/339): Introduce custom REPL implementation instead `clojure.main/repl`.
+* [#341](https://github.com/nrepl/nrepl/pull/341): Make session middleware handle all dynamic bindings.
 
 ### Bugs fixed
 

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -9,7 +9,7 @@
    [nrepl.middleware :refer [set-descriptor!]]
    [nrepl.middleware.caught :as caught]
    [nrepl.middleware.print :as print]
-   [nrepl.misc :as misc :refer [response-for with-session-classloader]]
+   [nrepl.misc :as misc :refer [response-for]]
    [nrepl.transport :as t])
   (:import
    (clojure.lang Compiler$CompilerException
@@ -20,11 +20,6 @@
 (def ^:dynamic *msg*
   "The message currently being evaluated."
   nil)
-
-(defn- capture-thread-bindings
-  "Capture thread bindings, excluding nrepl implementation vars."
-  []
-  (dissoc (get-thread-bindings) #'*msg*))
 
 (defn- set-line!
   [^LineNumberingPushbackReader reader line]
@@ -54,140 +49,78 @@
       (and (instance? Compiler$CompilerException e)
            (instance? ThreadDeath (.getCause e)))))
 
-(defmacro with-repl-bindings
-  "Executes body in the context of thread-local bindings for several vars
-  that often need to be set!: *ns* *warn-on-reflection* *math-context*
-  *print-meta* *print-length* *print-level* *compile-path*
-  *command-line-args* *1 *2 *3 *e"
-  [& body]
-  `(binding [*ns* *ns*
-             *warn-on-reflection* *warn-on-reflection*
-             *math-context* *math-context*
-             *print-meta* *print-meta*
-             *print-length* *print-length*
-             *print-level* *print-level*
-             *data-readers* *data-readers*
-             *default-data-reader-fn* *default-data-reader-fn*
-             *compile-path* (System/getProperty "clojure.compile.path" "classes")
-             *command-line-args* *command-line-args*
-             *unchecked-math* *unchecked-math*
-             *assert* *assert*
-             ;; Conditional bindings for compatibility with older Clojure.
-             ~@(when (resolve '*print-namespace-maps*)
-                 ['*print-namespace-maps* true
-                  'clojure.spec.alpha/*explain-out* 'clojure.spec.alpha/*explain-out*])
-             ~@(when (resolve '*repl*)
-                 ['*repl* true])
-             *1 nil
-             *2 nil
-             *3 nil
-             *e nil]
-     ~@body))
-
 (defn evaluate
   "Evaluate msg's `:code` (either a string or a seq of forms to be evaluated)
   within the dynamic context of its session. `:ns` can be optionally
   specified (resolved via `find-ns`). The message MUST contain a Transport
   implementation in :transport; expression results and errors will be sent via
   that Transport."
-  [{:keys [transport session eval ns code file line column out-limit]
+  [{:keys [transport eval ns code line column]
     :as msg}]
-  (let [explicit-ns (and ns (-> ns symbol find-ns))
-        original-ns (@session #'*ns*)
-        maybe-restore-original-ns (if explicit-ns
-                                    #(assoc % #'*ns* original-ns)
-                                    identity)]
+  (let [explicit-ns (and ns (-> ns symbol find-ns))]
     (if (and ns (not explicit-ns))
       (t/send transport (response-for msg {:status #{:error :namespace-not-found :done}
                                            :ns ns}))
-      (let [;; TODO: out-limit -> out-buffer-size | err-buffer-size
-            ;; TODO: new options: out-quota | err-quota
-            opts {::print/buffer-size (or out-limit (get (meta session) :out-limit))}
-            out (print/replying-PrintWriter :out msg opts)
-            err (print/replying-PrintWriter :err msg opts)]
+      (let [eof (Object.)
+            read (if (string? code)
+                   (let [reader (source-logging-pushback-reader code line column)
+                         read-cond (or (-> msg :read-cond keyword)
+                                       :allow)]
+                     #(read {:read-cond read-cond :eof eof} reader))
+                   (let [code (.iterator ^Iterable code)]
+                     #(if (.hasNext code)
+                        (.next code)
+                        eof)))
+            eval-fn (if eval (find-var (symbol eval)) clojure.core/eval)
+            caught (fn [^Throwable e]
+                     (set! *e e)
+                     (when-not (interrupted? e)
+                       (let [resp {::caught/throwable e
+                                   :status :eval-error
+                                   :ex (str (class e))
+                                   :root-ex (str (class (clojure.main/root-cause e)))}]
+                         (t/send transport (response-for msg resp)))))]
         (try
-          ;; TODO: assert DCL
-          (let [eof (Object.)
-                read (if (string? code)
-                       (let [reader (source-logging-pushback-reader code line column)
-                             read-cond (or (-> msg :read-cond keyword)
-                                           :allow)]
-                         #(read {:read-cond read-cond :eof eof} reader))
-                       (let [code (.iterator ^Iterable code)]
-                         #(if (.hasNext code)
-                            (.next code)
-                            eof)))
-                eval-fn (if eval (find-var (symbol eval)) clojure.core/eval)
-                caught (fn [^Throwable e]
-                         (set! *e e)
-                         (when-not (interrupted? e)
-                           (let [resp {::caught/throwable e
-                                       :status :eval-error
-                                       :ex (str (class e))
-                                       :root-ex (str (class (clojure.main/root-cause e)))}]
-                             (t/send transport (response-for msg resp)))))]
-            (with-repl-bindings
-              (try
-                (let [bindings
-                      (-> (get-thread-bindings)
-                          (into caught/default-bindings)
-                          (into print/default-bindings)
-                          (into @session)
-                          (into {#'*out* out
-                                 #'*err* err
-                                 ;; clojure.test captures *out* at load-time, so we need to make sure
-                                 ;; runtime output of test status/results is redirected properly
-                                 ;; TODO: is this something we need to consider in general, or is this
-                                 ;; specific hack reasonable?
-                                 #'clojure.test/*test-out* out})
-                          (cond-> explicit-ns (assoc #'*ns* explicit-ns)
-                                  file (assoc #'*file* file)))]
-                  (pop-thread-bindings)
-                  (push-thread-bindings bindings))
-
-                (loop []
-                  (let [read-eval *read-eval*
-                        input (try
-                                (clojure.main/with-read-known (read))
-                                (catch Throwable e
-                                  (let [e (if (instance? LispReader$ReaderException e)
-                                            (ex-info nil {:clojure.error/phase :read-source} e)
-                                            e)]
-                                    ;; If error happens during read phase, call
-                                    ;; caught-hook but don't continue executing.
-                                    (caught e)
-                                    eof)))]
-                    (when-not (identical? input eof)
-                      (try
-                        (let [value (binding [*read-eval* read-eval]
-                                      (with-session-classloader (eval-fn input)))]
-                          (set! *3 *2)
-                          (set! *2 *1)
-                          (set! *1 value)
-                          (try
-                            ;; *out* has :tag metadata; *err* does not
-                            (.flush ^Writer *err*)
-                            (.flush *out*)
-                            (t/send transport (response-for msg {:ns (str (ns-name *ns*))
-                                                                 :value value
-                                                                 ::print/keys #{:value}}))
+          (with-bindings (if explicit-ns
+                           {#'*ns* explicit-ns}
+                           {})
+            (loop []
+              (let [input (try
+                            (clojure.main/with-read-known (read))
                             (catch Throwable e
-                              (throw (ex-info nil {:clojure.error/phase :print-eval-result} e)))))
+                              (let [e (if (instance? LispReader$ReaderException e)
+                                        (ex-info nil {:clojure.error/phase :read-source} e)
+                                        e)]
+                                ;; If error happens during read phase, call
+                                ;; caught-hook but don't continue executing.
+                                (caught e)
+                                eof)))]
+                (when-not (identical? input eof)
+                  (try
+                    (let [value (eval-fn input)]
+                      (set! *3 *2)
+                      (set! *2 *1)
+                      (set! *1 value)
+                      (try
+                        ;; *out* has :tag metadata; *err* does not
+                        (.flush ^Writer *err*)
+                        (.flush *out*)
+                        (t/send transport (response-for msg {:ns (str (ns-name *ns*))
+                                                             :value value
+                                                             ::print/keys #{:value}}))
                         (catch Throwable e
-                          (caught e)))
-                      ;; Otherwise, when errors happen during eval/print phase,
-                      ;; report the exception but continue executing the
-                      ;; remaining readable forms.
-                      (recur))))
+                          (throw (ex-info nil {:clojure.error/phase :print-eval-result} e)))))
+                    (catch Throwable e
+                      (caught e)))
+                  ;; Otherwise, when errors happen during eval/print phase,
+                  ;; report the exception but continue executing the
+                  ;; remaining readable forms.
+                  (recur)))))
 
-                (catch Throwable e
-                  (caught e)))
+          (catch Throwable e
+            (caught e)))
 
-              (reset! session (maybe-restore-original-ns (capture-thread-bindings)))
-              (flush)))
-          (finally
-            (.flush err)
-            (.flush out)))))))
+        (flush)))))
 
 (defn interruptible-eval
   "Evaluation middleware that supports interrupts.  Returns a handler that supports
@@ -201,9 +134,9 @@
         (if-not (:code msg)
           (t/send transport (response-for msg :status #{:error :no-code :done}))
           (exec id
-                #(binding [*msg* msg]
-                   (evaluate msg))
-                #(t/send transport (response-for msg :status :done))))
+                #(evaluate msg)
+                #(t/send transport (response-for msg :status :done))
+                msg))
         (h msg)))))
 
 (set-descriptor! #'interruptible-eval

--- a/test/clojure/nrepl/sanity_test.clj
+++ b/test/clojure/nrepl/sanity_test.clj
@@ -2,81 +2,9 @@
   (:require
    [clojure.test :refer :all]
    [nrepl.core :as nrepl]
-   [nrepl.middleware.interruptible-eval :as eval]
    [nrepl.middleware.print :as print]
-   [nrepl.middleware.session :as session]
-   [nrepl.misc :as misc]
    [nrepl.test-helpers :as th]
-   [nrepl.transport :as transport :refer [piped-transports]])
-  (:import
-   (java.util.concurrent BlockingQueue LinkedBlockingQueue TimeUnit)))
-
-(defn- internal-eval
-  ([expr] (internal-eval nil expr))
-  ([ns expr]
-   (let [[local remote] (piped-transports)
-         expr (if (string? expr)
-                expr
-                (binding [*print-meta* true]
-                  (pr-str expr)))
-         msg (cond-> {:code expr :transport remote :session (atom {})}
-               ns (assoc :ns ns))]
-     (eval/evaluate msg)
-     (-> (nrepl/response-seq local 0)
-         (nrepl/combine-responses)
-         (select-keys [:ns :value :out :err])))))
-
-(deftest eval-sanity
-  (try
-    (are [result expr] (= result (internal-eval expr))
-      {:ns "user" :value [3]}
-      '(+ 1 2)
-
-      {:ns "user" :value [nil]}
-      '*1
-
-      {:ns "user" :value [nil]}
-      '(do (def ^{:dynamic true} ++ +) nil)
-
-      {:ns "user" :value [5]}
-      '(binding [++ -] (++ 8 3))
-
-      {:ns "user" :value [42]}
-      '(set! *print-length* 42)
-
-      {:ns "user" :value [nil]}
-      '*print-length*)
-    (finally (ns-unmap *ns* '++))))
-
-(deftest specified-namespace
-  (try
-    (are [ns result expr] (= result (internal-eval ns expr))
-      (ns-name *ns*)
-      {:ns "user" :value [3]}
-      '(+ 1 2)
-
-      'user
-      {:ns "user" :value '[("user" "++")]}
-      '(do
-         (def ^{:dynamic true} ++ +)
-         (map #(-> #'++ meta % str) [:ns :name]))
-
-      (ns-name *ns*)
-      {:ns "user" :value [5]}
-      '(binding [user/++ -]
-         (user/++ 8 3)))
-    (finally (ns-unmap 'user '++))))
-
-(deftest multiple-expressions
-  (are [result expr] (= result (internal-eval expr))
-    {:ns "user" :value [4 65536.0]}
-    "(+ 1 3) (Math/pow 2 16)"
-
-    {:ns "user" :value [4 20 1 0]}
-    "(+ 2 2) (* *1 5) (/ *2 4) (- *3 4)"
-
-    {:ns "user" :value [nil]}
-    '*1))
+   [nrepl.transport :as transport :refer [piped-transports]]))
 
 (deftest repl-out-writer
   (let [[local remote] (piped-transports)


### PR DESCRIPTION
## The problem

The relation between `session` and `interruptible-eval` middleware is quite intertwined. The eval middleware binds REPL-relevant dynamic variables around the evaluated expression so that the evaluated expression can `set!` those. This made sense until `session` middleware started persisting these dynvars (to restore them after interrupts). To facilitate this, `interruptible-eval` performs some head-scratching hacks to let `session` mw see the changes made by the evaluated code. Some of the dynvars (e.g., `*in*`) are bound by `session`, some (e.g., `*out*`) are rebound with every new message (but still saved into the session); `*msg*` lives in `interruptible-eval`, is bound by `session`, is prevented from saving into the session atom by `interruptible-eval`. Messy and very confusing.

## The proposal

Let `session` handle all the dynvars required by `interruptible-eval` and the evaluated code. The `session` mw gathers all the dynvars, binds them in its `:exec` implementations, gets them back and persists (only in non-ephemeral sessions). This requires `session` mw to know a bit more about evaluation than it should, but it is still better than what we have now. The non-standard bindings like `*in*` and `*out*` are also bound by `session` but the mechanics of it is more explicit and apparent. The `interruptible-eval` mw becomes dumber and simply hopes that `session` mw sets up all the necessary dynvars.

I had to move some tests from sanity_check to core. Sanity check tests relied on calling `nrepl.middleware.interruptible-eval/evaluate` directly. I kept those tests but made them more e2endy.

---

- [x] You've updated the [changelog](../CHANGELOG.md)