### PR TITLE
Allow configuring the default printer via config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#93](https://github.com/nrepl/nrepl/issues/93): Allow configuring the default print function via the `:printer` and `:printer-options` configuration keys.
+
 ### Changes
 
 * [#284](https://github.com/nrepl/nrepl/issues/284): Include the `-f`/`--repl-fn` option in the command-line help output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New features
 
+- [#93](https://github.com/nrepl/nrepl/issues/93): **(Experimental)** Allow setting a default print function for every session of a server via the `:nrepl.middleware.print/print` and `:nrepl.middleware.print/options` configuration keys.
 - [#455](https://github.com/nrepl/nrepl/pull/455): The built-in command-line client can now connect using a URL (`--connect --host <url>`), including the `nrepls://`/`nrepl+edns://` URLs TLS servers advertise (combined with `--tls-keys-file`/`--tls-keys-str`), the `nrepl+unix:` URLs filesystem-socket servers advertise, and `http(s)://` when `nrepl/drawbridge` is on the classpath.
 
 ### Changes

--- a/doc/modules/ROOT/pages/usage/misc.adoc
+++ b/doc/modules/ROOT/pages/usage/misc.adoc
@@ -224,6 +224,31 @@ You can also easily leverage more powerful pretty-printers like `fipp` or `zprin
      (z/zprint value options))))
 ----
 
+=== Configuring the default printer
+
+Using `set!` on `\*print-fn*` only affects the current session. To change the
+default printer for _every_ session of a server, configure it in
+xref:server.adoc#_configuration_keys[the nREPL configuration file] (`.nrepl.edn`
+or the global `nrepl.edn`) via the `:printer` and `:printer-options` keys:
+
+[source,clojure]
+----
+{:printer my.namespace/zprint-pprint
+ :printer-options {:width 60}}
+----
+
+`:printer` must be a namespace-qualified symbol resolving to a function with the
+signature `[value writer options]` -- the same shape used by the
+`nrepl.middleware.print/print` request option (and by the `zprint` wrapper
+above). `:printer-options` is an optional map passed to that function as its
+third argument.
+
+The configured printer becomes the default whenever a request doesn't specify
+its own printer and the session hasn't overridden `\*print-fn*`. A per-request
+printer or a `set!` within the session still takes precedence.
+
+NOTE: Configurable default printers were added in nREPL 1.8.
+
 == Evaluation Errors
 
 The dynamic var `nrepl.middleware.caught/\*caught-fn*` can be `set!` at the REPL

--- a/doc/modules/ROOT/pages/usage/misc.adoc
+++ b/doc/modules/ROOT/pages/usage/misc.adoc
@@ -224,6 +224,33 @@ You can also easily leverage more powerful pretty-printers like `fipp` or `zprin
      (z/zprint value options))))
 ----
 
+=== Configuring the default printer
+
+Using `set!` on `\*print-fn*` only changes the current session. To set the
+default for _every_ session a server serves, put it in
+xref:server.adoc#_configuration_keys[the nREPL configuration file] (`.nrepl.edn`
+or the global `nrepl.edn`), under the same keys a request would use:
+
+[source,clojure]
+----
+{:nrepl.middleware.print/print   my.namespace/zprint-pprint
+ :nrepl.middleware.print/options {:width 60}}
+----
+
+`:nrepl.middleware.print/print` is a namespace-qualified symbol resolving to a
+function with the signature `[value writer options]`, the same shape the request
+option takes (and the `zprint` wrapper above).
+`:nrepl.middleware.print/options` is an optional map handed to it as the third
+argument.
+
+The server installs this as the default printer when it starts, so a per-request
+printer or a `set!` inside a session still wins. A symbol that can't be resolved
+is logged and ignored, leaving the built-in printer in place.
+
+NOTE: Configurable default printers were added in nREPL 1.8. The feature is
+experimental - the configuration keys and the way the printer is installed
+may still change in a future release.
+
 == Evaluation Errors
 
 The dynamic var `nrepl.middleware.caught/\*caught-fn*` can be `set!` at the REPL

--- a/doc/modules/ROOT/pages/usage/server.adoc
+++ b/doc/modules/ROOT/pages/usage/server.adoc
@@ -516,6 +516,16 @@ The following keys are recognized in `.nrepl.edn` and `~/.nrepl/nrepl.edn`:
 | —
 | A namespace-qualified symbol resolving to a custom REPL function (used with `--interactive`).
 
+| :printer
+| symbol
+| —
+| A namespace-qualified symbol resolving to the default print function for evaluation results. Must have the signature `[value writer options]`. See xref:usage/misc.adoc#_configuring_the_default_printer[Configuring the default printer].
+
+| :printer-options
+| map
+| —
+| A map passed as the third argument to `:printer`.
+
 |===
 
 === Merging CLI and config values (`^:concat`)

