### PR TITLE
Use JAVA_OPTS instead of JVM_OPTS in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 defaults: &defaults
   working_directory: ~/repo
   environment:
-    JVM_OPTS: -Xmx3200m -Dclojure.main.report=stderr
+    JAVA_OPTS: -Xmx3200m -Dclojure.main.report=stderr
   resource_class: large # default is medium. large (may) give us more consistent CI results
 
 # Runners for OpenJDK


### PR DESCRIPTION
The test matrix runs through the clojure CLI (`clojure -M` / `clojure -T:build`), which forwards `JAVA_OPTS` to the JVM and doesn't read `JVM_OPTS` at all - that's a Leiningen convention left over from when the CircleCI images ran lein.

So the `-Xmx3200m` heap cap and, more usefully, `-Dclojure.main.report=stderr` were silently not applied. That's why failing jobs printed `Full report at: /tmp/clojure-*.edn` (a temp file CI throws away) instead of the actual error in the log. Renaming the var makes both take effect.