### PR TITLE
Trim stack of eval handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#335](https://github.com/nrepl/nrepl/pull/335): Remove support for sideloading and `wrap-sideloader` middleware.
 * [#339](https://github.com/nrepl/nrepl/pull/339): Introduce custom REPL implementation instead `clojure.main/repl`.
 * [#341](https://github.com/nrepl/nrepl/pull/341): Make session middleware handle all dynamic bindings.
+* [#342](https://github.com/nrepl/nrepl/pull/342): Make the stack of the eval handler shorter.
 
 ### Bugs fixed
 

--- a/src/java/nrepl/SessionThread.java
+++ b/src/java/nrepl/SessionThread.java
@@ -1,0 +1,23 @@
+package nrepl;
+
+import clojure.lang.IFn;
+
+/**
+ * A custom thread implementation that trims the eval callstack further.
+ */
+public class SessionThread extends Thread {
+
+    IFn runFn;
+
+    public SessionThread(IFn runFn, String name, ClassLoader classLoader) {
+        this.runFn = runFn;
+        setName(name);
+        setContextClassLoader(classLoader);
+        setDaemon(true);
+    }
+
+    @Override
+    public void run() {
+        runFn.invoke();
+    }
+}


### PR DESCRIPTION
Addresses #331.

Example stack in `1.2.0` - 26 frames:

```
user=> (Exception.)
#error {
 :cause nil
 :via
 [{:type java.lang.Exception
   :message nil
   :at [user$eval2561 invokeStatic "NO_SOURCE_FILE" 1]}]
 :trace
 [[user$eval2561 invokeStatic "NO_SOURCE_FILE" 1]
  [user$eval2561 invoke "NO_SOURCE_FILE" 1]
---> nREPL part ends here <---
  [clojure.lang.Compiler eval "Compiler.java" 7691]
  [clojure.lang.Compiler eval "Compiler.java" 7646]
  [clojure.core$eval invokeStatic "core.clj" 3232]
  [clojure.core$eval invoke "core.clj" 3228]
  [nrepl.middleware.interruptible_eval$evaluate$fn__1426$fn__1427 invoke "interruptible_eval.clj" 102]
  [clojure.lang.AFn applyToHelper "AFn.java" 152]
  [clojure.lang.AFn applyTo "AFn.java" 144]
  [clojure.core$apply invokeStatic "core.clj" 667]
  [clojure.core$with_bindings_STAR_ invokeStatic "core.clj" 1990]
  [clojure.core$with_bindings_STAR_ doInvoke "core.clj" 1990]
  [clojure.lang.RestFn invoke "RestFn.java" 428]
  [nrepl.middleware.interruptible_eval$evaluate$fn__1426 invoke "interruptible_eval.clj" 102]
  [clojure.main$repl$read_eval_print__9240$fn__9243 invoke "main.clj" 437]
  [clojure.main$repl$read_eval_print__9240 invoke "main.clj" 437]
  [clojure.main$repl$fn__9249 invoke "main.clj" 459]
  [clojure.main$repl invokeStatic "main.clj" 459]
  [clojure.main$repl doInvoke "main.clj" 368]
  [clojure.lang.RestFn invoke "RestFn.java" 1526]
  [nrepl.middleware.interruptible_eval$evaluate invokeStatic "interruptible_eval.clj" 99]
  [nrepl.middleware.interruptible_eval$evaluate invoke "interruptible_eval.clj" 71]
  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__1459$fn__1463 invoke "interruptible_eval.clj" 166]
  [clojure.lang.AFn run "AFn.java" 22]
  [nrepl.middleware.session$session_exec$main_loop__1531$fn__1535 invoke "session.clj" 236]
  [nrepl.middleware.session$session_exec$main_loop__1531 invoke "session.clj" 235]
  [clojure.lang.AFn run "AFn.java" 22]
  [java.lang.Thread run "Thread.java" 1570]]}
```

Example stack in `master` - 28 frames:

```
user=> (Exception.)
#error {
 :cause nil
 :via
 [{:type java.lang.Exception
   :message nil
   :at [user$eval2485 invokeStatic "NO_SOURCE_FILE" 1]}]
 :trace
 [[user$eval2485 invokeStatic "NO_SOURCE_FILE" 1]
  [user$eval2485 invoke "NO_SOURCE_FILE" 1]
---> nREPL code ends here <---
  [clojure.lang.Compiler eval "Compiler.java" 7691]
  [clojure.lang.Compiler eval "Compiler.java" 7646]
  [clojure.core$eval invokeStatic "core.clj" 3232]
  [clojure.core$eval invoke "core.clj" 3228]
  [nrepl.middleware.interruptible_eval$evaluate$fn__1418$fn__1419$fn__1422 invoke "interruptible_eval.clj" 101]
  [nrepl.middleware.interruptible_eval$evaluate$fn__1418$fn__1419 invoke "interruptible_eval.clj" 100]
  [clojure.lang.AFn applyToHelper "AFn.java" 152]
  [clojure.lang.AFn applyTo "AFn.java" 144]
  [clojure.core$apply invokeStatic "core.clj" 667]
  [clojure.core$with_bindings_STAR_ invokeStatic "core.clj" 1990]
  [clojure.core$with_bindings_STAR_ doInvoke "core.clj" 1990]
  [clojure.lang.RestFn invoke "RestFn.java" 428]
  [nrepl.middleware.interruptible_eval$evaluate$fn__1418 invoke "interruptible_eval.clj" 85]
  [nrepl.middleware.interruptible_eval$evaluate invokeStatic "interruptible_eval.clj" 84]
  [nrepl.middleware.interruptible_eval$evaluate invoke "interruptible_eval.clj" 52]
  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__1431$fn__1435 invoke "interruptible_eval.clj" 138]
  [clojure.lang.AFn run "AFn.java" 22]
  [nrepl.middleware.session$session_exec$main_loop__1513$fn__1517$fn__1518 invoke "session.clj" 325]
  [clojure.lang.AFn applyToHelper "AFn.java" 152]
  [clojure.lang.AFn applyTo "AFn.java" 144]
  [clojure.core$apply invokeStatic "core.clj" 667]
  [clojure.core$with_bindings_STAR_ invokeStatic "core.clj" 1990]
  [clojure.core$with_bindings_STAR_ doInvoke "core.clj" 1990]
  [clojure.lang.RestFn invoke "RestFn.java" 428]
  [nrepl.middleware.session$session_exec$main_loop__1513$fn__1517 invoke "session.clj" 323]
  [nrepl.middleware.session$session_exec$main_loop__1513 invoke "session.clj" 320]
  [clojure.lang.AFn run "AFn.java" 22]
  [java.lang.Thread run "Thread.java" 1570]]}
```

Example stack after this PR - 5 frames:

```
user=> (Exception.)
#error {
 :cause nil
 :via
 [{:type java.lang.Exception
   :message nil
   :at [user$eval2494 invokeStatic "NO_SOURCE_FILE" 1]}]
 :trace
 [[user$eval2494 invokeStatic "NO_SOURCE_FILE" 1]
  [user$eval2494 invoke "NO_SOURCE_FILE" 1]
---> nREPL code ends here <---
  [clojure.lang.Compiler eval "Compiler.java" 7691]
  [nrepl.middleware.interruptible_eval$evaluator$run__1410$fn__1421 invoke "interruptible_eval.clj" 104]
  [nrepl.middleware.interruptible_eval$evaluator$run__1410 invoke "interruptible_eval.clj" 101]
  [nrepl.middleware.session$session_exec$session_loop__1508 invoke "session.clj" 322]
  [nrepl.SessionThread run "SessionThread.java" 21]]}
```

---

- [x] You've updated the [changelog](../CHANGELOG.md)