### PR TITLE
[session] Restore compatibility with middleware that passes 3 args to :exec

### DIFF
--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -142,8 +142,7 @@
           (t/send transport (response-for msg :status #{:error :no-code :done}))
           (exec id
                 (evaluator msg)
-                #(t/send transport (response-for msg :status :done))
-                msg))
+                #(t/send transport (response-for msg :status :done))))
         (h msg)))))
 
 (set-descriptor! #'interruptible-eval


### PR DESCRIPTION
My refactoring of interruptible-eval and session middleware broke cider-nrepl middleware that relied on calling session's `:exec` function. While it is possible to fix things in cider-nrepl, then it would be trickier to keep it compatible with older and never nREPL versions. I rethought the implementation to preserve the backward compatibility here.

See https://github.com/clojure-emacs/cider/issues/3727.

We'll need a beta3 after merging this.