### PR TITLE
Clean up project.clj

### DIFF
--- a/doc/modules/ROOT/pages/design/middleware.adoc
+++ b/doc/modules/ROOT/pages/design/middleware.adoc
@@ -108,9 +108,9 @@ The values in the `:handles` map are used to support the `"describe"` operation,
 which provides "a machine- and human-readable directory and documentation for
 the operations supported by an nREPL endpoint" (see
 `nrepl.impl.docs/generate-ops-info` and the results of
-`lein with-profile +maint run -m nrepl.impl.docs` xref:ops.adoc[here]).
+`lein with-profile +docs run -m nrepl.impl.docs` xref:ops.adoc[here]).
 
-TIP: There's also `lein with-profile +maint run -m nrepl.impl.docs --output md`
+TIP: There's also `lein with-profile +docs run -m nrepl.impl.docs --output md`
 if you'd like to generate an ops listing in Markdown format.
 
 The `:requires` and `:expects` entries control the order in which

--- a/doc/modules/ROOT/pages/hacking_on_nrepl.adoc
+++ b/doc/modules/ROOT/pages/hacking_on_nrepl.adoc
@@ -142,13 +142,6 @@ use a command like this:
 $ lein with-profile 1.8 test
 ----
 
-To run tests for all Clojure versions from 1.8 to latest configured.
-
-[source,shell]
-----
-$ lein test-all
-----
-
 === Running tests on CI
 
 For ease of use/consistency with other nREPL projects, tests are ran on CI

--- a/project.clj
+++ b/project.clj
@@ -53,16 +53,16 @@
                       :test-selectors {:default '(complement :min-java-version)}
                       :aliases {"test" "test2junit"}})
              :junixsocket {:dependencies [[com.kohlschutter.junixsocket/junixsocket-core "2.10.1" :extension "pom"]]}
-             :clj-kondo {:dependencies [[clj-kondo "2025.09.22"]]}
+             :clj-kondo {:dependencies [[clj-kondo "2026.01.19"]]}
              ;; Clojure versions matrix
-             :provided {:dependencies [[org.clojure/clojure "1.12.2"]]}
+             :provided {:dependencies [[org.clojure/clojure "1.12.4"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]
                     :source-paths ["src/spec"]}
              :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]
                     :source-paths ["src/spec"]}
