### PR TITLE
Send built-in client input to the server as raw text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#284](https://github.com/nrepl/nrepl/issues/284): Include the `-f`/`--repl-fn` option in the command-line help output.
 * [#376](https://github.com/nrepl/nrepl/issues/376): Document the `session-closed` status returned by the `close` op.
 
+### Bugs fixed
+
+* [#182](https://github.com/nrepl/nrepl/issues/182): The built-in client now sends input to the server as raw text instead of reading it client-side, so reader typos, auto-resolved keywords relying on session aliases (e.g. `::io/foo`) and custom tagged literals no longer crash the REPL.
+
 ## 1.7.0 (2026-04-14)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#464](https://github.com/nrepl/nrepl/pull/464): Revert an earlier change that broke use of custom classloaders via `setContextClassLoader`.
 - [#466](https://github.com/nrepl/nrepl/pull/466): Serialize namespace loading when resolving client-supplied vars, so concurrent sessions can't race on `require`.
 - [#458](https://github.com/nrepl/nrepl/pull/458): Report descriptive errors for invalid TLS key material (missing, legacy-format or encrypted private keys, missing certificates) instead of NPEs and generic JSSE messages.
+- [#182](https://github.com/nrepl/nrepl/issues/182): The built-in client now sends input to the server as raw text instead of reading it client-side, so reader typos, auto-resolved keywords relying on session aliases (e.g. `::io/foo`) and custom tagged literals no longer crash the REPL.
 
 ## 1.7.0 (2026-04-14)
 

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -16,7 +16,8 @@
    [nrepl.util.threading :as threading]
    [nrepl.version :as version])
   (:import
-   [java.io FileNotFoundException]))
+   [java.io FileNotFoundException]
+   [nrepl.in CapturingPushbackReader]))
 
 (defn- clean-up-and-exit
   "Performs any necessary clean up and calls `(System/exit status)`."
@@ -87,6 +88,57 @@ Exit:      Control+D or (exit) or (quit)"
           (System/getProperty "java.vm.name")
           (System/getProperty "java.runtime.version")))
 
