### PR TITLE
Replace noisy-future with customized executors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#339](https://github.com/nrepl/nrepl/pull/339): Introduce custom REPL implementation instead `clojure.main/repl`.
 * [#341](https://github.com/nrepl/nrepl/pull/341): Make session middleware handle all dynamic bindings.
 * [#342](https://github.com/nrepl/nrepl/pull/342): Make the stack of the eval handler shorter.
+* [#345](https://github.com/nrepl/nrepl/pull/345): Use customized executors for all asynchronous tasks.
 
 ### Bugs fixed
 

--- a/project.clj
+++ b/project.clj
@@ -80,6 +80,7 @@
              :cljfmt {:plugins [[lein-cljfmt "0.8.0"]]
                       :cljfmt {:indents {delay [[:inner 0]]
                                          returning [[:inner 0]]
+                                         run-with [[:inner 0]]
                                          testing-dynamic [[:inner 0]]
                                          testing-print [[:inner 0]]}}}
 

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -10,10 +10,10 @@
    [nrepl.config :as config]
    [nrepl.core :as nrepl]
    [nrepl.ack :refer [send-ack]]
-   [nrepl.misc :refer [noisy-future]]
    [nrepl.server :as nrepl-server]
    [nrepl.socket :as socket]
    [nrepl.transport :as transport]
+   [nrepl.util.threading :as threading]
    [nrepl.version :as version])
   (:import
    [java.net URI]))
@@ -97,9 +97,11 @@ Exit:      Control+D or (exit) or (quit)"
     (println (repl-intro))
     ;; We take 50ms to listen to any greeting messages, and display the value
     ;; in the `:out` slot.
-    (noisy-future (->> (client)
-                       (take-while #(nil? (:id %)))
-                       (run! #(when-let [msg (:out %)] (print msg)))))
+    (threading/run-with @threading/transport-executor
+      ;; Doesn't matter which executor we hijack here, just don't use `future`.
+      (->> (client)
+           (take-while #(nil? (:id %)))
+           (run! #(when-let [msg (:out %)] (print msg)))))
     (Thread/sleep 50)
     (let [session (nrepl/client-session client)]
       (swap! running-repl assoc :transport transport)

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -15,16 +15,19 @@
       (apply println "ERROR:" msgs)
       (when ex (.printStackTrace ^Throwable ex (java.io.PrintWriter. *out*))))))
 
+(defmacro log-exceptions [& body]
+  `(try
+     ~@body
+     (catch Throwable ex#
+       (log ex#)
+       (throw ex#))))
+
 (defmacro noisy-future
   "Executes body in a future, logging any exceptions that make it to the
   top level."
+  {:deprecated "1.3"}
   [& body]
-  `(future
-     (try
-       ~@body
-       (catch Throwable ex#
-         (log ex#)
-         (throw ex#)))))
+  `(future (log-exceptions ~@body)))
 
 (defmacro returning
   "Executes `body`, returning `x`."

--- a/src/clojure/nrepl/util/classloader.clj
+++ b/src/clojure/nrepl/util/classloader.clj
@@ -1,0 +1,27 @@
+(ns nrepl.util.classloader
+  "Creating and managing classloaders supplied to evaluated code."
+  {:added "1.3"}
+  (:import clojure.lang.DynamicClassLoader))
+
+;; TODO : test
+(defn find-topmost-dcl
+  "Try to find and return the highest level DynamicClassLoader instance in the
+  given classloader chain. If not a single DCL is found, return nil."
+  ^DynamicClassLoader
+  [^ClassLoader cl]
+  (loop [cl cl, dcl nil]
+    (if cl
+      (recur (.getParent cl) (if (instance? DynamicClassLoader cl)
+                               cl dcl))
+      dcl)))
+
+(defn dynamic-classloader
+  "Return the topmost DynamicClassLoader if it is present among the parents of the
+  given classloader, otherwise create a new DynamicClassLoader. `classloader`
+  defaults to thread's context classloader if not provided."
+  ^DynamicClassLoader
+  ([]
+   (dynamic-classloader (.getContextClassLoader (Thread/currentThread))))
+  ([classloader]
+   (or (find-topmost-dcl classloader)
+       (DynamicClassLoader. classloader))))

--- a/src/clojure/nrepl/util/threading.clj
+++ b/src/clojure/nrepl/util/threading.clj
@@ -1,0 +1,90 @@
+(ns nrepl.util.threading
+  "Functions and tools for dealing with all threads and threadpools necessary for
+  nREPL operation."
+  {:added "1.3"}
+  (:require
+   [nrepl.misc :as misc]
+   [nrepl.util.classloader :as classloader])
+  (:import
+   (java.util.concurrent Executors ExecutorService ScheduledExecutorService
+                         TimeUnit)
+   (nrepl DaemonThreadFactory)))
+
+(defn thread-factory
+  "Return a thread factory that produces daemon threads with the name specified by
+  `thread-name-fmt`."
+  [thread-name-fmt]
+  (DaemonThreadFactory. thread-name-fmt (classloader/dynamic-classloader)))
+
+(defmacro run-with
+  "Run the provided `body` using `executor`. Don't wait for the result (unless the
+  executor itself is blocking)."
+  {:style/indent 1}
+  [executor & body]
+  `(.submit ~(with-meta executor {:tag (symbol (.getName ExecutorService))})
+            (reify Runnable
+              (run [_#]
+                ~@body))))
+
+;; Executors are wrapped in delays to defer their initialization.
+
+(def listen-executor
+  "Executor used to accept incoming connections."
+  (delay (Executors/newCachedThreadPool (thread-factory "nREPL-server-%d"))))
+
+(def transport-executor
+  "Executor used to run the transport  run the handler loop and handle individual requests."
+  (delay (Executors/newCachedThreadPool (thread-factory "nREPL-transport-%d"))))
+
+(def handle-executor
+  "Executor used to run the handler loop and handle individual requests."
+  (delay (Executors/newCachedThreadPool (thread-factory "nREPL-handler-%d"))))
+
+;;;; Thread interruption. Used by session middleware to make eval interruptible.
+
+(def thread-reaper-executor
+  "Executor used to kill session threads that did not respond to interrupt."
+  (delay (Executors/newScheduledThreadPool
+          0 (thread-factory "nREPL-thread-reaper-%d"))))
+
+(defn- jvmti-stop-thread [t]
+  ((misc/requiring-resolve 'nrepl.util.jvmti/stop-thread) t))
+
+(defn- try-stop-thread [^Thread t]
+  (cond
+    (<= misc/java-version 19) (.stop t)
+    ;; Since JDK20, Thread.stop() no longer works. We must resort to using
+    ;; JVMTI native agent which luckily still supports Stop Thread command.
+    ;; Whether this is more dangerous than calling Thread.stop() in earlier
+    ;; JDKs is unknown, but assume the worst and never use this if you can't
+    ;; take the risk!
+    (misc/jvmti-agent-enabled?) (jvmti-stop-thread t)
+
+    (not (misc/attach-self-enabled?))
+    (misc/log "Cannot stop thread on JDK21+ without -Djdk.attach.allowAttachSelf"
+              "enabled, see https://nrepl.org/nrepl/installation.html#jvmti.")))
+
+(def ^:private force-stop-delay-ms 5000)
+
+(defn interrupt-stop
+  "This works as follows
+
+  1. Calls interrupt
+  2. Wait 100ms. This is mainly to allow thread that respond quickly to
+     interrupts to send a message back in response to the interrupt. Significantly,
+     this includes an exception thrown by `Thread/sleep`.
+  3. Asynchronously: wait another `force-stop-delay-ms` (5000ms) for the thread
+     to cleanly terminate. Only calls `.stop` if it fails to do so (and risk
+     state corruption)
+
+  This set of behaviours strikes a balance between allowing a thread to respond
+  to an interrupt, but also ensuring we actually kill runaway processes."
+  [^Thread t]
+  ;; TODO: make timeouts configurable?
+  (.interrupt t)
+  (Thread/sleep 100)
+  (.schedule ^ScheduledExecutorService @thread-reaper-executor
+             ^Runnable #(misc/log-exceptions
+                         (when-not (= (.getState t) Thread$State/TERMINATED)
+                           (try-stop-thread t)))
+             ^long force-stop-delay-ms TimeUnit/MILLISECONDS))

--- a/src/java/nrepl/DaemonThreadFactory.java
+++ b/src/java/nrepl/DaemonThreadFactory.java
@@ -1,0 +1,29 @@
+package nrepl;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Thread factory that constructs daemon threads and names them sequentially.
+ * Rewritten from reify because of some weird issue with Clojure 1.7.
+ */
+public class DaemonThreadFactory implements ThreadFactory {
+
+    private final AtomicLong counter = new AtomicLong(0);
+    private final String nameFormat;
+    private final ClassLoader classloader;
+
+    public DaemonThreadFactory(String nameFormat, ClassLoader classloader) {
+        this.nameFormat = nameFormat;
+        this.classloader = classloader;
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread t = new Thread(r);
+        t.setName(String.format(nameFormat, counter.getAndIncrement()));
+        t.setContextClassLoader(classloader);
+        t.setDaemon(true);
+        return t;
+    }
+}

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -22,6 +22,7 @@
    [nrepl.misc :refer [uuid]]
    [nrepl.server :as server]
    [nrepl.test-helpers :as th]
+   [nrepl.util.threading :as threading]
    [nrepl.transport :as transport])
   (:import
    (java.io File Writer)
@@ -524,7 +525,7 @@
 
 (def-repl-test non-interruptible-stop-thread
   (testing "non-interruptible code can still be interrupted"
-    (with-redefs [session/force-stop-delay-ms 500]
+    (with-redefs [threading/force-stop-delay-ms 500]
       (let [resp (message session {:op "eval"
                                    :code (code
                                           (do (def vol (volatile! 0))

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -779,6 +779,7 @@
                 first
                 clean-response
                 :status)))
+    (Thread/sleep 500)
     (is (= #{:done :eval-error :interrupted}
            (->> resp
                 combine-responses

--- a/test/clojure/nrepl/util/classloader_test.clj
+++ b/test/clojure/nrepl/util/classloader_test.clj
@@ -1,0 +1,23 @@
+(ns nrepl.util.classloader-test
+  (:require [clojure.test :refer :all]
+            [nrepl.util.classloader :as classloader])
+  (:import clojure.lang.DynamicClassLoader))
+
+(def top-cl (->> (.getContextClassLoader (Thread/currentThread))
+                 (iterate #(.getParent ^ClassLoader %))
+                 (take-while identity)
+                 last))
+
+(deftest find-topmost-dcl-test
+  (let [dcl1 (DynamicClassLoader. top-cl)
+        dcl2 (DynamicClassLoader. dcl1)]
+    (is (= nil (classloader/find-topmost-dcl top-cl)))
+    (is (= dcl1 (classloader/find-topmost-dcl dcl1)))
+    (is (= dcl1 (classloader/find-topmost-dcl dcl2)))))
+
+(deftest dynamic-classloader-test
+  (let [dcl1 (DynamicClassLoader. top-cl)
+        dcl2 (DynamicClassLoader. dcl1)]
+    (is (instance? DynamicClassLoader (classloader/dynamic-classloader top-cl)))
+    (is (= dcl1 (classloader/dynamic-classloader dcl1)))
+    (is (= dcl1 (classloader/dynamic-classloader dcl2)))))


### PR DESCRIPTION
Addresses #332.

This PR replaces relying on Clojure futures to perform nREPL internal asynchronous tasks with custom-branded executors. Different stages of the nREPL process get different threads. The futures pool is no longer touched, and thus nREPL doesn't anymore leave hanging non-daemon threads that can prevent the application from stopping normally.

This is what the result looks like:

<img width="1000" alt="image" src="https://github.com/nrepl/nrepl/assets/468477/ee66e6b0-71b4-4d58-aa0d-04c10ec3087c">

Tangentially, this PR extracts classloader-related and thread-related code into dedicated namespaces out of `session.clj`. So the middleware namespace got a bit lighter.

This code is fresh, so I will be dogfooding it for a while.

---

- [x] You've updated the [changelog](../CHANGELOG.md)