### PR TITLE
[middleware] Introduce safe-handle

### DIFF
--- a/doc/modules/ROOT/pages/building_middleware.adoc
+++ b/doc/modules/ROOT/pages/building_middleware.adoc
@@ -182,6 +182,32 @@ As a result, in some cases you'd be invoking nREPL's op and in other cases `cide
 If `cider-nrepl` had named the op `cider/complete` instead, that would have prevented this unfortunate
 situation.
 
+=== Robustness and error handling
+
+Given how misbehavior of a foundational tool like nREPL can greatly diminish the
+user experience, it is doubly important to prevent exceptions or errors to
+happen during middleware processing, but also vital to signalize that an error
+did occur (as the communication is often asynchronous, this needs to be done
+explicitly). A common pattern is to use `nrepl.transport/safe-handle` macro
+which accepts a list of op and handler pairs and wraps the handler invocation in
+`try/catch` block so that you don't forget to. If an exception is thrown, the
+macro will send an error message through the message's transport. For example:
+
+[source,clojure]
+----
+(defn wrap-foo [h]
+  (fn [msg]
+    (safe-handle msg
+      "foo" foo-reply
+      :else h)))
+----
+
+This middleware will call `(foo-reply msg)` in a try/catch if the message has
+`:op "foo"`, and otherwise will invoke the rest of the middleware chain with
+`h`. The return of `(foo-reply msg)` is merged with msg-specific fields and sent
+to the client. If `(foo-reply msg)` throws an exception, a message with `:status
+#{:foo-error}` will be sent to the client.
+
 == Additional Resources
 
 * https://metaredux.com/posts/2019/12/04/documenting-nrepl-middleware-apis.html

--- a/project.clj
+++ b/project.clj
@@ -90,6 +90,7 @@
                                          run-with [[:inner 0]]
                                          testing-dynamic [[:inner 0]]
                                          testing-print [[:inner 0]]
+                                         safe-handle [[:inner 0]]
                                          when-require [[:inner 0]]}}}
 
              :eastwood [:test

--- a/src/clojure/nrepl/middleware.clj
+++ b/src/clojure/nrepl/middleware.clj
@@ -3,7 +3,7 @@
   (:require
    [clojure.set :as set]
    [nrepl.misc :as misc]
-   [nrepl.transport :as t]
+   [nrepl.transport :as t :refer [safe-handle]]
    [nrepl.version :as version]))
 
 ;; Registering dynvars that are used to configure middleware. This lives here
@@ -49,29 +49,33 @@
   {:major misc/java-version
    :version-string (System/getProperty "java.version")})
 
+(defn- describe-reply
+  [{:keys [descriptors verbose?] :as msg}]
+  (merge
+   (when-let [aux (reduce
+                   (fn [aux {:keys [describe-fn]}]
+                     (if describe-fn
+                       (merge aux (describe-fn msg))
+                       aux))
+                   nil
+                   (vals descriptors))]
+     {:aux aux})
+   {:ops (let [ops (apply merge (map :handles (vals descriptors)))]
+           (if verbose?
+             ops
+             (zipmap (keys ops) (repeat {}))))
+    :versions {:nrepl (safe-version version/version)
+               :clojure (safe-version
+                         (assoc *clojure-version* :version-string (clojure-version)))
+               :java (safe-version (java-version))}
+    :status :done}))
+
 (defn wrap-describe
   [h]
-  (fn [{:keys [op descriptors verbose?] :as msg}]
-    (if (= op "describe")
-      (t/respond-to msg (merge
-                         (when-let [aux (reduce
-                                         (fn [aux {:keys [describe-fn]}]
-                                           (if describe-fn
-                                             (merge aux (describe-fn msg))
-                                             aux))
-                                         nil
-                                         (vals descriptors))]
-                           {:aux aux})
-                         {:ops (let [ops (apply merge (map :handles (vals descriptors)))]
-                                 (if verbose?
-                                   ops
-                                   (zipmap (keys ops) (repeat {}))))
-                          :versions {:nrepl (safe-version version/version)
-                                     :clojure (safe-version
-                                               (assoc *clojure-version* :version-string (clojure-version)))
-                                     :java (safe-version (java-version))}
-                          :status :done}))
-      (h msg))))
+  (fn [msg]
+    (safe-handle msg
+      "describe" describe-reply
+      :else h)))
 
 (set-descriptor! #'wrap-describe
                  {:handles {"describe"

--- a/test/clojure/nrepl/middleware/completion_test.clj
+++ b/test/clojure/nrepl/middleware/completion_test.clj
@@ -22,7 +22,7 @@
            clean-response)))
 
 (def-repl-test completions-op-error
-  (is+ {:status #{:done :completion-error}
+  (is+ {:status #{:done :error :completions-error}
         :completions mc/absent}
        (-> (nrepl/message session {:op "completions"})
            nrepl/combine-responses

--- a/test/clojure/nrepl/middleware/lookup_test.clj
+++ b/test/clojure/nrepl/middleware/lookup_test.clj
@@ -35,7 +35,7 @@
              clean-response))))
 
 (def-repl-test lookup-op-error
-  (is+ {:status #{:done :lookup-error}}
+  (is+ {:status #{:done :error :lookup-error}}
        (-> (nrepl/message session {:op "lookup"})
            nrepl/combine-responses
            clean-response)))


### PR DESCRIPTION
This is analogous to `with-safe-transport` that we talked about, with some differences.
- I never liked the name `with-safe-transport` because it implies the transport itself is somehow made safe where it is just a glorified try-catch. Meaning that asynchronous errors on the transport are not really caught. I think `safe-handle` name is more appropriate.
- Obviously, we cannot do the stacktrace analysis magic inside nrepl because that is a cider-nrepl functionality. So all `safe-handle` does is it sends an error response over the transport containing the exception message and the status of the form `:<op>-error`. I didn't do any customization of status keywords, these errors should be exceedingly rare, and the bikeshedding here is not important.

There just a few spots where I managed to use this new macro, but there might be more in the future, so I think it is useful.
