### PR TITLE
Fix broken link in usage/server.adoc

### DIFF
--- a/doc/modules/ROOT/pages/usage/server.adoc
+++ b/doc/modules/ROOT/pages/usage/server.adoc
@@ -496,7 +496,7 @@ The following keys are recognized in `.nrepl.edn` and `~/.nrepl/nrepl.edn`:
 | :tls-keys-file
 | string
 | —
-| Path to a file containing certificates and private key for TLS. See xref:tls.adoc[TLS].
+| Path to a file containing certificates and private key for TLS. See xref:usage/tls.adoc[TLS].
 
 | :tls-keys-str
 | string


### PR DESCRIPTION
The correct path is usage/tls.adoc, otherwise asciidoctor shows an error.