### PR TITLE
[eval] Preserve filename in functions compiled during regular eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#385](https://github.com/nrepl/nrepl/pull/385): Preserve filename in functions compiled during regular eval.
+
 ## 1.4.0 (2025-09-02)
 
 ### New features

--- a/test/clojure/nrepl/middleware/interruptible_eval_test.clj
+++ b/test/clojure/nrepl/middleware/interruptible_eval_test.clj
@@ -1,0 +1,23 @@
+(ns nrepl.middleware.interruptible-eval-test
+  {:author "Oleksandr Yakushev"}
+  (:require
+   [clojure.test :refer :all]
+   [clojure.string :as str]
+   [nrepl.core :as nrepl]
+   [nrepl.core-test :refer [def-repl-test repl-server-fixture]]))
+
+(use-fixtures :each repl-server-fixture)
+
+(defn- find-frame-ending-with [^Throwable ex, suffix]
+  (some #(when (str/ends-with? (.getClassName ^StackTraceElement %) suffix) %)
+        (.getStackTrace ex)))
+
+(def-repl-test preserves-source-location-test
+  (testing "plain eval remembers source file for the compiled function"
+    (dorun (repl-eval session "(in-ns 'nrepl.middleware.interruptible-eval-test)"))
+    (dorun (nrepl/message session
+                          {:op "eval" :code "(defn div0 [] (/ 1 0))"
+                           :file "src/acme/foo.clj" :line 42}))
+    (dorun (repl-eval session "(div0)"))
+    (let [[resp] (repl-values session "(.getFileName (find-frame-ending-with *e \"div0\"))")]
+      (is (= "foo.clj" resp)))))


### PR DESCRIPTION
This is a fix to an annoying behavior of CIDER's `C-c C-c`, `C-c C-e`, or any eval really. When you compile a function with it, it wil not remember the filename of the file that you compiled it from. So, if later on an exception is thrown, you get this `REPL` thing (translated from `NO_SOURCE_FILE`):

<img width="590" height="114" alt="image" src="https://github.com/user-attachments/assets/c96f4a00-317d-4f12-832f-3c0df682298f" />

After the fix, it looks more pleasant:

<img width="674" height="115" alt="image" src="https://github.com/user-attachments/assets/d337646a-63cc-44b4-87f2-be7815033bba" />

Another good thing: we may eventually remove CIDER hack that translates that `NO_SOURCE_FILE` back into the correct file when jumping to the stacktrace element.

---

- [x] You've added tests to cover your change(s)
- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)