### PR TITLE
Add support for naming the port file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* Add support for naming the port file (via command line/env variable/function args)
+
 ## 1.5.1 (2025-10-18)
 
 ### Bugs fixed

--- a/src/clojure/nrepl/config.clj
+++ b/src/clojure/nrepl/config.clj
@@ -79,7 +79,10 @@
   It's created by merging the global configuration file
   with a local configuration file that would normally
   the placed in the directory in which you're running
-  nREPL."
-  (merge
-   (load-config config-file)
-   (load-config (io/file ".nrepl.edn"))))
+  nREPL. Environment variables can override config file settings."
+  (let [base-config (merge
+                     (load-config config-file)
+                     (load-config (io/file ".nrepl.edn")))
+        env-port-file (non-empty-env "NREPL_PORT_FILE")]
+    (cond-> base-config
+      env-port-file (assoc :port-file env-port-file))))


### PR DESCRIPTION
Adds the ability to configure the port file name (default `.nrepl-port`) via CLI arguments, environment variables, config files, and programmatic API.

I find with new AI agents I often want a test REPL (which starts/stops things that would break my dev REPL) AND dev REPL, and I have MCP servers start both. I want to be able to connect to both of them via port files so I can fix problems the AI agents have, but the current library overwrites the file on the second REPL start. I'd actually like to go both directions, but in any case I need alternate port file names. I've written my own deps entry point, but I'd like to be able to configure this in Cursive, but when I talked with Colin Fleming of Cursive, he said he can't add support for that without nrepl library support because of middleware constraints, so I'm submitting this patch.

## Examples:

```bash
# CLI
clojure -M -m nrepl.cmdline --port-file my-port.txt

# Environment variable
export NREPL_PORT_FILE=my-port.txt

# Config file (.nrepl.edn)
{:port-file "my-port.txt"}

# Programmatic API
(server/start-server :port 7888 :port-file ".nrepl-port")
```

## Configuration Precedence

1. CLI argument (`--port-file`)
2. Environment variable (`NREPL_PORT_FILE`)
3. Config file
4. Default (`.nrepl-port` for CLI, `nil` for programmatic API)

## Backward Compatibility

✅ **Fully backward compatible** - No breaking changes:
- CLI: Creates `.nrepl-port` by default (unchanged)
- Programmatic API: No port file unless explicitly requested (unchanged)
- All changes are additive (optional parameters only)

## Bug Fix

Fixes bug where filesystem socket servers incorrectly wrote port files with `nil` content. Port file creation now explicitly skipped for filesystem sockets.

## Testing

All 19 tests passed covering:
- CLI default behavior and custom `--port-file` option
- Environment variable and config file support
- Configuration precedence (CLI > Env > Config)
- Programmatic API with various `:port-file` values
- Filesystem socket edge case
- Backward compatibility
