### PR TITLE
[eval] Don't send :done twice if namespace can't be resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 * [#385](https://github.com/nrepl/nrepl/pull/385): Preserve filename in functions compiled during regular eval.
 
+### Bugs fixed
+
+* [#215](https://github.com/nrepl/nrepl/pull/215): Don't send `:done` twice if namespace can't be resolved during `eval`.
+
 ## 1.4.0 (2025-09-02)
 
 ### New features

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -65,7 +65,7 @@
           short-fname (short-file-name file)
           explicit-ns (some-> ns symbol find-ns)]
       (if (and (some? ns) (nil? explicit-ns))
-        (t/respond-to msg {:status #{:error :namespace-not-found :done}
+        (t/respond-to msg {:status #{:error :namespace-not-found}
                            :ns     ns})
         (let [eof (Object.)
               read (if (string? code)


### PR DESCRIPTION
Given how #215 is 5 years old, I think it is good enough to just fix it in the easiest way possible. There are other ways but they are more complicated than this bug is worth. Also, we are all within spec to send :done as a separate message. Also, this is an unhappy path anyway.

---

- [x] You've updated the [changelog](../CHANGELOG.md)(that only applies to user-visible changes)