### PR TITLE
[session] Allow passing explicit msg to persistent session :exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#364](https://github.com/nrepl/nrepl/pull/364): Retain explicitly added session values.
+
 ## 1.3.0 (2024-08-13)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#363](https://github.com/nrepl/nrepl/pull/363): Pass the up-to-date `msg` to interruptible eval.
 * [#364](https://github.com/nrepl/nrepl/pull/364): Retain explicitly added session values.
 
 ## 1.3.0 (2024-08-13)

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -142,7 +142,8 @@
           (t/send transport (response-for msg :status #{:error :no-code :done}))
           (exec id
                 (evaluator msg)
-                #(t/send transport (response-for msg :status :done))))
+                #(t/send transport (response-for msg :status :done))
+                msg))
         (h msg)))))
 
 (set-descriptor! #'interruptible-eval

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -228,9 +228,11 @@
                (if (fn? r)
                  (r) ;; -1 stack frame this way.
                  (.run r))
-               ;; Remove vars that we don't want to save into the session.
-               (reset! session (dissoc (get-thread-bindings)
-                                       #'*msg* Compiler/LOADER))
+               (swap! session (fn [current]
+                                (-> (merge current (get-thread-bindings))
+                                    ;; Remove vars that we don't want to save
+                                    ;; into the session.
+                                    (dissoc #'*msg* Compiler/LOADER))))
                ;; We don't use try/finally here because if the eval throws an
                ;; exception, we're going to discard the whole thread. This makes
                ;; the stack cleaner.


### PR DESCRIPTION
Resurrect an `:exec` arity that takes an explicit `msg`. It was briefly like that on the road to 1.3, then I scrapped it because it introduced incompatibility for middleware that still called `:exec` with three arguments. Ultimately, the correct way is to pass an explicit `msg`. But the PR keeps the old 3-arg version for compatibility and tries to do "good enough" by taking the initial `*msg*` in such case.

The other commit partly restores the old session management behavior that Piggieback relies on.