### PR TITLE
Fix EDN transport with Unix domain sockets

### DIFF
--- a/src/spec/nrepl/spec.clj
+++ b/src/spec/nrepl/spec.clj
@@ -214,11 +214,11 @@
                                   ::interrupt-id
                                   ::prefix ::complete-fn ::options ::completions
                                   ::sym ::lookup-fn ::info]
-                        :opt [:nrepl.middleware.print/print
-                              :nrepl.middleware.print/options
-                              :nrepl.middleware.print/stream?
-                              :nrepl.middleware.print/buffer-size
-                              :nrepl.middleware.print/quota
-                              :nrepl.middleware.print/keys
-                              :nrepl.middleware.caught/caught
-                              :nrepl.middleware.caught/print?]))
+                         :opt [:nrepl.middleware.print/print
+                               :nrepl.middleware.print/options
+                               :nrepl.middleware.print/stream?
+                               :nrepl.middleware.print/buffer-size
+                               :nrepl.middleware.print/quota
+                               :nrepl.middleware.print/keys
+                               :nrepl.middleware.caught/caught
+                               :nrepl.middleware.caught/print?]))

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -346,9 +346,7 @@
                              "nil" ":user/a"
                              "nil" ":a/a"]
             >devnull        (fn [& _] nil)]
-        (with-redefs [cmd/clean-up-and-exit >devnull
-                      ;; EDN transport doesn't work here because of a bug (#351).
-                      transport-fns [#'nrepl.transport/bencode]]
+        (with-redefs [cmd/clean-up-and-exit >devnull]
           (with-server-every-transport (fn [] {:socket (str (create-tmpdir "target" "socket-test-") "/socket")})
             (binding [*in* (java.io.PushbackReader. (java.io.StringReader. test-input))]
               (let [results (atom [])]

--- a/test/clojure/nrepl/edn_test.clj
+++ b/test/clojure/nrepl/edn_test.clj
@@ -2,8 +2,10 @@
   (:require [clojure.test :refer [deftest is testing]]
             [nrepl.core :as nrepl]
             [nrepl.server :as server]
+            [nrepl.socket :as socket]
             [nrepl.transport :as transport])
   (:import
+   (java.nio.file Files)
    (nrepl.server Server)))
 
 (defn return-evaluation
@@ -26,3 +28,30 @@
   (testing "simple expressions"
     (is (= (return-evaluation {:op "eval" :code "(range 40)"})
            [(eval '(range 40))]))))
+
+(when socket/unix-domain-flavor
+  (deftest edn-transport-unix-socket
+    (let [tmpdir (Files/createTempDirectory
+                  (.toPath (clojure.java.io/as-file "target"))
+                  "edn-socket-test-"
+                  (into-array java.nio.file.attribute.FileAttribute []))
+          sock-path (str tmpdir "/socket")]
+      (try
+        (with-open [^Server server (server/start-server :transport-fn transport/edn
+                                                        :socket sock-path)]
+          (with-open [^nrepl.transport.FnTransport
+                      conn (nrepl/connect :transport-fn transport/edn
+                                          :socket sock-path)]
+            (let [client (nrepl/client conn 1000)]
+              (testing "basic eval over Unix socket"
+                (is (= [5] (nrepl/response-values
+                            (nrepl/message client {:op "eval" :code "(+ 2 3)"})))))
+              (testing "expressions returning collections"
+                (is (= [(range 40)] (nrepl/response-values
+                                     (nrepl/message client {:op "eval" :code "(range 40)"})))))
+              (testing "multiple sequential evaluations"
+                (is (= [10] (nrepl/response-values
+                             (nrepl/message client {:op "eval" :code "(* 2 5)"}))))))))
+        (finally
+          (Files/deleteIfExists (.resolve tmpdir "socket"))
+          (Files/deleteIfExists tmpdir))))))


### PR DESCRIPTION
The EDN transport used `io/reader` and `io/writer` directly on sockets, which fails on JDK `SocketChannel` (Unix domain sockets) because `io/writer` can't coerce a `SocketChannel` to an `OutputStream`. This switches to `socket/buffered-input` and `socket/buffered-output`, matching the approach already used by the bencode transport.

Fixes #351