### PR TITLE
Point readers at the official protocol spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Extremely stable. nREPL's protocol and API are rock-solid and battle
 tested. nREPL's team pledges to evolve them only in
 backwards-compatible ways.
 
+The protocol itself is formally specified at <https://spec.nrepl.org>.
+
 All experimental features are marked explicitly as such in nREPL's
 documentation, but even those are fairly stable by most standards.
 

--- a/doc/modules/ROOT/nav.adoc
+++ b/doc/modules/ROOT/nav.adoc
@@ -12,6 +12,7 @@
 ** xref:design/transports.adoc[Transports]
 ** xref:design/middleware.adoc[Middleware]
 * xref:ops.adoc[Built-in Ops]
+* https://spec.nrepl.org[Protocol Spec]
 * xref:extensions.adoc[Extensions]
 * xref:beyond_clojure.adoc[Beyond Clojure]
 * xref:hacking_on_nrepl.adoc[Hacking on nREPL]

--- a/doc/modules/ROOT/pages/building_clients.adoc
+++ b/doc/modules/ROOT/pages/building_clients.adoc
@@ -22,6 +22,10 @@ Clojure(Script) servers can use EDN for richer type support (keywords, sets, etc
 are preserved rather than coerced to strings), but should ideally support bencode
 as well for maximum compatibility.
 
+TIP: Refer to https://spec.nrepl.org[spec.nrepl.org] for the canonical, normative
+description of the protocol — the op definitions and message shapes a client can
+rely on across server implementations.
+
 A typical message exchange between a client and a server would be:
 
 * Client sends `clone` to create a new session.

--- a/doc/modules/ROOT/pages/building_servers.adoc
+++ b/doc/modules/ROOT/pages/building_servers.adoc
@@ -3,7 +3,8 @@
 == Overview
 
 This part of the documentation aims to guide you in the process of implementing
-an nREPL server. The focus is going to be on implementing the language-agnostic nREPL protocol,
+an nREPL server. The focus is going to be on implementing the language-agnostic
+nREPL protocol (formally specified at https://spec.nrepl.org[spec.nrepl.org]),
 not on specifics of the reference nREPL server implementation for Clojure.
 
 == Basics


### PR DESCRIPTION
Adds links to <https://spec.nrepl.org> from the four most visible spots:

- README `## Status` - where the protocol stability claim already lives.
- Sidebar nav (`nav.adoc`) - right after Built-in Ops, for top-level discoverability.
- Building Servers - the Overview paragraph that already mentions the language-agnostic protocol.
- Building Clients - the Basics section, alongside the bencode/EDN guidance.

No changes to `cljdoc.edn` since that schema only references local files.