-             :1.12 {:dependencies [[org.clojure/clojure "1.12.2"]]
+             :1.12 {:dependencies [[org.clojure/clojure "1.12.4"]]
                     :source-paths ["src/spec"]}
 
 
@@ -83,20 +83,15 @@
                                      ;; in this project
                                      :test-ns-regex [#"^((?!nrepl.sanity-test).)*$"]}}
 
-             :cljfmt {:plugins [[lein-cljfmt "0.8.0"]]
-                      :cljfmt {:indents {delay [[:inner 0]]
-                                         returning [[:inner 0]]
-                                         run-with [[:inner 0]]
-                                         testing-dynamic [[:inner 0]]
-                                         testing-print [[:inner 0]]
-                                         safe-handle [[:inner 0]]
-                                         when-require [[:inner 0]]}}}
+             :cljfmt {:plugins [[dev.weavejester/lein-cljfmt "0.15.6"]]
+                      :cljfmt {:extra-indents {run-with [[:inner 0]]
+                                               testing-print [[:inner 0]]
+                                               safe-handle [[:inner 0]]
+                                               when-require [[:inner 0]]}}}
 
              :eastwood [:test
-                        {:plugins [[jonase/eastwood "1.4.0"]]
+                        {:plugins [[jonase/eastwood "1.4.3"]]
                          :eastwood {:config-files ["eastwood.clj"]
-                                    :ignored-faults {:non-dynamic-earmuffs {nrepl.middleware.load-file true}
-                                                     :unused-ret-vals {nrepl.util.completion-test true
+                                    :ignored-faults {:unused-ret-vals {nrepl.util.completion-test true
                                                                        nrepl.bencode true}
-                                                     :deprecations {nrepl.helpers true}
                                                      :reflection {nrepl.socket.dynamic true}}}}]})

--- a/project.clj
+++ b/project.clj
@@ -26,8 +26,7 @@
   :javac-options ["-target" "8" "-source" "8"]
 
   :aliases {"bump-version" ["change" "version" "leiningen.release/bump-version"]
-            "test-all" ["with-profile" "+1.8:+1.9:+1.10:+1.11:+fastlane:+junixsocket" "test"]
-            "docs" ["with-profile" "+maint" "run" "-m" "nrepl.impl.docs" "--file"
+            "docs" ["with-profile" "+docs" "run" "-m" "nrepl.impl.docs" "--file"
                     ~(clojure.java.io/as-relative-path
                       (clojure.java.io/file "doc" "modules" "ROOT" "pages" "ops.adoc"))]
             "kaocha" ["with-profile" "+test" "run" "-m" "kaocha.runner"]}
@@ -44,8 +43,7 @@
                                     :password :env/clojars_password
                                     :sign-releases false}]]
 
-  :profiles {:fastlane {:dependencies [[nrepl/fastlane "0.1.0"]]}
-             :dev ~dev-test-common-profile
+  :profiles {:dev ~dev-test-common-profile
              :test ~(merge
                      dev-test-common-profile
                      {:plugins      '[[test2junit "1.4.2"]]

--- a/project.clj
+++ b/project.clj
@@ -67,13 +67,13 @@
 
 
 
-             ;;; Maintenance profile
+             ;;; Docs generation profile
              ;;
              ;; It contains the small CLI utility (aliased to "lein docs") that
              ;; generates the nREPL ops documentation from their descriptor
              ;; metadata.
-             :maint {:source-paths ["src/maint"]
-                     :dependencies [[org.clojure/tools.cli "1.2.245"]]}
+             :docs {:source-paths ["src/maint"]
+                    :dependencies [[org.clojure/tools.cli "1.2.245"]]}
 
              ;; CI tools
              :cloverage {:plugins [[lein-cloverage "1.2.4"]]

--- a/src/maint/nrepl/impl/docs.clj
+++ b/src/maint/nrepl/impl/docs.clj
@@ -27,7 +27,7 @@
 (defn- usage [options-summary]
   (->> [(:doc (meta #'-main))
         ""
-        "Usage: lein with-profile +maint run -m nrepl.impl.docs [options]"
+        "Usage: lein with-profile +docs run -m nrepl.impl.docs [options]"
         ""
         "Options:"
         options-summary]

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -49,15 +49,6 @@
   {#'transport/bencode "nrepl"
    #'transport/edn "nrepl+edn"})
 
-;; There is a profile that adds the fastlane dependency and test
-;; its transports.
-(when-require 'fastlane.core
-  (def transport-fn->protocol
-    (merge transport-fn->protocol
-           {(requiring-resolve 'fastlane.core/transit+msgpack) "transit+msgpack"
-            (requiring-resolve 'fastlane.core/transit+json) "transit+json"
-            (requiring-resolve 'fastlane.core/transit+json-verbose) "transit+json-verbose"})))
-
 (def ^File project-base-dir (File. (System/getProperty "nrepl.basedir" ".")))
 
 (def ^:dynamic ^nrepl.server.Server  *server* nil)
@@ -107,17 +98,13 @@
        ~@body)))
 
 (defmacro def-repl-test
+  {:style/indent 1}
   [name & body]
   `(deftest ~name
      (with-repl-server ~@body)))
 
 (defn- strict-transport? []
-  ;; TODO: add transit here.
-  (or (= *transport-fn* #'transport/edn)
-      (when-require 'fastlane.core
-        (or (= *transport-fn* (requiring-resolve 'fastlane.core/transit+msgpack))
-            (= *transport-fn* (requiring-resolve 'fastlane.core/transit+json))
-            (= *transport-fn* (requiring-resolve 'fastlane.core/transit+json-verbose))))))
+  (= *transport-fn* #'transport/edn))
 
 (defn- check-response-format
   "checks response against spec, if available it to do a spec check later"


### PR DESCRIPTION
- Remove mentions of Fastlane in the code – nobody uses it. Let's reconsider adding Transit transport to nREPL itself if desirable.
- Remove `lein test-all` because it wasn't doing what it claimed (it doesn't test against all Clojure versions). Let CI deal with that.
- Bump a bunch of deps.
- Rename `maint` profile/command to `docs` as that name has always been confusing me (obviously it stands for "maintenance" but I parsed it as "main" all the time).