### PR TITLE
Documentation improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#284](https://github.com/nrepl/nrepl/issues/284): Include the `-f`/`--repl-fn` option in the command-line help output.
+
 ## 1.7.0 (2026-04-14)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#284](https://github.com/nrepl/nrepl/issues/284): Include the `-f`/`--repl-fn` option in the command-line help output.
+* [#376](https://github.com/nrepl/nrepl/issues/376): Document the `session-closed` status returned by the `close` op.
 
 ## 1.7.0 (2026-04-14)
 

--- a/doc/modules/ROOT/pages/building_middleware.adoc
+++ b/doc/modules/ROOT/pages/building_middleware.adoc
@@ -234,6 +234,46 @@ When using `safe-handle`, the handler function (e.g. `foo-reply`) should return
 a response map rather than sending the response itself -- `safe-handle` takes
 care of sending via `respond-to`.
 
+=== Terminating and passing through requests
+
+Every request a client sends expects at least one response that carries a
+`:done` status -- that's how clients know the exchange is over and stop waiting
+for more messages. When your middleware handles an op, make sure exactly one
+response includes `:done` (typically the final one). Sending it more than once,
+or attaching it to an intermediate message, can confuse clients that treat
+`:done` as "this exchange is complete" (see https://github.com/nrepl/nrepl/issues/215[nrepl/nrepl#215]
+for an example of the trouble that causes).
+
+Just as important, a middleware should only act on the ops it actually handles
+and delegate everything else to the downstream handler `h`:
+
+[source,clojure]
+----
+(fn [{:keys [op] :as msg}]
+  (if (= op "foo")
+    (handle-foo msg)
+    (h msg)))  ;; <- don't swallow ops you don't handle
+----
+
+Forgetting to call `h` for unknown ops effectively breaks every other op in the
+stack, since requests that should have flowed to the middleware below yours
+silently disappear.
+
+=== Keep your descriptor accurate
+
+The middleware descriptor isn't just documentation -- nREPL uses `:requires`
+and `:expects` to order the middleware stack (see
+xref:design/middleware.adoc[the middleware design documentation] for the exact
+semantics). Getting them wrong leads to middleware running in the wrong order,
+which tends to surface as subtle, hard-to-debug failures.
+
+It also pays to fully document each op you handle via `:doc`, `:requires`,
+`:optional` and `:returns` in the `:handles` map. This information is exposed to
+clients through the `describe` op and is used to generate
+xref:ops.adoc[the built-in ops documentation], so a well-described op directly
+improves the experience of every client author integrating with your
+middleware.
+
 == Additional Resources
 
 * https://metaredux.com/posts/2019/12/04/documenting-nrepl-middleware-apis.html

--- a/doc/modules/ROOT/pages/ops.adoc
+++ b/doc/modules/ROOT/pages/ops.adoc
@@ -38,7 +38,8 @@ Optional parameters::
 {blank}
 
 Returns::
-{blank}
+* `:status` 'session-closed' if the session was successfully closed. Sent in addition to the usual 'done' status, so clients should check for it to confirm the session was actually closed (rather than assuming success from 'done' alone).
+
 
 
 === `completions`

--- a/doc/modules/ROOT/pages/usage/misc.adoc
+++ b/doc/modules/ROOT/pages/usage/misc.adoc
@@ -98,6 +98,32 @@ The function should ideally return results in the following format:
  "Returns a lazy sequence consisting of the result of applying f to\n  the set of first items of each coll, followed by applying f to the\n  set of second items in each coll, until any one of the colls is\n  exhausted.  Any remaining items in other colls are ignored. Function\n  f should accept number-of-colls arguments. Returns a transducer when\n  no collection is provided."}
 ----
 
