### PR TITLE
Add nrepl.transport/respond-to

### DIFF
--- a/src/clojure/nrepl/middleware/caught.clj
+++ b/src/clojure/nrepl/middleware/caught.clj
@@ -26,14 +26,12 @@
 (def configuration-keys
   [::caught-fn ::print?])
 
-(defn- resolve-caught
-  [{:keys [::caught transport] :as msg}]
-  (when-let [var-sym (some-> caught (symbol))]
+(defn- resolve-caught [msg]
+  (when-let [var-sym (some-> (::caught msg) (symbol))]
     (let [caught-var (misc/requiring-resolve var-sym)]
       (when-not caught-var
-        (let [resp {:status ::error
-                    ::error (str "Couldn't resolve var " var-sym)}]
-          (transport/send transport (misc/response-for msg resp))))
+        (transport/respond-to msg {::error (str "Couldn't resolve var " var-sym)
+                                   :status ::error}))
       caught-var)))
 
 (defn- caught-transport

--- a/src/clojure/nrepl/middleware/lookup.clj
+++ b/src/clojure/nrepl/middleware/lookup.clj
@@ -13,10 +13,9 @@
    :added "0.8"}
   (:require
    [nrepl.middleware :as middleware :refer [set-descriptor!]]
-   [nrepl.misc :refer [response-for] :as misc]
+   [nrepl.misc :as misc]
    [nrepl.transport :as t]
-   [nrepl.util.lookup :as lookup])
-  (:import nrepl.transport.Transport))
+   [nrepl.util.lookup :as lookup]))
 
 (def ^:dynamic *lookup-fn*
   "Function to use for lookup. Takes two arguments:
@@ -28,15 +27,14 @@
 (defn lookup-reply
   [{:keys [session sym ns lookup-fn] :as msg}]
   (try
-    (let [ns (if ns (symbol ns) (symbol (str (@session #'*ns*))))
+    (let [the-ns (if ns (symbol ns) (symbol (str (@session #'*ns*))))
           sym (symbol sym)
           lookup-fn (or (some-> lookup-fn symbol misc/requiring-resolve)
                         (misc/resolve-in-session msg *lookup-fn*))]
-      (response-for msg {:status :done :info (lookup-fn ns sym)}))
-    (catch Exception _e
-      (if (nil? ns)
-        (response-for msg {:status #{:done :lookup-error :namespace-not-found}})
-        (response-for msg {:status #{:done :lookup-error}})))))
+      {:status :done, :info (lookup-fn the-ns sym)})
+    (catch Exception _
+      {:status (cond-> #{:done :lookup-error}
+                 (some? ns) (conj :namespace-not-found))})))
 
 (defn wrap-lookup
   "Middleware that provides symbol info lookup.
@@ -47,9 +45,9 @@
   * `lookup` – a fully-qualified symbol naming a var whose function to use for
   lookup. Must point to a function with signature [sym ns]."
   [h]
-  (fn [{:keys [op ^Transport transport] :as msg}]
+  (fn [{:keys [op] :as msg}]
     (if (= op "lookup")
-      (t/send transport (lookup-reply msg))
+      (t/respond-to msg (lookup-reply msg))
       (h msg))))
 
 (set-descriptor! #'wrap-lookup

--- a/src/clojure/nrepl/transport.clj
+++ b/src/clojure/nrepl/transport.clj
@@ -6,7 +6,7 @@
    [clojure.java.io :as io]
    [clojure.walk :as walk]
    [nrepl.bencode :as bencode]
-   [nrepl.misc :refer [uuid]]
+   [nrepl.misc :refer [response-for uuid]]
    [nrepl.socket :as socket]
    [nrepl.util.threading :as threading]
    nrepl.version)
@@ -247,3 +247,8 @@
   (let [a (LinkedBlockingQueue.)
         b (LinkedBlockingQueue.)]
     [(QueueTransport. a b) (QueueTransport. b a)]))
+
+(defn respond-to
+  "Send a response for `msg` with `response-data` using message's transport."
+  [msg & response-data]
+  (send (:transport msg) (apply response-for msg response-data)))

--- a/test/clojure/nrepl/middleware/completion_test.clj
+++ b/test/clojure/nrepl/middleware/completion_test.clj
@@ -22,7 +22,7 @@
            clean-response)))
 
 (def-repl-test completions-op-error
-  (is+ {:status #{:done :completion-error :namespace-not-found}
+  (is+ {:status #{:done :completion-error}
         :completions mc/absent}
        (-> (nrepl/message session {:op "completions"})
            nrepl/combine-responses

--- a/test/clojure/nrepl/middleware/lookup_test.clj
+++ b/test/clojure/nrepl/middleware/lookup_test.clj
@@ -35,7 +35,7 @@
              clean-response))))
 
 (def-repl-test lookup-op-error
-  (is+ {:status #{:done :lookup-error :namespace-not-found}}
+  (is+ {:status #{:done :lookup-error}}
        (-> (nrepl/message session {:op "lookup"})
            nrepl/combine-responses
            clean-response)))


### PR DESCRIPTION
Similarly to what I added to cider-nrepl one day, `respond-to` is a shortcut for a common pattern `(transport/send (:transport msg) (response-for msg ...)`.

Still no `with-safe-transport` but I'm considering it.