### PR TITLE
[config] Add support for dynamic var defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Changes
 
-* [#370](https://github.com/nrepl/nrepl/pull/3370): Accept `:client-name` and `:client-version` in `clone` op.
+* [#370](https://github.com/nrepl/nrepl/pull/370): Accept `:client-name` and `:client-version` in `clone` op.
+* [#374](https://github.com/nrepl/nrepl/pull/374): Add support for dynamic var defaults.
 
 ## 1.3.1 (2025-01-01)
 

--- a/doc/modules/ROOT/pages/usage/server.adoc
+++ b/doc/modules/ROOT/pages/usage/server.adoc
@@ -409,3 +409,22 @@ And this is an example of a local config file:
  :handler      some.ns/awesome-handler
  :transport    nrepl.transport/bencode}
 ----
+
+=== Dynamic var defaults
+
+You can use the server configuration file (either project-local or system-wide)
+to specify the default values for any dynamic variable whenever a new client is
+connected (note that the variable's namespace has to be already loaded at that
+point). This serves two important purposes:
+
+- Gives a starting value to the dynamic variable.
+- Makes it rebindable thread-locally via `set!`.
+
+For example, you can use this feature to enable reflection warnings in all your
+local projects by putting this into your global config:
+
+..nrepl/nrepl.edn
+[source,clojure]
+----
+{:dynamic-vars {clojure.core/*warn-on-reflection* true}}
+----

--- a/test/clojure/nrepl/middleware/session_test.clj
+++ b/test/clojure/nrepl/middleware/session_test.clj
@@ -1,0 +1,28 @@
+(ns nrepl.middleware.session-test
+  {:author "Oleksandr Yakushev"}
+  (:require
+   [clojure.test :refer :all]
+   [nrepl.config :as config]
+   [nrepl.core-test :refer [repl-server-fixture with-repl-server]]))
+
+(use-fixtures :each repl-server-fixture)
+
+(def ^:dynamic *test-var1*)
+(def ^:dynamic *test-var2* :root)
+
+(deftest dynvar-defaults-test
+  (testing "dynvar receives a default value from config"
+    (with-redefs [config/config {:dynamic-vars {'nrepl.middleware.session-test/*test-var1* 1}}]
+      (with-repl-server
+        (let [result (repl-values session "nrepl.middleware.session-test/*test-var1*")]
+          (is (= [1] result))))))
+
+  (testing "config can override a dynvar that has a root value"
+    (with-repl-server
+      (let [result (repl-values session "nrepl.middleware.session-test/*test-var2*")]
+        (is (= [:root] result))))
+
+    (with-redefs [config/config {:dynamic-vars {'nrepl.middleware.session-test/*test-var2* :override}}]
+      (with-repl-server
+        (let [result (repl-values session "nrepl.middleware.session-test/*test-var2*")]
+          (is (= [:override] result)))))))


### PR DESCRIPTION
This solves several issues:

1. Finally gives a way to enforce `*warn-on-reflection*` in all projects by default. Only on the server side, not the client side, but I suppose clients can invent something for this too if they want. But this covers my personal needs by 95%.
2. Offers an opt-in solution for users to open certain dynvars for changing via `set!`. This is something similar to what is requested in https://github.com/nrepl/nrepl/discussions/373, albeit less flexible. Perhaps, we will need something in the future that can evaluate code too (the current implementation only accepts constants as defaults), but still this solution can go a long way.

Thoughts, suggestions.

---

- [x] You've added tests to cover your change(s)
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)