### PR TITLE
Fix load-file sending nil message for empty files

### DIFF
--- a/src/clojure/nrepl/middleware/load_file.clj
+++ b/src/clojure/nrepl/middleware/load_file.clj
@@ -60,7 +60,8 @@
                             ;; to avoid confusing tools which assume any
                             ;; :ns always means *ns*.
                             (when (and (contains? (:status resp) :done)
-                                       (not @error-encountered))
+                                       (not @error-encountered)
+                                       @last-result)
                               (.send transport (dissoc @last-result :ns)))
                             (.send transport resp)))))]
     (-> (dissoc msg :file-path)

--- a/test/clojure/nrepl/middleware/load_file_test.clj
+++ b/test/clojure/nrepl/middleware/load_file_test.clj
@@ -76,3 +76,27 @@
                                  :file very-long-code
                                  :file-path "/path/to/source.clj"
                                  :file-name "source.clj"}))))))
+
+(def-repl-test load-file-empty-file
+  (let [resp (nrepl/combine-responses
+              (nrepl/message session {:op "load-file"
+                                      :file ""
+                                      :file-path "/path/to/empty.clj"
+                                      :file-name "empty.clj"}))]
+    (testing "empty file completes without error"
+      (is (some #{:done "done"} (:status resp)))
+      (is (not (contains? resp :ex))))
+    (testing "empty file produces no value"
+      (is (not (contains? resp :value))))))
+
+(def-repl-test load-file-only-comments
+  (let [resp (nrepl/combine-responses
+              (nrepl/message session {:op "load-file"
+                                      :file ";; just a comment\n;; another comment\n"
+                                      :file-path "/path/to/comments.clj"
+                                      :file-name "comments.clj"}))]
+    (testing "comments-only file completes without error"
+      (is (some #{:done "done"} (:status resp)))
+      (is (not (contains? resp :ex))))
+    (testing "comments-only file produces no value"
+      (is (not (contains? resp :value))))))


### PR DESCRIPTION
When a file has no evaluable forms (empty or comments-only), no `:value` response is produced during evaluation, so `last-result` stays nil. The `:done` handler then sends `(dissoc nil :ns)` — a nil message — to the client. With bencode this is silently encoded as an empty list; with EDN it writes the literal `"nil"` which breaks client parsing.

The fix adds a nil guard so no result message is sent when there's nothing to send.

I came across this while looking at the state of the EDN transport.