### PR TITLE
Follow-up fixes for the tools.deps migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
           command: |
             java -version; if(-not $?){exit 9}
             clojure -T:build javac :with-tests true; if(-not $?){exit 9}
-            clojure -T:build test; if(-not $?){exit 9}
+            clojure -M:dev:test; if(-not $?){exit 9}
 
 run_always: &run_always
   filters:

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,9 @@ deploy: check-env
 		echo "[Error] CIRCLE_TAG $(CIRCLE_TAG) must start with 'v'."; \
 		exit 1; \
 	fi
-	export PROJECT_VERSION=$$(echo "$(CIRCLE_TAG)" | sed 's/^v//'); \
 	# Clean is performed inside deploy task, no need to clean in Make
-	clojure -T:build deploy :version "$PROJECT_VERSION"
+	export PROJECT_VERSION=$$(echo "$(CIRCLE_TAG)" | sed 's/^v//'); \
+	clojure -T:build deploy :version "\"$$PROJECT_VERSION\""
 
 # Usage: PROJECT_VERSION=99.99 make install
 install: check-install-env

--- a/build/docs.clj
+++ b/build/docs.clj
@@ -10,10 +10,6 @@
 
 (declare docs)
 
-(defn- error-msg [errors]
-  (str "The following errors occurred while parsing your command:\n\n"
-       (str/join \newline errors)))
-
 ;; oh, kill me now
 (defn- markdown-escape
   [^String s]

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src/clojure" "res" "target/classes"
-         ;; Inlcude Java sources to paths so that they are packaged into the JAR
+         ;; Include Java sources to paths so that they are packaged into the JAR
          ;; and can later be jumped into.
          "src/java"]
  :deps {org.clojure/clojure {:mvn/version "1.12.4" :mvn/scope "provided"}}

--- a/doc/modules/ROOT/pages/design/middleware.adoc
+++ b/doc/modules/ROOT/pages/design/middleware.adoc
@@ -147,10 +147,10 @@ Use:
 The values in the `:handles` map are used to support the `"describe"` operation,
 which provides "a machine- and human-readable directory and documentation for
 the operations supported by an nREPL endpoint" (see
-`nrepl.impl.docs/generate-ops-info` and the results of
-`lein with-profile +docs run -m nrepl.impl.docs` xref:ops.adoc[here]).
+`build.docs/generate-ops-info` and the results of
+`make docs` xref:ops.adoc[here]).
 
-TIP: There's also `lein with-profile +docs run -m nrepl.impl.docs --output md`
+TIP: There's also `clojure -X:docs :format '"md"'`
 if you'd like to generate an ops listing in Markdown format.
 
 === Understanding middleware ordering

--- a/doc/modules/ROOT/pages/hacking_on_nrepl.adoc
+++ b/doc/modules/ROOT/pages/hacking_on_nrepl.adoc
@@ -100,7 +100,7 @@ the REPL you're using.
 
 == Task Management
 
-See `Makefile` the list of for available tasks.
+See the `Makefile` for the list of available tasks.
 
 == Running the tests
 

--- a/src/clojure/nrepl/version.clj
+++ b/src/clojure/nrepl/version.clj
@@ -20,10 +20,10 @@
     (catch Exception _e nil)))
 
 (defn- get-version
-  "Attempts to get the project version from system properties (set when running
-  Leiningen), or a properties file based on the group and artifact ids (in jars
-  built by Leiningen), or a default version passed in.  Falls back to an empty
-  string when no default is present."
+  "Attempts to get the project version from system properties, or a properties
+  file based on the group and artifact ids (in jars built by tools.build), or a
+  default version passed in.  Falls back to an empty string when no default is
+  present."
   ([] (get-version ""))
   ([default-version]
    (or (System/getProperty (str artifact ".version"))


### PR DESCRIPTION
Small follow-ups to the tools.deps migration commit:

- Fix typos and broken grammar in `deps.edn` and the hacking guide.
- Update the middleware doc and the `version.clj` docstring that still referenced the old Leiningen-based doc generation.
- Drop the dead `error-msg` fn left behind when the CLI `-main` entrypoint was removed from `build/docs.clj`.
- Fix the `deploy` Make target, which passed a mangled version (Make was expanding `$PROJECT_VERSION` and the `export` ran in a separate shell from the `clojure` call).