### PR TITLE
[out] Fix tearing of multi-byte characters during output flushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs fixed
 
 * [#302](https://github.com/nrepl/nrepl/issues/302): Use the actual bind address in the server startup message instead of resolving via `.getHostName` (which returns `localhost` and breaks IPv6-only clients).
+* [#432](https://github.com/nrepl/nrepl/issues/432): Fix CallbackBufferedOutputStream corrupting multi-byte UTF-8 characters at buffer boundary.
 
 ## 1.6.0 (2026-02-26)
 

--- a/src/java/nrepl/out/CallbackBufferedOutputStream.java
+++ b/src/java/nrepl/out/CallbackBufferedOutputStream.java
@@ -19,16 +19,37 @@ public class CallbackBufferedOutputStream extends OutputStream {
     public CallbackBufferedOutputStream(IFn callback, int bufferSize) {
         this.callback = callback;
         this.bufferSize = bufferSize;
-        this.charset = Charset.defaultCharset();
+        this.charset = Charset.forName("UTF-8");
         this.buffer = new ByteArrayOutputStream();
+    }
+
+    private static boolean isSingleByteChar(byte b) {
+        return (b & 0b10000000) == 0;
+    }
+
+    private static boolean isCharacterStartingByte(byte b) {
+        return isSingleByteChar(b) ||
+            (b & 0b11000000) == 0b11000000; // start of multi-byte UTF-8 character
+    }
+
+    private static int clamp(int value, int min, int max) {
+        return Math.min(Math.max(value, min), max);
     }
 
     @Override
     public void write(int b) throws IOException {
         synchronized (bufferLock) {
-            buffer.write(b);
-            if (b == '\n' || buffer.size() >= bufferSize)
-                maybeFlush(false);
+            if (isSingleByteChar((byte)b)) {
+                buffer.write(b);
+                if (b == '\n' || buffer.size() >= bufferSize)
+                    maybeFlush(false);
+            } else {
+                // If we are behind flush because of multi-byte characters,
+                // flush first and then append to fresh buffer.
+                if (buffer.size() >= bufferSize && isCharacterStartingByte((byte)b))
+                    maybeFlush(false);
+                buffer.write(b);
+            }
         }
     }
 
@@ -37,9 +58,26 @@ public class CallbackBufferedOutputStream extends OutputStream {
         synchronized (bufferLock) {
             int end = off + len;
             while (off < end) {
-                int writeLen = Math.min(len, bufferSize - buffer.size());
+                // Make sure to clamp to at least 1 character because
+                // buffer.size() might run above bufferSize if multi-byte
+                // characters are involved.
+                int writeLen = clamp(bufferSize - buffer.size(), 1, len);
+                boolean canFlush = false;
+                if (isSingleByteChar(b[off+writeLen-1])) {
+                    canFlush = true;
+                } else {
+                    // Scan until the next character-starting byte to avoid
+                    // character tearing.
+                    while (writeLen+1 < len) {
+                        if (isCharacterStartingByte(b[off+writeLen])) {
+                            canFlush = true;
+                            break;
+                        }
+                        writeLen++;
+                    }
+                }
                 buffer.write(b, off, writeLen);
-                maybeFlush(false);
+                if (canFlush) maybeFlush(false);
                 off += writeLen;
                 len -= writeLen;
             }
@@ -71,7 +109,7 @@ public class CallbackBufferedOutputStream extends OutputStream {
         String content = buffer.toString(charset.name());
         int length = content.length();
         int lastNewlineIndex = content.lastIndexOf('\n');
-        int lengthToFlush = (force || size == bufferSize) ? length : lastNewlineIndex + 1;
+        int lengthToFlush = (force || size >= bufferSize) ? length : lastNewlineIndex + 1;
         if (lengthToFlush > 0) {
             String flushContent = content.substring(0, lengthToFlush);
             callback.invoke(flushContent);

--- a/test/clojure/nrepl/util/out_test.clj
+++ b/test/clojure/nrepl/util/out_test.clj
@@ -1,6 +1,8 @@
 (ns nrepl.util.out-test
   (:require [clojure.test :refer :all]
-            [nrepl.util.out :as out]))
+            [clojure.string :as str]
+            [nrepl.util.out :as out])
+  (:import nrepl.out.CallbackBufferedOutputStream))
 
 (defn- reset-callbacks-fixture
   "Helper to reset the internal state for testing."
@@ -77,3 +79,17 @@
       (Thread/sleep 100)
 
       (is (= (repeat 10 "1\n") @out-calls)))))
+
+(deftest test-multibyte-character-handling
+  (doseq [buffer-len (range 10 20)
+          prefix-len (range 1 (inc buffer-len))]
+    (let [chunks   (atom [])
+          callback (fn [s] (swap! chunks conj s))
+          stream   (CallbackBufferedOutputStream. callback buffer-len)
+          prefix (byte-array prefix-len (byte (int \-)))
+          sun (.getBytes "☀" "UTF-8")]
+      (.write stream prefix 0 (count prefix))
+      (.write stream sun 0 (count sun))
+      (.flush stream)
+      (is (str/ends-with? (last @chunks) "☀") (str @chunks))
+      (is (every? #{\- \☀} (apply str @chunks)) (str @chunks)))))


### PR DESCRIPTION
Fixes #432.

It also hardcodes UTF-8 as output encoding. I think it is the right thing to do. I don't think any existing clients would correctly deal with anything else.

---

- [x] You've added tests to cover your changes.
- [x] You've updated the [changelog](../CHANGELOG.md) (only applies to user-visible changes)