### PR TITLE
Add links to issues and docs source in FAQ

### DIFF
--- a/doc/modules/ROOT/pages/faq.adoc
+++ b/doc/modules/ROOT/pages/faq.adoc
@@ -95,8 +95,8 @@ the manual.
 There are many ways in which you can help nREPL:
 
 * Donate funds
-* Work on improving the documentation
-* Solve open issues
-* File bug reports and suggestions for improvements
+* Work on https://github.com/nrepl/nrepl/tree/master/doc/modules/ROOT/pages[improving the documentation]
+* Solve https://github.com/nrepl/nrepl/issues[open issues]
+* https://github.com/nrepl/nrepl/issues/new?template=bug_report.md[File bug reports] and suggestions for improvements
 * Promote nREPL via blog posts or at meetups and conferences
 * Invite members of the nREPL team to speak about nREPL at meetups and conferences


### PR DESCRIPTION
The GitHub repo URL isn't very prominent, so also include relevant links in the FAQ.