--- a/doc/modules/ROOT/pages/usage/server.adoc
+++ b/doc/modules/ROOT/pages/usage/server.adoc
@@ -518,6 +518,16 @@ The following keys are recognized in `.nrepl.edn` and `~/.nrepl/nrepl.edn`:
 | —
 | A namespace-qualified symbol resolving to a custom REPL function (used with `--interactive`).
 
+| :nrepl.middleware.print/print
+| symbol
+| —
+| *(Experimental)* A namespace-qualified symbol resolving to the default print function for evaluation results. Must have the signature `[value writer options]`. See xref:usage/misc.adoc#_configuring_the_default_printer[Configuring the default printer].
+
+| :nrepl.middleware.print/options
+| map
+| —
+| *(Experimental)* A map handed to `:nrepl.middleware.print/print` as its third argument.
+
 |===
 
 === Merging CLI and config values (`^:concat`)

--- a/src/clojure/nrepl/middleware/print.clj
+++ b/src/clojure/nrepl/middleware/print.clj
@@ -5,6 +5,7 @@
    :added  "0.6"}
   (:refer-clojure :exclude [print])
   (:require
+   [nrepl.config :as config]
    [nrepl.middleware :refer [set-descriptor!]]
    [nrepl.misc :as misc]
    [nrepl.transport :as transport])
@@ -14,12 +15,17 @@
    (nrepl.out CallbackBufferedOutputStream QuotaBoundWriter QuotaExceeded)
    (nrepl.transport Transport)))
 
+(def ^:private default-print-fn
+  "The built-in default print function, equivalent to `clojure.core/pr`."
+  @#'clojure.core/pr-on) ;; Private in clojure.core
+
 (def ^:dynamic *print-fn*
   "Function to use for printing. Takes two arguments: `value`, the value to print,
   and `writer`, the `java.io.PrintWriter` to print on.
 
-  Defaults to the equivalent of `clojure.core/pr`."
-  @#'clojure.core/pr-on) ;; Private in clojure.core
+  Defaults to the equivalent of `clojure.core/pr`, unless a `:printer` is set in
+  the nREPL configuration file (see `wrap-print`)."
+  default-print-fn)
 
 (def ^:dynamic *stream?*
   "If logical true, the result of printing each value will be streamed to the
@@ -136,6 +142,38 @@
                                    :status ::error}))
       print-var)))
 
+(let [state (atom {})]
+  (defn- config-print-fn
+    "Resolve the default print function configured via the `:printer` and
+    `:printer-options` keys in the nREPL configuration file, if any.
+
+    Returns a `[value writer]` function that applies `:printer-options`, or nil
+    when no (resolvable) `:printer` is configured. The result is cached and only
+    recomputed when the config map changes (which currently only happens in
+    tests)."
+    []
+    (let [cfg config/config]
+      (if (identical? (first @state) cfg)
+        (second @state)
+        (let [printer (:printer cfg)
+              print-var (cond
+                          (nil? printer) nil
+                          (or (symbol? printer) (string? printer))
+                          (misc/requiring-resolve (symbol printer))
+                          :else ::invalid)
+              f (cond
+                  (nil? printer) nil
+                  (= ::invalid print-var)
+                  (do (misc/log ":printer must be a namespace-qualified symbol, got:" (pr-str printer))
+                      nil)
+                  (nil? print-var)
+                  (do (misc/log "Could not resolve :printer var:" (str printer))
+                      nil)
+                  :else
+                  (let [opts (:printer-options cfg)]
+                    (fn [value writer] (print-var value writer opts))))]
+          (second (reset! state [cfg f])))))))
+
 (defn- booleanize-bencode-val [m key]
   (if (contains? m key)
     ;; As a convention, empty list is treated as logical false.
@@ -159,7 +197,9 @@
 
   * `::print-fn` – the function to use for printing. In requests, will be
   resolved from the above two options (if provided). Defaults to the equivalent
-  of `clojure.core/pr`. Must have signature [writer options].
+  of `clojure.core/pr`, or to the printer configured via the `:printer` and
+  `:printer-options` keys in the nREPL configuration file, when set. Must have
+  signature [writer options].
 
   * `::stream?` – if logical true, the result of printing each value will be
   streamed to the client over one or more messages.
@@ -180,7 +220,13 @@
           print-fn (if print-var
                      (fn [value writer]
                        (print-var value writer options))
-                     (misc/resolve-in-session msg *print-fn*))
+                     (let [session-fn (misc/resolve-in-session msg *print-fn*)]
+                       ;; When neither the request nor the session overrides the
+                       ;; printer, fall back to the one configured in nrepl.edn
+                       ;; (if any) before defaulting to the built-in printer.
+                       (if (identical? session-fn default-print-fn)
+                         (or (config-print-fn) session-fn)
+                         session-fn)))
           msg (-> msg
                   (assoc ::print-fn print-fn)
                   (booleanize-bencode-val ::stream?))]

