### PR TITLE
Add support for XDG_CONFIG_HOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#386](https://github.com/nrepl/nrepl/pull/386): Add support for XDG_CONFIG_HOME
 * [#383](https://github.com/nrepl/nrepl/pull/383): Introduce `safe-handle` helper to simplify dealing with errors in middleware responses.
 
 ### Changes

--- a/doc/modules/ROOT/pages/usage/server.adoc
+++ b/doc/modules/ROOT/pages/usage/server.adoc
@@ -367,15 +367,16 @@ nREPL server's behaviour via configuration files.
 
 There are two configuration files:
 
-* Global configuration file `.nrepl/nrepl.edn`
+* Global configuration file `~/.nrepl/nrepl.edn`
 * Local configuration file `.nrepl.edn`
 
 The global configuration file is useful for setting options that you'd
 like to use for all the nREPL servers that you start (e.g. a common
 `bind-address`, `transport`, `handler`, etc).
 
-TIP: You can alter the location of the global configuration file
-via the environment variable `NREPL_CONFIG_DIR`.
+TIP: Set `NREPL_CONFIG_DIR` to override the global config directory.
+Otherwise nREPL uses `$XDG_CONFIG_HOME/nrepl`, then `~/.config/nrepl`,
+and finally defaults to `~/.nrepl`.
 
 The local configuration file should be placed in the directory from
 which you're starting the server (normally the root directory of your

--- a/src/clojure/nrepl/config.clj
+++ b/src/clojure/nrepl/config.clj
@@ -29,10 +29,9 @@
   or `nil` otherwise."
   [env-var]
   (let [value (System/getenv env-var)]
-    (when (and value (not (str/blank? value)))
-      value)))
+    (when (not (str/blank? value)) value)))
 
-(def config-file-name "nrepl.edn")
+(def ^:private config-file-name "nrepl.edn")
 
 (def config-file
   "nREPL's global configuration file.

--- a/src/clojure/nrepl/config.clj
+++ b/src/clojure/nrepl/config.clj
@@ -29,7 +29,7 @@
   or `nil` otherwise."
   [env-var]
   (let [value (System/getenv env-var)]
-    (when (not (str/blank? value)) value)))
+    (when-not (str/blank? value) value)))
 
 (def ^:private config-file-name "nrepl.edn")
 
@@ -50,8 +50,14 @@
          (some-> (non-empty-env "XDG_CONFIG_HOME") (io/file "nrepl" config-file-name))
          (io/file xdg-config-default-dir "nrepl" config-file-name)
          (io/file home-dir ".nrepl" config-file-name)]]
-    (or (some #(when (and % (.exists %)) %) candidates)
+    (or (some (fn [^java.io.File file]
+                (when (and file (.exists file)) file))
+              candidates)
         (last candidates))))
+
+(def config-dir
+  "nREPL's global configuration directory."
+  (.getParentFile ^java.io.File config-file))
 
 (defn- load-edn
   "Load edn from an io/reader source (filename or io/resource)."

--- a/src/clojure/nrepl/config.clj
+++ b/src/clojure/nrepl/config.clj
@@ -37,13 +37,13 @@
   "nREPL's global configuration file.
 
   The location is determined with the following precedence:
-   $NREPL_CONFIG_DIR/nrepl.edn
-   $XDG_CONFIG_HOME/nrepl/nrepl.edn
-   ~/.config/nrepl/nrepl.edn (if ~/.config exists)
-   ~/.nrepl/nrepl.edn
+  * $NREPL_CONFIG_DIR/nrepl.edn
+  * $XDG_CONFIG_HOME/nrepl/nrepl.edn
+  * ~/.config/nrepl/nrepl.edn (if ~/.config exists)
+  * ~/.nrepl/nrepl.edn
 
   Return the first existing config file in this order. If no config
-  file exists in any of these locations, returns the default path
+  file exists in any of these locations, return the default path
   `~/.nrepl/nrepl.edn`."
   (let [candidates
         [(some-> (non-empty-env "NREPL_CONFIG_DIR") (io/file config-file-name))


### PR DESCRIPTION
Closes #384.

The [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest) says:
> If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used.
so I also checked if `~/.config` exists (therefore the user is already using other tools adhering to XDG) and then use the `~/.config/nrepl` as well before defaulting to \~/.nrepl`.

Put it into the TIP in the documentation as well.

No tests :( as there were no tests for this code before as well.
Any chances for the first commit to nrepl? :)