### PR TITLE
Add brepl CLI client to docs

### DIFF
--- a/doc/modules/ROOT/pages/usage/clients.adoc
+++ b/doc/modules/ROOT/pages/usage/clients.adoc
@@ -15,6 +15,7 @@ servers written in any language.
 * https://github.com/eraserhd/rep[rep] (A single-shot nREPL client designed for shell invocation.)
 * https://git.sr.ht/~technomancy/shevek/[shevek] (A command-line nREPL client written in https://fennel-lang.org/[Fennel], works with non-Clojure servers)
 * https://github.com/kanej/parle[Parle] (A command-line nREPL client using node.js written in ClojureScript)
+* https://github.com/licht1stein/brepl[brepl] (A fast babashka based command-line nREPL client)
 
 NOTE: Leiningen uses REPL-y internally as its command-line nREPL client.
 


### PR DESCRIPTION
This a docs PR that adds a tiny CLI client I built.