+(def ^:private permissive-reader-resolver
+  "A reader resolver that accepts any alias or class name. Used when reading
+  user input purely to find form boundaries (see `read-form-for-server`):
+  aliases and classes may exist only in the server's session, so the client
+  must not reject them (this is what lets `::alias/kw` reach the server)."
+  (reify clojure.lang.LispReader$Resolver
+    (currentNS [_] 'user)
+    (resolveClass [_ sym] sym)
+    (resolveAlias [_ sym] sym)
+    (resolveVar [_ sym] sym)))
+
+(def ^:private eof-marker (Object.))
+
+(defn- read-form-for-server
+  "Reads a single form from `pbr` (a `CapturingPushbackReader`) and returns a
+  map of `:form` and `:code` - the exact input text that was consumed - or
+  `::eof` when the input is exhausted.
+
+  The client never evaluates the form; it is read only to find its boundary
+  in the input stream (and to detect the exit/quit commands), while `:code`
+  is sent to the server verbatim. Reading is therefore deliberately
+  permissive: `*suppress-read*` keeps record and eval (`#=`) literals inert,
+  the resolver accepts unknown aliases/classes, and reader conditionals are
+  preserved - all of them are left for the server to actually interpret."
+  [^CapturingPushbackReader pbr]
+  (.clearCaptured pbr)
+  (binding [*suppress-read* true
+            *reader-resolver* permissive-reader-resolver]
+    (let [form (try
+                 (read {:eof eof-marker :read-cond :preserve} pbr)
+                 (catch java.io.IOException _
+                   ;; The input stream is gone (e.g. a closed pipe); there is
+                   ;; nothing left to read, so treat it as end of input.
+                   eof-marker))]
+      (if (identical? form eof-marker)
+        ::eof
+        {:form form
+         :code (str/trim (.getCaptured pbr))}))))
+
+(defn- skip-to-end-of-line
+  "Discards characters from `rdr` up to and including the next newline (or
+  end of input). Used to drop the rest of a line after a reader error, the
+  way `clojure.main`'s REPL does."
+  [^java.io.Reader rdr]
+  (try
+    (loop []
+      (let [c (.read rdr)]
+        (when-not (or (neg? c) (= c (int \newline)))
+          (recur))))
+    (catch java.io.IOException _ nil)))
+
 (defn- run-repl-with-transport
   [transport {:keys [prompt err out value]
               :or   {prompt #(print (str % "=> "))
@@ -111,22 +163,39 @@ Exit:      Control+D or (exit) or (quit)"
     ;; We take 50ms to listen to any greeting messages, and display the value
     ;; in the `:out` slot.
     (Thread/sleep 50)
-    (let [session (nrepl/client-session client)]
+    (let [session (nrepl/client-session client)
+          input-reader (CapturingPushbackReader. *in*)]
       (swap! running-repl assoc :transport transport :client session)
       (binding [*ns* *ns*]
         (loop []
           (prompt *ns*)
           (flush)
-          (let [input (read *in* false 'exit)]
-            (if (done? input)
+          (let [input (try
+                        (read-form-for-server input-reader)
+                        (catch Exception e
+                          ;; A broken form should never take the REPL down.
+                          ;; Report it and discard the rest of the line, like
+                          ;; clojure.main does; the reader is then guaranteed
+                          ;; to make progress on the next iteration.
+                          (err (str "Syntax error: "
+                                    (or (.getMessage e)
+                                        (some-> (.getCause e) .getMessage)
+                                        (str e))
+                                    "\n"))
+                          (flush)
+                          (skip-to-end-of-line input-reader)
+                          ::retry))]
+            (cond
+              (identical? ::retry input)
+              (recur)
+
+              (or (identical? ::eof input) (done? (:form input)))
               (clean-up-and-exit 0)
-              ;; Make sure the metadata read from *in* is preserved when we feed
-              ;; the form to nREPL.
-              (let [code-str (binding [*print-meta* true]
-                               (pr-str input))
-                    id (str "nrepl.cmdline-" (uuid))]
+
+              :else
+              (let [id (str "nrepl.cmdline-" (uuid))]
                 (swap! awaiting assoc id (promise))
-                (doseq [res (nrepl/message session {:op "eval" :code code-str :id id})]
+                (doseq [res (nrepl/message session {:op "eval" :code (:code input) :id id})]
                   (when (:ns res) (set! *ns* (create-ns (symbol (:ns res))))))
                 @(get @awaiting id)
                 (swap! awaiting dissoc id)

--- a/src/clojure/nrepl/cmdline.clj
+++ b/src/clojure/nrepl/cmdline.clj
@@ -16,7 +16,8 @@
    [nrepl.util.threading :as threading]
    [nrepl.version :as version])
   (:import
-   [java.io FileNotFoundException]))
+   [clojure.lang LineNumberingPushbackReader]
+   [java.io FileNotFoundException IOException]))
 
 (defn- clean-up-and-exit
   "Performs any necessary clean up and calls `(System/exit status)`."
@@ -87,6 +88,58 @@ Exit:      Control+D or (exit) or (quit)"
           (System/getProperty "java.vm.name")
           (System/getProperty "java.runtime.version")))
 
+(def ^:private permissive-reader-resolver
+  "A reader resolver that accepts any alias or class name. Used when reading
+  user input purely to find form boundaries (see `read-form-for-server`):
+  aliases and classes may exist only in the server's session, so the client
+  must not reject them (this is what lets `::alias/kw` reach the server)."
+  (reify clojure.lang.LispReader$Resolver
+    (currentNS [_] 'user)
+    (resolveClass [_ sym] sym)
+    (resolveAlias [_ sym] sym)
+    (resolveVar [_ sym] sym)))
+
+(def ^:private eof-marker (Object.))
+
+(defn- read-form-for-server
+  "Reads a single form from `rdr` and returns a map of `:form` and `:code` -
+  the exact input text that was consumed - or `::eof` when the input is
+  exhausted.
+
+  The client never evaluates the form; it is read only to find its boundary
+  in the input stream (and to detect the exit/quit commands), while `:code`
+  is sent to the server verbatim. Reading is therefore deliberately
+  permissive: `*suppress-read*` keeps record and tagged literals inert, the
+  resolver accepts unknown aliases/classes, and reader conditionals are
+  preserved - all of them are left for the server to actually interpret.
+
+  `*read-eval*` is off because `*suppress-read*` does not cover `#=`: the
+  reader would otherwise evaluate it here, in the client, and the server
+  would then evaluate the same text again. A `#=` form is rejected outright
+  instead."
+  [^LineNumberingPushbackReader rdr]
+  (binding [*suppress-read* true
+            *read-eval* false
+            *reader-resolver* permissive-reader-resolver]
+    (let [[form code] (try
+                        (read+string {:eof eof-marker :read-cond :preserve} rdr)
+                        (catch IOException _
+                          ;; The input stream is gone (e.g. a closed pipe);
+                          ;; there is nothing left to read, so treat it as
+                          ;; end of input.
+                          [eof-marker nil]))]
+      (if (identical? form eof-marker)
+        ::eof
+        {:form form :code code}))))
+
+(defn- skip-to-end-of-line
+  "Discards the rest of the current line. Used after a reader error, the way
+  `clojure.main`'s REPL does."
+  [^LineNumberingPushbackReader rdr]
+  (try
+    (.readLine rdr)
+    (catch IOException _ nil)))
+
 (defn- run-repl-with-transport
   [transport {:keys [prompt err out value]
               :or   {prompt #(print (str % "=> "))
@@ -111,22 +164,39 @@ Exit:      Control+D or (exit) or (quit)"
     ;; We take 50ms to listen to any greeting messages, and display the value
     ;; in the `:out` slot.
     (Thread/sleep 50)
-    (let [session (nrepl/client-session client)]
+    (let [session (nrepl/client-session client)
+          input-reader (LineNumberingPushbackReader. *in*)]
       (swap! running-repl assoc :transport transport :client session)
       (binding [*ns* *ns*]
         (loop []
           (prompt *ns*)
           (flush)
-          (let [input (read *in* false 'exit)]
-            (if (done? input)
+          (let [input (try
+                        (read-form-for-server input-reader)
+                        (catch Exception e
+                          ;; A broken form should never take the REPL down.
+                          ;; Report it and discard the rest of the line, like
+                          ;; clojure.main does; the reader is then guaranteed
+                          ;; to make progress on the next iteration.
+                          (err (str "Syntax error: "
+                                    (or (ex-message e)
+                                        (some-> (ex-cause e) ex-message)
+                                        (str e))
+                                    "\n"))
+                          (flush)
+                          (skip-to-end-of-line input-reader)
+                          ::retry))]
+            (cond
+              (identical? ::retry input)
+              (recur)
+
+              (or (identical? ::eof input) (done? (:form input)))
               (clean-up-and-exit 0)
-              ;; Make sure the metadata read from *in* is preserved when we feed
-              ;; the form to nREPL.
-              (let [code-str (binding [*print-meta* true]
-                               (pr-str input))
-                    id (str "nrepl.cmdline-" (uuid))]
+
+              :else
+              (let [id (str "nrepl.cmdline-" (uuid))]
                 (swap! awaiting assoc id (promise))
-                (doseq [res (nrepl/message session {:op "eval" :code code-str :id id})]
+                (doseq [res (nrepl/message session {:op "eval" :code (:code input) :id id})]
                   (when (:ns res) (set! *ns* (create-ns (symbol (:ns res))))))
                 @(get @awaiting id)
                 (swap! awaiting dissoc id)

--- a/src/java/nrepl/in/CapturingPushbackReader.java
+++ b/src/java/nrepl/in/CapturingPushbackReader.java
@@ -1,0 +1,76 @@
+package nrepl.in;
+
+import java.io.IOException;
+import java.io.PushbackReader;
+import java.io.Reader;
+
+/**
+ * A PushbackReader that records every character it reads into an internal
+ * buffer (removing it again on unread), so that the exact text consumed by a
+ * read can be recovered afterwards via {@link #getCaptured()}. Used by the
+ * built-in command-line client to find a form's boundary while keeping the
+ * original input text to send to the server verbatim.
+ *
+ * <p>Only single-character {@code read()}/{@code unread(int)} are capture-aware
+ * (that is all Clojure's LispReader uses). The bulk {@code read(char[], ...)}
+ * methods route through {@code read()} so they stay consistent, but the bulk
+ * {@code unread(char[])} methods are unsupported rather than silently
+ * corrupting the capture.
+ */
+public class CapturingPushbackReader extends PushbackReader {
+    private final StringBuilder captured = new StringBuilder();
+
+    public CapturingPushbackReader(Reader in) {
+        super(in);
+    }
+
+    /** Returns the text consumed since the last {@link #clearCaptured()}. */
+    public String getCaptured() {
+        return captured.toString();
+    }
+
+    /** Discards the captured text, e.g. before reading the next form. */
+    public void clearCaptured() {
+        captured.setLength(0);
+    }
+
+    @Override
+    public int read() throws IOException {
+        int c = super.read();
+        if (c != -1) {
+            captured.append((char) c);
+        }
+        return c;
+    }
+
+    @Override
+    public void unread(int c) throws IOException {
+        int len = captured.length();
+        if (len > 0) {
+            captured.setLength(len - 1);
+        }
+        super.unread(c);
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        for (int n = 0; n < len; n++) {
+            int c = read();
+            if (c == -1) {
+                return n == 0 ? -1 : n;
+            }
+            cbuf[off + n] = (char) c;
+        }
+        return len;
+    }
+
+    @Override
+    public void unread(char[] cbuf, int off, int len) {
+        throw new UnsupportedOperationException("bulk unread is not capture-aware");
+    }
+
+    @Override
+    public void unread(char[] cbuf) {
+        throw new UnsupportedOperationException("bulk unread is not capture-aware");
+    }
+}

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -201,6 +201,75 @@
                                :value #(swap! results conj %)})
               (is (= expected-output @results)))))))))
 
+(deftest raw-input-handling
+  ;; The client reads input only to find form boundaries and sends the raw
+  ;; text to the server, so reader context that exists only in the server
+  ;; session (aliases, data readers) doesn't matter on the client, and broken
+  ;; input can't kill the REPL.
+  (with-open [^Server server (server/start-server :handler (server/default-handler))]
+    (let [drive (fn [input]
+                  (let [>devnull (fn [& _] nil)
+                        values (atom [])
+                        errors (atom "")]
+                    (binding [*in* (java.io.PushbackReader. (java.io.StringReader. input))]
+                      (with-redefs [cmd/clean-up-and-exit >devnull]
+                        (#'cmd/run-repl "127.0.0.1" (:port server)
+                                        {:prompt >devnull
+                                         :err #(swap! errors str %)
+                                         :out >devnull
+                                         :value #(swap! values conj %)})))
+                    {:values @values :errors @errors}))]
+      (testing "a reader typo doesn't kill the session"
+        (let [{:keys [values errors]} (drive ")\n(+ 1 2)")]
+          (is (= ["3"] values))
+          (is (str/includes? errors "Unmatched delimiter"))))
+      (testing "tagged literals unknown to the client are read by the server"
+        (let [{:keys [values errors]} (drive "#nosuch/tag 42\n(+ 1 2)")]
+          (is (= ["3"] values))
+          (is (str/includes? errors "No reader function for tag nosuch/tag"))))
+      (testing "auto-resolved keywords use the server session's aliases"
+        (let [{:keys [values]} (drive "(require '[clojure.string :as zzz])\n::zzz/foo")]
+          (is (= ["nil" ":clojure.string/foo"] values))))
+      (testing "multi-line forms work"
+        (is (= ["3"] (:values (drive "(+ 1\n2)")))))
+      (testing "reader conditionals are passed through to the server"
+        (is (= ["1"] (:values (drive "#?(:clj 1 :cljs 2)")))))
+      (testing "#_ discard is sent along with the following form"
+        (is (= ["42"] (:values (drive "#_(/ 1 0) 42")))))
+      (testing "metadata reaches the server without client-side re-printing"
+        (is (= ["true"] (:values (drive "(:foo (meta (quote ^:foo bar)))")))))
+      (testing "the exit command stops the loop before remaining input"
+        (is (= ["3"] (:values (drive "(+ 1 2)\nexit\n(+ 7 8)")))))
+      (testing "after a reader error the rest of the line is discarded (not re-read)"
+        ;; `)foo` must not sneak `foo` through to the server as a real eval.
+        (let [{:keys [values errors]} (drive ")foo\n(+ 1 2)")]
+          (is (str/includes? errors "Unmatched delimiter"))
+          (is (= ["3"] values))))
+      (testing "EOF in the middle of a form ends the loop instead of hanging"
+        (is (= ["3"] (:values (drive "(+ 1 2)\n(+ 4"))))))))
+
+(deftest read-form-for-server-passthrough
+  ;; The client reads only to find the form boundary; literals that would
+  ;; throw under *read-eval* false (records, #=) or that the client can't
+  ;; resolve (aliased keywords, unknown tags) are read inertly and their
+  ;; exact text is handed to the server verbatim.
+  (let [read-one (fn [s]
+                   (let [rdr (nrepl.in.CapturingPushbackReader.
+                              (java.io.PushbackReader. (java.io.StringReader. s)))]
+                     (#'cmd/read-form-for-server rdr)))]
+    (are [input expected-code] (= expected-code (:code (read-one input)))
+      "#clojure.lang.PersistentQueue[]" "#clojure.lang.PersistentQueue[]"
+      "#=(+ 1 1)"                       "#=(+ 1 1)"
+      "#nosuch/tag 42"                  "#nosuch/tag 42"
+      "::zzz/foo"                       "::zzz/foo"
+      "(+ 1\n  2)"                      "(+ 1\n  2)")
+    (testing "only the first form is consumed, leaving the rest for the next read"
+      (let [rdr (nrepl.in.CapturingPushbackReader.
+                 (java.io.PushbackReader. (java.io.StringReader. "(+ 1 2) (+ 3 4)")))]
+        (is (= "(+ 1 2)" (:code (#'cmd/read-form-for-server rdr))))
+        (is (= "(+ 3 4)" (:code (#'cmd/read-form-for-server rdr))))
+        (is (= :nrepl.cmdline/eof (#'cmd/read-form-for-server rdr)))))))
+
 ;;; Unix domain socket tests
 
 (defn send-jdk-socket-message [message path]

--- a/test/clojure/nrepl/cmdline_test.clj
+++ b/test/clojure/nrepl/cmdline_test.clj
@@ -17,6 +17,7 @@
    [nrepl.test-helpers :refer [eval-value1 free-port is+ with-process]]
    [nrepl.transport :as transport])
   (:import
+   (clojure.lang LineNumberingPushbackReader)
    (java.lang ProcessBuilder$Redirect)
    (java.net Socket SocketAddress)
    (java.nio.channels Channels SocketChannel)
@@ -200,6 +201,86 @@
                                :out >devnull
                                :value #(swap! results conj %)})
               (is (= expected-output @results)))))))))
+
+(deftest raw-input-handling
+  ;; The client reads input only to find form boundaries and sends the raw
+  ;; text to the server, so reader context that exists only in the server
+  ;; session (aliases, data readers) doesn't matter on the client, and broken
+  ;; input can't kill the REPL.
+  (with-open [^Server server (server/start-server :handler (server/default-handler))]
+    (let [drive (fn [input]
+                  (let [>devnull (fn [& _] nil)
+                        values (atom [])
+                        errors (atom "")]
+                    (binding [*in* (java.io.StringReader. input)]
+                      (with-redefs [cmd/clean-up-and-exit >devnull]
+                        (#'cmd/run-repl "127.0.0.1" (:port server)
+                                        {:prompt >devnull
+                                         :err #(swap! errors str %)
+                                         :out >devnull
+                                         :value #(swap! values conj %)})))
+                    {:values @values :errors @errors}))]
+      (testing "a reader typo doesn't kill the session"
+        (let [{:keys [values errors]} (drive ")\n(+ 1 2)")]
+          (is (= ["3"] values))
+          (is (str/includes? errors "Unmatched delimiter"))))
+      (testing "tagged literals unknown to the client are read by the server"
+        (let [{:keys [values errors]} (drive "#nosuch/tag 42\n(+ 1 2)")]
+          (is (= ["3"] values))
+          (is (str/includes? errors "No reader function for tag nosuch/tag"))))
+      (testing "auto-resolved keywords use the server session's aliases"
+        (let [{:keys [values]} (drive "(require '[clojure.string :as zzz])\n::zzz/foo")]
+          (is (= ["nil" ":clojure.string/foo"] values))))
+      (testing "multi-line forms work"
+        (is (= ["3"] (:values (drive "(+ 1\n2)")))))
+      (testing "reader conditionals are passed through to the server"
+        (is (= ["1"] (:values (drive "#?(:clj 1 :cljs 2)")))))
+      (testing "#_ discard is sent along with the following form"
+        (is (= ["42"] (:values (drive "#_(/ 1 0) 42")))))
+      (testing "metadata reaches the server without client-side re-printing"
+        (is (= ["true"] (:values (drive "(:foo (meta (quote ^:foo bar)))")))))
+      (testing "the exit command stops the loop before remaining input"
+        (is (= ["3"] (:values (drive "(+ 1 2)\nexit\n(+ 7 8)")))))
+      (testing "after a reader error the rest of the line is discarded (not re-read)"
+        ;; `)foo` must not sneak `foo` through to the server as a real eval.
+        (let [{:keys [values errors]} (drive ")foo\n(+ 1 2)")]
+          (is (str/includes? errors "Unmatched delimiter"))
+          (is (= ["3"] values))))
+      (testing "EOF in the middle of a form ends the loop instead of hanging"
+        (is (= ["3"] (:values (drive "(+ 1 2)\n(+ 4"))))))))
+
+(deftest read-form-for-server-passthrough
+  ;; The client reads only to find the form boundary; literals that would
+  ;; throw under *read-eval* false (records, #=) or that the client can't
+  ;; resolve (aliased keywords, unknown tags) are read inertly and their
+  ;; exact text is handed to the server verbatim.
+  (let [read-one (fn [s]
+                   (let [rdr (LineNumberingPushbackReader.
+                              (java.io.StringReader. s))]
+                     (#'cmd/read-form-for-server rdr)))]
+    (are [input expected-code] (= expected-code (:code (read-one input)))
+      "#clojure.lang.PersistentQueue[]" "#clojure.lang.PersistentQueue[]"
+      "#nosuch/tag 42"                  "#nosuch/tag 42"
+      "::zzz/foo"                       "::zzz/foo"
+      "(+ 1\n  2)"                      "(+ 1\n  2)")
+    (testing "tagged literals are held inert rather than constructed"
+      (are [input] (instance? clojure.lang.TaggedLiteral (:form (read-one input)))
+        "#clojure.lang.PersistentQueue[]"
+        "#nosuch/tag 42"))
+    (testing "#= is rejected instead of being evaluated in the client"
+      ;; *suppress-read* doesn't cover #=, so without *read-eval* false the
+      ;; reader runs it here and the server then runs the same text again.
+      (let [ran (atom false)]
+        (intern 'nrepl.cmdline-test 'mark-ran (fn [] (reset! ran true)))
+        (is (thrown-with-msg? RuntimeException #"EvalReader not allowed"
+                              (read-one "#=(nrepl.cmdline-test/mark-ran)")))
+        (is (false? @ran))))
+    (testing "only the first form is consumed, leaving the rest for the next read"
+      (let [rdr (LineNumberingPushbackReader.
+                 (java.io.StringReader. "(+ 1 2) (+ 3 4)"))]
+        (is (= "(+ 1 2)" (:code (#'cmd/read-form-for-server rdr))))
+        (is (= "(+ 3 4)" (:code (#'cmd/read-form-for-server rdr))))
+        (is (= :nrepl.cmdline/eof (#'cmd/read-form-for-server rdr)))))))
 
 ;;; Unix domain socket tests
 


### PR DESCRIPTION
The interactive built-in client read each form with its own reader and re-printed it before sending it on, which made the *client's* reader the first to see your code. Anything it couldn't handle took the whole REPL down: a stray `)`, a custom tagged literal, or an auto-resolved keyword like `::io/foo` whose alias only exists in the server's session (#182 - deceptively worked under `--interactive` since client and server share a JVM there).

Now the client reads input only to find where each top-level form ends, captures the exact source text with `read+string` and sends it to the server verbatim, so the server's reader is the only one that interprets the code. The boundary read is defused: `*suppress-read*` holds record and tagged literals inert, a permissive `*reader-resolver*` accepts unknown aliases and classes, and reader conditionals are preserved. `*read-eval*` is off too - `*suppress-read*` doesn't cover `#=`, so otherwise the reader evaluates it client-side and the server then evaluates the same text again. Reader errors print and discard the rest of the line like `clojure.main` instead of crashing, and a closed input stream ends the loop cleanly.

Fixes #182.

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your changes.
- [x] You've updated the [changelog](../CHANGELOG.md) (only applies to user-visible changes)