### PR TITLE
[transport] Check early that the top-level nREPL message is a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Bugs fixed
 
+* [#348](https://github.com/nrepl/nrepl/pull/348): Fail with helpful error if incorrect bencode is written through the transport.
+
 ## 1.2.0 (2024-06-10)
 
 ### Changes

--- a/src/clojure/nrepl/bencode.clj
+++ b/src/clojure/nrepl/bencode.clj
@@ -268,6 +268,16 @@
           :else (do (.unread input first-byte)
                     (read-netstring* input)))))
 
+(defn read-nrepl-message
+  "Sames as `read-bencode`, but ensure that the top-level value is a map as
+  expected by the nREPL protocol."
+  [^PushbackInputStream input]
+  (let [first-byte (read-byte input)]
+    (if (= first-byte d)
+      (read-map input)
+      (throw (ex-info (format "nREPL message must be a map.
+Wrong first byte: %s (must be %d)." first-byte d) {})))))
+
 ;; ## Writing bencode
 ;;
 ;; Writing bencode is similar easy as reading it. The main entry point

--- a/src/clojure/nrepl/transport.clj
+++ b/src/clojure/nrepl/transport.clj
@@ -123,7 +123,7 @@
    (let [in (PushbackInputStream. (socket/buffered-input in))
          out (socket/buffered-output out)]
      (fn-transport
-      #(let [payload (rethrow-on-disconnection s (bencode/read-bencode in))
+      #(let [payload (rethrow-on-disconnection s (bencode/read-nrepl-message in))
              unencoded (<bytes (payload "-unencoded"))
              to-decode (apply dissoc payload "-unencoded" unencoded)]
          (walk/keywordize-keys (merge (dissoc payload "-unencoded")

--- a/test/clojure/nrepl/transport_test.clj
+++ b/test/clojure/nrepl/transport_test.clj
@@ -1,7 +1,8 @@
 (ns nrepl.transport-test
   (:require [nrepl.transport :as sut]
             [clojure.test :refer [deftest testing is]])
-  (:import [java.io ByteArrayOutputStream]))
+  (:import (java.io BufferedInputStream BufferedOutputStream
+                    ByteArrayInputStream ByteArrayOutputStream)))
 
 (deftest bencode-safe-write-test
   (testing "safe-write-bencode only writes if the whole message is writable"
@@ -21,3 +22,22 @@
                (.recv fn-transport)     ;; :op "clone"
                (-> (.recv fn-transport) ;; :op "eval"
                    :code)))))))
+
+(deftest malformed-bencode-input-test
+  (testing "if non-bencode input is passed, throw an informative error"
+    (let [in (-> (.getBytes "123456789123456789123456789")
+                 ByteArrayInputStream.
+                 BufferedInputStream.)
+          out (BufferedOutputStream. (ByteArrayOutputStream.))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"^nREPL message must be a map."
+                            (sut/recv (sut/bencode in out))))))
+
+  (testing "if top-level message is not a map, throw an informative error"
+    (let [in (-> (.getBytes "li1ei2ei3ee")
+                 ByteArrayInputStream.
+                 BufferedInputStream.)
+          out (BufferedOutputStream. (ByteArrayOutputStream.))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"^nREPL message must be a map."
+                            (sut/recv (sut/bencode in out)))))))


### PR DESCRIPTION
Fixes #285.

The idea is to check early if the first byte is `d` (in bencode, this means that the next value is a map). Because all nREPL messages are maps in the top-level, this saves us from reading garbage if someone sends us not bencode (e.g., in a scenario when socket REPL connects on the nREPL bencode port).

---

- [x] You've updated the [changelog](../CHANGELOG.md)