### PR TITLE
Consume stdin responses explicitly in the request-*in* tests

### DIFF
--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -643,22 +643,20 @@
     (is (thrown? SocketException (repl-eval session "(+ 1 1)")))))
 
 (def-repl-test request-*in*
-  (is (= '((1 2 3)) (response-values (for [resp (repl-eval session "(read)")]
-                                       (do
-                                         (when (-> resp clean-response :status (contains? :need-input))
-                                           (session {:op "stdin" :stdin "(1 2 3)"}))
-                                         resp)))))
+  (let [responses (repl-eval session "(read)")]
+    (is+ {:status (mc/via #(map keyword %) [:need-input])} (first responses))
+    (session {:op "stdin" :stdin "(1 2 3)"})
+    (is+ {:value "(1 2 3)"} (second responses)))
 
   (session {:op "stdin" :stdin (th/newline->sys "a\nb\nc\n")})
   (doseq [x "abc"]
     (is (= [(str x)] (repl-values session "(read-line)")))))
 
 (def-repl-test request-*in*-eof
-  (is+ nil? (response-values (for [resp (repl-eval session "(read)")]
-                               (do
-                                 (when (-> resp clean-response :status (contains? :need-input))
-                                   (session {:op "stdin" :stdin []}))
-                                 resp)))))
+  (let [responses (repl-eval session "(read)")]
+    (is+ {:status (mc/via #(map keyword %) [:need-input])} (first responses))
+    (session {:op "stdin" :stdin []})
+    (is+ nil? (response-values responses))))
 
 (def-repl-test request-multiple-read-newline-*in*
   ;; Verify that when ":ohai\n" is supplied (with a newline), a `(read)`
@@ -673,20 +671,18 @@
   (is+ ["a"] (repl-values session "(read-line)")))
 
 (def-repl-test request-multiple-read-with-buffered-newline-*in*
-  (is+ [:ohai] (response-values (for [resp (repl-eval session "(read)")]
-                                  (do
-                                    (when (-> resp clean-response :status (contains? :need-input))
-                                      (session {:op "stdin" :stdin (th/newline->sys ":ohai\na\n")}))
-                                    resp))))
+  (let [responses (repl-eval session "(read)")]
+    (is+ {:status (mc/via #(map keyword %) [:need-input])} (first responses))
+    (session {:op "stdin" :stdin (th/newline->sys ":ohai\na\n")})
+    (is+ {:value ":ohai"} (second responses)))
 
   (is+ ["a"] (repl-values session "(read-line)")))
 
 (def-repl-test request-multiple-read-objects-*in*
-  (is+ [:ohai] (response-values (for [resp (repl-eval session "(read)")]
-                                  (do
-                                    (when (-> resp clean-response :status (contains? :need-input))
-                                      (session {:op "stdin" :stdin (th/newline->sys ":ohai :kthxbai\n")}))
-                                    resp))))
+  (let [responses (repl-eval session "(read)")]
+    (is+ {:status (mc/via #(map keyword %) [:need-input])} (first responses))
+    (session {:op "stdin" :stdin (th/newline->sys ":ohai :kthxbai\n")})
+    (is+ {:value ":ohai"} (second responses)))
 
   (is+ [" :kthxbai"] (repl-values session "(read-line)")))
 


### PR DESCRIPTION
Following #460, the rest of the `request-*in*` tests still had the same shape that made `request-multiple-read-newline` flaky: the stdin `session` send was buried inside a lazy `for` over the response seq that `response-values` only realized later, so the send fired at a nondeterministic point during realization.

This rewrites the remaining four the same way #460 did the first: force the first response, assert it's `need-input`, send stdin, then force and assert the value. No behavior change, just deterministic consumption with the side effect out of the lazy seq.

Verified locally across both transports, including full-namespace runs.

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your changes.
- [ ] You've updated the [changelog](../CHANGELOG.md) (only applies to user-visible changes)
