### PR TITLE
[misc] Restore with-session-classloader macro

### DIFF
--- a/src/clojure/nrepl/middleware/dynamic_loader.clj
+++ b/src/clojure/nrepl/middleware/dynamic_loader.clj
@@ -11,7 +11,7 @@
   (:require [clojure.string :as str]
             [nrepl.middleware :refer [linearize-middleware-stack set-descriptor!]]
             [nrepl.middleware.session :as middleware.session]
-            [nrepl.misc :as misc :refer [response-for with-classloader]]
+            [nrepl.misc :as misc :refer [response-for with-session-classloader]]
             [nrepl.transport :as t]))
 
 (def ^:dynamic *state* nil)
@@ -23,7 +23,7 @@
 
 (defn- update-stack!
   [middleware]
-  (with-classloader
+  (with-session-classloader
     (let [resolved (map (fn [middleware-str-or-var]
                           (if (var? middleware-str-or-var)
                             middleware-str-or-var
@@ -42,7 +42,7 @@
 
 (defn- require-namespaces
   [namespaces]
-  (with-classloader
+  (with-session-classloader
     (run! (fn [namespace]
             (try
               (require (symbol namespace))

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -9,7 +9,7 @@
    [nrepl.middleware :refer [set-descriptor!]]
    [nrepl.middleware.caught :as caught]
    [nrepl.middleware.print :as print]
-   [nrepl.misc :as misc :refer [response-for with-classloader]]
+   [nrepl.misc :as misc :refer [response-for with-session-classloader]]
    [nrepl.transport :as t])
   (:import
    (clojure.lang Compiler$CompilerException DynamicClassLoader
@@ -99,7 +99,7 @@
           (clojure.main/repl
            :eval (let [eval-fn (if eval (find-var (symbol eval)) clojure.core/eval)]
                    (fn [form]
-                     (with-classloader (eval-fn form))))
+                     (with-session-classloader (eval-fn form))))
            :init #(let [bindings
                         (-> (get-thread-bindings)
                             (into caught/default-bindings)

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -78,7 +78,7 @@
           (when log?
             (log e))))))
 
-(defmacro with-classloader
+(defmacro with-session-classloader
   "Bind `clojure.lang.Compiler/LOADER` to the context classloader. This is
   required to get hotloading with pomegranate working under certain conditions."
   [& body]


### PR DESCRIPTION
`with-session-classloader` is a public macro that is used in other projects (e.g., cider-nrepl). Even though it will soon become unnecessary in nREPL itself (and will probably turn into a NOP at some point), keeping the name is important for compatibility.