### PR TITLE
[transport] Refactor TTY transport to avoid double-read

### DIFF
--- a/test/clojure/nrepl/transport_test.clj
+++ b/test/clojure/nrepl/transport_test.clj
@@ -11,22 +11,6 @@
                    (#'sut/safe-write-bencode out {"obj" (Object.)})))
       (is (empty? (.toByteArray out))))))
 
-(deftest tty-read-conditional-test
-  (testing "tty-read-msg is configured to preserve conditionals"
-    (let [in (-> "(try nil (catch #?(:clj Throwable :cljr Exception) e nil))"
-                 (java.io.StringReader.)
-                 (java.io.PushbackReader.))
-          out (ByteArrayOutputStream.)
-          expected (if sut/clojure<1-10
-                     ;; Old behavior was to process conditionals on read
-                     '[(try nil (catch Throwable e nil))]
-                     "(try nil (catch #?(:clj Throwable :cljr Exception) e nil))")]
-      (is (= expected
-             (let [^nrepl.transport.FnTransport fn-transport (sut/tty in out nil)]
-               (.recv fn-transport)     ;; :op "clone"
-               (-> (.recv fn-transport) ;; :op "eval"
-                   :code)))))))
-
 (deftest malformed-bencode-input-test
   (testing "if non-bencode input is passed, throw an informative error"
     (let [in (-> (.getBytes "123456789123456789123456789")


### PR DESCRIPTION
This builds upon the recent contribution by @frankleonrose. I figured that instead of reading the stream out-of-band and then passing the read string to`eval`, we can pass the stream itself to `eval` middleware with some surgical modifications to the latter. Since we already have a custom runtime-only handling of `:code` in eval (it supports taking already read forms from the list – this is only needed by testing and yet it is supported, so it's fine for us to add another support for runtime streams).

The diff for `interruptible-eval` looks huge mostly because of whitespace, the actual changes are minimal.

I decided to make another attempt on this because the current solution flakes the tests occasionally, so I hope to fix the flake too.