--- a/src/clojure/nrepl/middleware/print.clj
+++ b/src/clojure/nrepl/middleware/print.clj
@@ -5,6 +5,7 @@
    :added  "0.6"}
   (:refer-clojure :exclude [print])
   (:require
+   [nrepl.config :as config]
    [nrepl.middleware :refer [set-descriptor!]]
    [nrepl.misc :as misc]
    [nrepl.transport :as transport])
@@ -18,7 +19,9 @@
   "Function to use for printing. Takes two arguments: `value`, the value to print,
   and `writer`, the `java.io.PrintWriter` to print on.
 
-  Defaults to the equivalent of `clojure.core/pr`."
+  Defaults to the equivalent of `clojure.core/pr`, unless a printer is
+  configured in the nREPL configuration file, in which case
+  `configure-default-printer!` installs that one instead."
   @#'clojure.core/pr-on) ;; Private in clojure.core
 
 (def ^:dynamic *stream?*
@@ -127,6 +130,34 @@
           (send-nonstreamed msg resp opts)))
       this)))
 
+(defn- config-printer
+  "Resolve the printer configured via the `::print` and `::options` keys in the
+  nREPL configuration file. Returns a [value writer] function applying
+  `::options`, or nil when nothing resolvable is configured."
+  []
+  (when-let [printer (::print config/config)]
+    (if-let [print-var (try
+                         (requiring-resolve (symbol printer))
+                         ;; Config-supplied, so a bad value is a user error.
+                         ;; Log it and keep the built-in printer, rather than
+                         ;; breaking every eval on the server.
+                         (catch Exception _ nil))]
+      (let [options (::options config/config)]
+        (fn [value writer] (print-var value writer options)))
+      (do (misc/log "Could not resolve the" (str ::print) "var:" (pr-str printer))
+          nil))))
+
+(defn configure-default-printer!
+  "Install the printer from the nREPL configuration file as the root value of
+  `*print-fn*`, making it the default for every session. Called when a server
+  starts. Per-request and per-session printers still take precedence.
+
+  Experimental: the configuration keys this reads may still change."
+  {:added "1.8"}
+  []
+  (when-let [f (config-printer)]
+    (alter-var-root #'*print-fn* (constantly f))))
+
 (defn- resolve-print
   [{:keys [::print] :as msg}]
   (when-let [var-sym (some-> print (symbol))]
@@ -163,7 +194,9 @@
 
   * `::print-fn` – the function to use for printing. In requests, will be
   resolved from the above two options (if provided). Defaults to the equivalent
-  of `clojure.core/pr`. Must have signature [writer options].
+  of `clojure.core/pr`, or to the printer set in the nREPL configuration file
+  under the same `::print` and `::options` keys. Must have signature
+  [writer options].
 
   * `::stream?` – if logical true, the result of printing each value will be
   streamed to the client over one or more messages.

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -9,7 +9,7 @@
    nrepl.middleware.io
    nrepl.middleware.load-file
    nrepl.middleware.lookup
-   nrepl.middleware.print
+   [nrepl.middleware.print :as print]
    nrepl.middleware.session
    [nrepl.misc :refer [log log-exceptions response-for]]
    [nrepl.socket :as socket :refer [inet-socket unix-server-socket]]
@@ -214,6 +214,9 @@
     (let [msg "tls? is true, but neither tls-keys-str nor tls-keys-file is present"]
       (log msg)
       (throw (ex-info msg {:nrepl/kind ::invalid-start-request}))))
+  ;; A printer configured in the nREPL configuration file becomes the default
+  ;; for every session this server serves.
+  (print/configure-default-printer!)
   (let [transport-fn (or transport-fn t/bencode)
         port (or port 0)
         bind (or bind "127.0.0.1")

--- a/test/clojure/nrepl/middleware/print_test.clj
+++ b/test/clojure/nrepl/middleware/print_test.clj
@@ -10,6 +10,7 @@
   (:require [clojure.java.io :as io]
             [clojure.test :refer [deftest is testing]]
             [matcher-combinators.matchers :as mc]
+            [nrepl.config :as config]
             [nrepl.core :refer [combine-responses]]
             [nrepl.middleware.print :as print]
             [nrepl.test-helpers :refer [is+]]
@@ -74,6 +75,35 @@
                   ::print/print   `custom-printer
                   ::print/keys    #{:value}
                   ::print/options {:sub "bar"}}))))
+
+(deftest config-printer
+  (with-redefs [config/config {:printer 'nrepl.middleware.print-test/custom-printer}]
+    (testing-print "config :printer is used as the default when the request has no ::print"
+      (is+ [{:value "<foo 42 ...>"}]
+           (handle {:value       42
+                    ::print/keys #{:value}}))))
+  (with-redefs [config/config {:printer         'nrepl.middleware.print-test/custom-printer
+                               :printer-options {:sub "cfg"}}]
+    (testing-print "config :printer-options are passed to the configured printer"
+      (is+ [{:value "<foo 42 cfg>"}]
+           (handle {:value       42
+                    ::print/keys #{:value}})))
+    (testing-print "an explicit request ::print overrides the configured printer"
+      (is+ [{:value "<foo 42 req>"}]
+           (handle {:value          42
+                    ::print/keys    #{:value}
+                    ::print/print   `custom-printer
+                    ::print/options {:sub "req"}}))))
+  (with-redefs [config/config {:printer 'my.missing.ns/printer}]
+    (testing-print "an unresolvable :printer falls back to the default printer"
+      (is+ [{:value "42"}]
+           (handle {:value       42
+                    ::print/keys #{:value}}))))
+  (with-redefs [config/config {}]
+    (testing-print "no :printer means the built-in default printer is used"
+      (is+ [{:value "42"}]
+           (handle {:value       42
+                    ::print/keys #{:value}})))))
 
 (deftest override-value-printing
   (testing-print "custom ::print/keys"

--- a/test/clojure/nrepl/middleware/print_test.clj
+++ b/test/clojure/nrepl/middleware/print_test.clj
@@ -10,6 +10,7 @@
   (:require [clojure.java.io :as io]
             [clojure.test :refer [deftest is testing]]
             [matcher-combinators.matchers :as mc]
+            [nrepl.config :as config]
             [nrepl.core :refer [combine-responses]]
             [nrepl.middleware.print :as print]
             [nrepl.test-helpers :refer [is+]]
@@ -74,6 +75,49 @@
                   ::print/print   `custom-printer
                   ::print/keys    #{:value}
                   ::print/options {:sub "bar"}}))))
+
+(deftest config-printer
+  (testing "the configured printer is resolved, with its options applied"
+    (with-redefs [config/config {::print/print   `custom-printer
+                                 ::print/options {:sub "cfg"}}]
+      (binding [print/*print-fn* (#'print/config-printer)]
+        (testing-print "it prints values that carry no printer of their own"
+          (is+ [{:value "<foo 42 cfg>"}]
+               (handle {:value       42
+                        ::print/keys #{:value}})))
+        (testing-print "a printer on the request still wins"
+          (is+ [{:value "<foo 42 req>"}]
+               (handle {:value          42
+                        ::print/keys    #{:value}
+                        ::print/print   `custom-printer
+                        ::print/options {:sub "req"}}))))))
+
+  (testing "nothing configured leaves the built-in printer in place"
+    (with-redefs [config/config {}]
+      (is (nil? (#'print/config-printer)))))
+
+  (testing "an unresolvable printer is reported and ignored"
+    (with-redefs [config/config {::print/print 'my.missing.ns/printer}]
+      (is (nil? (binding [*err* (java.io.StringWriter.)]
+                  (#'print/config-printer))))))
+
+  (testing "configure-default-printer! installs it as the root default"
+    (let [original print/*print-fn*]
+      (try
+        (with-redefs [config/config {::print/print `custom-printer}]
+          (print/configure-default-printer!))
+        (testing-print "so a plain request uses it"
+          (is+ [{:value "<foo 42 ...>"}]
+               (handle {:value       42
+                        ::print/keys #{:value}})))
+        (finally
+          (alter-var-root #'print/*print-fn* (constantly original))))))
+
+  (testing "the root default is restored after that test"
+    (testing-print "so a plain request prints normally again"
+      (is+ [{:value "42"}]
+           (handle {:value       42
+                    ::print/keys #{:value}})))))
 
 (deftest override-value-printing
   (testing-print "custom ::print/keys"


### PR DESCRIPTION
The print function could only be set per request or with `set!` inside a session, so there was no way to set a default for a whole server, and a client that doesn't expose the print options couldn't reach it at all.

The configured printer becomes the root value of `*print-fn*` when the server starts, rather than being consulted per request. That way the existing precedence holds by construction: request beats session `set!` beats configured default, with no extra bookkeeping in `wrap-print`.

Config keys are `:nrepl.middleware.print/print` and `:nrepl.middleware.print/options`, matching the request keys, which also keeps them clear of third-party middleware config.

Fixes #93.