+This map is returned to the client under the `:info` key of the `lookup`
+response (alongside the usual `:status ["done"]`).
+
+Every key is optional -- it's included only when the looked-up var (or
+special form) actually carries the corresponding metadata. nREPL's default
+lookup function may return the following keys:
+
+`:name`:: The (unqualified) name of the var or special form.
+`:ns`:: The namespace the var belongs to.
+`:doc`:: The docstring, when present.
+`:arglists`:: The var's argument lists, as a string.
+`:arglists-str`:: A duplicate of `:arglists` kept for backwards compatibility. Deprecated and subject to removal (see the note above).
+`:file`:: The file in which the var is defined. An absolute path for files on disk, or a `jar:` URL for definitions inside a jar.
+`:line`:: The line in `:file` where the definition starts.
+`:column`:: The column in `:file` where the definition starts.
+`:added`:: The library version in which the var was added, when recorded in its metadata.
+`:deprecated`:: Present (as `"true"` or a version string) when the var is marked deprecated.
+`:macro`:: `"true"` when the var is a macro.
+`:special-form`:: `"true"` when the symbol names a special form (e.g. `if`, `do`).
+`:forms`:: The valid syntactic forms, for special forms and some macros.
+`:protocol`:: The protocol the var belongs to, when applicable.
+`:resource`:: The classpath-relative resource path of the defining file.
+
+All values are strings or numbers, so they survive the Bencode transport.
+A custom `lookup-fn` is free to return a different set of keys.
+
 NOTE: nREPL's default lookup function is pretty basic and it can only handle symbols that resolve to special
 forms and vars.
 

--- a/doc/modules/ROOT/pages/usage/server.adoc
+++ b/doc/modules/ROOT/pages/usage/server.adoc
@@ -86,6 +86,7 @@ interface (this output was simply generated with `--help`):
 
 ....
 -i/--interactive            Start nREPL and connect to it with the built-in client.
+-f/--repl-fn REPL-FN        The function to run as the built-in REPL when combined with --interactive; defaults to `nrepl.cmdline/run-repl`. Must be expressed as a namespace-qualified symbol. The underlying var will be automatically `require`d.
 -c/--connect                Connect to a running nREPL with the built-in client.
 -C/--color                  Use colors to differentiate values from output in the REPL. Must be combined with --interactive.
 -b/--bind ADDR              Bind address, by default "127.0.0.1".
@@ -97,6 +98,8 @@ interface (this output was simply generated with `--help`):
 -m/--middleware MIDDLEWARE  A sequence of vars (expressed as namespace-qualified symbols), representing middleware you wish to mix in to the nREPL handler. The underlying vars will be automatically `require`d. If unavailable, the server will exit unless symbols are marked with ^:optional metadata.
 -t/--transport TRANSPORT    The transport to use (default `nrepl.transport/bencode`), expressed as a namespace-qualified symbol. The underlying var will be automatically `require`d.
 --help                      Show this help message.
+-v/--version                Display the nREPL version.
+--verbose                   Show verbose output.
 ....
 
 [NOTE]

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -209,6 +209,7 @@ Exit:      Control+D or (exit) or (quit)"
   "Usage:
 
   -i/--interactive            Start nREPL and connect to it with the built-in client.
+  -f/--repl-fn REPL-FN        The function to run as the built-in REPL when combined with --interactive; defaults to `nrepl.cmdline/run-repl`. Must be expressed as a namespace-qualified symbol. The underlying var will be automatically `require`d.
   -c/--connect                Connect to a running nREPL with the built-in client.
   -C/--color                  Use colors to differentiate values from output in the REPL. Must be combined with --interactive.
   -b/--bind ADDR              Bind address, by default \"127.0.0.1\".

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -384,7 +384,7 @@
                             {:doc "Closes the specified session."
                              :requires {"session" "The ID of the session to be closed."}
                              :optional {}
-                             :returns {}}
+                             :returns {"status" "'session-closed' if the session was successfully closed. Sent in addition to the usual 'done' status, so clients should check for it to confirm the session was actually closed (rather than assuming success from 'done' alone)."}}
                             "ls-sessions"
                             {:doc "Lists the IDs of all active sessions."
                              :requires {}


### PR DESCRIPTION
A few small docs fixes I'd been meaning to get to, one commit per issue:

- List the `-f`/`--repl-fn` option in the `--help` output (it was missing). Fixes #284.
- Document all the keys the `lookup` op can return. Fixes #257.
- Spell out a couple more middleware best practices (the `:done`/pass-through contract and keeping descriptors accurate). Fixes #144.
- Document the `session-closed` status of the `close` op so clients know to check for it. Fixes #376.