### PR TITLE
Fix flaky request-multiple-read-newline stdin test

### DIFF
--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -661,11 +661,18 @@
                                  resp)))))
 
 (def-repl-test request-multiple-read-newline-*in*
-  (is+ [:ohai] (response-values (for [resp (repl-eval session "(read)")]
-                                  (do
-                                    (when (-> resp clean-response :status (contains? :need-input))
-                                      (session {:op "stdin" :stdin (th/newline->sys ":ohai\n")}))
-                                    resp))))
+  ;; Send the input only once. Reading a non-self-delimiting token like `:ohai`
+  ;; makes the reader peek the char past it, so while the `:ohai\n` payload is
+  ;; still being enqueued the queue can momentarily read empty and the server
+  ;; emits a second, spurious `need-input`. Re-sending on every `need-input`
+  ;; would then push a stray `:ohai` that the follow-up `read-line` picks up.
+  (let [sent? (atom false)]
+    (is+ [:ohai] (response-values (for [resp (repl-eval session "(read)")]
+                                    (do
+                                      (when (and (-> resp clean-response :status (contains? :need-input))
+                                                 (compare-and-set! sent? false true))
+                                        (session {:op "stdin" :stdin (th/newline->sys ":ohai\n")}))
+                                      resp)))))
 
   (session {:op "stdin" :stdin (th/newline->sys "a\n")})
   (is+ ["a"] (repl-values session "(read-line)")))


### PR DESCRIPTION
This test occasionally failed in CI with `read-line` returning `:ohai` instead of `"a"`.

Reading a non-self-delimiting token like `:ohai` makes the reader peek the character past it, so while the `:ohai\n` payload is still being enqueued char-by-char the input queue can momentarily read empty and the server emits a second, spurious `need-input`. The test re-sent `:ohai\n` on every `need-input`, which pushed a stray `:ohai` that the follow-up `read-line` then read.

Sending the input just once (as a real client would) makes the test robust against the extra signal. Reproduced the failure ~3/600 under load before the change, 0/800 after.