### PR TITLE
[cmdline] Preserve metadata when sending input from CLI client to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bugs fixed
 
+* [#271](https://github.com/nrepl/nrepl/pull/271): Fix not being able to define dynamic variables from terminal REPL.
 * [#348](https://github.com/nrepl/nrepl/pull/348): Fail with helpful error if incorrect bencode is written through the transport.
 
 ## 1.2.0 (2024-06-10)


### PR DESCRIPTION
Fixes #271.

I decided to go with `*print-meta*` route as trying to read an s-expression from the inputstream while preserving it as a string is too cumbersome. This fix should do for now.

When refactoring the cmdline_test file, I also discovered #351. I couldn't fix it head-on, I created a bug report for now.

---

- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)