### PR TITLE
Use actual bind address in server startup message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#302](https://github.com/nrepl/nrepl/issues/302): Use the actual bind address in the server startup message instead of resolving via `.getHostName` (which returns `localhost` and breaks IPv6-only clients).
+
 ## 1.6.0 (2026-02-26)
 
 ### New features

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -16,8 +16,7 @@
    [nrepl.util.threading :as threading]
    [nrepl.version :as version])
   (:import
-   [java.io FileNotFoundException]
-   [java.net URI]))
+   [java.io FileNotFoundException]))
 
 (defn- clean-up-and-exit
   "Performs any necessary clean up and calls `(System/exit status)`."
@@ -454,16 +453,15 @@ Exit:      Control+D or (exit) or (quit)"
   connection details from.
   Takes nREPL server map and processed CLI options map.
   Returns connection header string."
-  [server options]
+  [{:keys [host port socket] :as server} options]
   (let [transport (:transport options)
-        ^java.net.ServerSocket ssocket (:server-socket server)
-        ^URI uri (socket/as-nrepl-uri ssocket (transport/uri-scheme transport))]
+        ^java.net.URI uri (socket/as-nrepl-uri server (transport/uri-scheme transport))]
     ;; The format here is important, as some tools (e.g. CIDER) parse the string
     ;; to extract from it the host and the port to connect to
-    (if-let [host (.getHost uri)]
+    (if socket
+      (str "nREPL server started on socket " (.toASCIIString uri))
       (format "nREPL server started on port %d on host %s - %s"
-              (.getPort uri) host uri)
-      (str "nREPL server started on socket " (.toASCIIString uri)))))
+              port host uri))))
 
 (defn save-port-file
   "Writes a file relative to project classpath with port number so other tools

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -215,6 +215,8 @@
       (log msg)
       (throw (ex-info msg {:nrepl/kind ::invalid-start-request}))))
   (let [transport-fn (or transport-fn t/bencode)
+        port (or port 0)
+        bind (or bind "127.0.0.1")
         ss (cond socket
                  (unix-server-socket socket)
                  (or tls? tls-keys-str tls-keys-file)

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -164,13 +164,25 @@
                    (cmd/server-opts {:middleware ['nonexistent/required]}))))))
 
 (deftest server-started-message
-  (with-open [^Server server (server/start-server
-                              :transport-fn #'transport/bencode
-                              :handler server/default-handler)]
-    (is+ #"nREPL server started on port \d+ on host .* - .*//.*:\d+"
-         (cmd/server-started-message
-          server
-          {:transport #'transport/bencode}))))
+  (testing "default bind uses 127.0.0.1 in message and URI"
+    (with-open [^Server server (server/start-server
+                                :transport-fn #'transport/bencode
+                                :handler server/default-handler)]
+      (let [msg (cmd/server-started-message
+                 server
+                 {:transport #'transport/bencode})]
+        (is+ #"nREPL server started on port \d+ on host 127\.0\.0\.1 - .*//127\.0\.0\.1:\d+"
+             msg))))
+  (testing "explicit localhost bind is preserved"
+    (with-open [^Server server (server/start-server
+                                :bind "localhost"
+                                :transport-fn #'transport/bencode
+                                :handler server/default-handler)]
+      (let [msg (cmd/server-started-message
+                 server
+                 {:transport #'transport/bencode})]
+        (is+ #"nREPL server started on port \d+ on host localhost - .*//localhost:\d+"
+             msg)))))
 
 (deftest ^:slow ack
   (with-server-every-transport nil


### PR DESCRIPTION
On dual-stack systems (IPv4 + IPv6), nREPL binds to `127.0.0.1` but prints `nrepl://localhost:PORT` in the startup banner because `as-nrepl-uri` calls `.getHostName` on the server socket. Clients like Calva resolve `localhost` to `::1` (IPv6), fail to connect, and report "connection refused".

This threads the explicit bind address through the Server record so the URI uses exactly what was specified (defaulting to `127.0.0.1`), rather than reverse-resolving the socket address.

Fixes #302, based on #340.

---

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your changes.
- [x] You've updated the [changelog](../CHANGELOG.md) (only applies to user-visible changes)