### PR TITLE
[print] Refactor print middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#341](https://github.com/nrepl/nrepl/pull/341): Make session middleware handle all dynamic bindings.
 * [#342](https://github.com/nrepl/nrepl/pull/342): Make the stack of the eval handler shorter.
 * [#345](https://github.com/nrepl/nrepl/pull/345): Use customized executors for all asynchronous tasks.
+* [#347](https://github.com/nrepl/nrepl/pull/347): Refactor print middleware to have tidier stack and use Java classes instead of proxies.
 
 ### Bugs fixed
 

--- a/src/java/nrepl/CallbackWriter.java
+++ b/src/java/nrepl/CallbackWriter.java
@@ -1,0 +1,41 @@
+package nrepl;
+
+import clojure.lang.IFn;
+import java.io.*;
+
+/**
+ * A variant of StringWriter that invokes the provided callback on the printed
+ * string every time something is written to the writer.
+ */
+public class CallbackWriter extends StringWriter {
+
+    private final IFn callback;
+
+    public CallbackWriter(IFn callback) {
+        super();
+        this.callback = callback;
+    }
+
+    @Override
+    public void write(char[] cbuf) {
+        this.write(cbuf, 0, cbuf.length);
+    }
+
+    @Override
+    public void write(char[] cbuf, int off, int len) {
+        this.write(new String(cbuf, off, len), off, len);
+    }
+
+    @Override
+    public void write(String str) {
+        this.write(str, 0, str.length());
+    }
+
+    @Override
+    public void write(String str, int off, int len) {
+        String s = off == 0 && len == str.length() ?
+            str : str.substring(off, off+len);
+        if (len > 0)
+            callback.invoke(s);
+    }
+}

--- a/src/java/nrepl/QuotaBoundWriter.java
+++ b/src/java/nrepl/QuotaBoundWriter.java
@@ -1,0 +1,94 @@
+package nrepl;
+
+import java.io.*;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Wrapper around <code>java.io.Writer</code> that throws
+ * <code>nrepl.QuotaExceeded</code> once it has written more than quota bytes.
+ */
+public class QuotaBoundWriter extends Writer {
+
+    private final Writer wrappedWriter;
+    private final int quota;
+    private int remaining;
+    private final ReentrantLock lock = new ReentrantLock();
+
+    public QuotaBoundWriter(Writer writer, int quotaBytes) {
+        super();
+        if (quotaBytes <= 0) {
+            throw new IllegalArgumentException("Invalid quota: " + quotaBytes);
+        }
+        this.wrappedWriter = writer;
+        this.quota = quotaBytes;
+        this.remaining = quotaBytes;
+    }
+
+    @Override
+    public void write(int c) throws IOException {
+        lock.lock();
+        try {
+            if (remaining <= 0)
+                throw new QuotaExceeded();
+            wrappedWriter.write(c);
+            remaining--;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void writeStringOrChars(Object stringOrChars, int off, int len)
+        throws IOException {
+        lock.lock();
+        try {
+            boolean tooBig = (len > remaining);
+            len = Math.min(len, remaining);
+            if (len > 0) {
+                if (stringOrChars instanceof String)
+                    wrappedWriter.write((String)stringOrChars, off, len);
+                else
+                    wrappedWriter.write((char[])stringOrChars, off, len);
+                remaining -= len;
+            }
+            if (tooBig)
+                throw new QuotaExceeded();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void write(char[] cbuf) throws IOException {
+        this.write(cbuf, 0, cbuf.length);
+    }
+
+    @Override
+    public void write(char[] cbuf, int off, int len) throws IOException {
+        writeStringOrChars(cbuf, off, len);
+    }
+
+    @Override
+    public void write(String str) throws IOException {
+        this.write(str, 0, str.length());
+    }
+
+    @Override
+    public void write(String str, int off, int len) throws IOException {
+        writeStringOrChars(str, off, len);
+    }
+
+    @Override
+    public String toString() {
+        return wrappedWriter.toString();
+    }
+
+    @Override
+    public void flush() throws IOException {
+        wrappedWriter.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        wrappedWriter.close();
+    }
+}

--- a/src/java/nrepl/QuotaExceeded.java
+++ b/src/java/nrepl/QuotaExceeded.java
@@ -1,5 +1,5 @@
 package nrepl;
 
-public class QuotaExceeded extends Throwable {
+public class QuotaExceeded extends Error {
 
 }


### PR DESCRIPTION
Several changes are made:

- Proxies that represented a writer that throws QuotaExceeded errors and the writer that calls underlying transport were rewritten to Java classes `QuotaWriter` and `CallbackWriter` respectively. They are bigger in LOC in Java compared to Clojure, but the handling of different arities is more explicit. Also, proxies are meh.
- Simplified and made more apparent the interaction between request and response print parameters, added more comments about what is happening.

The dynamic variables are kept in the working state, they are not going anywhere. @cichli, you may want to take a look.

---

- [x] You've updated the [changelog](../CHANGELOG.md)