### PR TITLE
[ci] Tune test matrices

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ jobs:
             - store_test_results:
                 path: test-results
 
-  test_windows:
+  test-windows:
     description: |
       Run tests on MS-Windows using the system's JDK version and Clojure 1.12.
     executor: win/default
@@ -184,47 +184,46 @@ workflows:
     jobs:
       - test:
           matrix:
-            alias: "test-jdk8"
+            alias: "test-1.12"
             parameters:
-              clojure_version: ["1.9", "1.10", "1.11", "1.12", "1.13"]
-              jdk_version: [jdk8]
+              clojure_version: ["1.12"]
+              jdk_version: [jdk17, jdk21, jdk25, jdk26]
+          <<: *run_always
+      - test:
+          matrix:
+            alias: "test-1.12-junixsocket"
+            parameters:
+              clojure_version: ["1.12"]
+              jdk_version: [jdk8, jdk11]
               # JDK8 and 11 need junitsocket library to support sockets as
               # connection target.
               extra_aliases: [":+junixsocket"]
           <<: *run_always
       - test:
           matrix:
-            alias: "test-jdk11"
+            alias: "test-1.13"
             parameters:
-              # JDK11 is the last tested version that needs junitsocket library
-              # to support sockets as connection target.
-              clojure_version: ["1.12"]
-              jdk_version: [jdk11]
-              extra_aliases: [":+junixsocket"]
+              clojure_version: ["1.13"]
+              jdk_version: [jdk17, jdk21, jdk25, jdk26]
           <<: *run_always
       - test:
           matrix:
-            alias: "test-older-jdk"
+            alias: "test-older"
             parameters:
-              clojure_version: ["1.12"]
-              jdk_version: [jdk17, jdk21, jdk25]
+              clojure_version: ["1.10", "1.11"]
+              jdk_version: [jdk8, jdk26]
           <<: *run_always
-      - test:
-          matrix:
-            alias: "test"
-            parameters:
-              clojure_version: ["1.10", "1.11", "1.12", "1.13"]
-              jdk_version: [jdk26]
-          <<: *run_always
-      - test_windows:
+      - test-windows:
           <<: *run_always
       - lint:
           <<: *run_always
       - deploy:
           requires:
-            - test-jdk8
-            - test-jdk11
-            - test-older-jdk
+            - test-1.12
+            - test-1.12-junixsocket
+            - test-1.13
+            - test-older
+            - test-windows
             - lint
           filters:
             branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changes
 
+- [#462](https://github.com/nrepl/nrepl/pull/462): **(Breaking)** Raise minimal supported Clojure version to 1.10.
 - [#284](https://github.com/nrepl/nrepl/issues/284): Include the `-f`/`--repl-fn` option in the command-line help output.
 - [#376](https://github.com/nrepl/nrepl/issues/376): Document the `session-closed` status returned by the `close` op.
 

--- a/deps.edn
+++ b/deps.edn
@@ -23,8 +23,8 @@
   :1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
   :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
-  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.4"}}}
-  :1.13 {:override-deps {org.clojure/clojure {:mvn/version "1.13.0-alpha2"}}}
+  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.5"}}}
+  :1.13 {:override-deps {org.clojure/clojure {:mvn/version "1.13.0-alpha5"}}}
 
   :+junixsocket {:extra-deps {com.kohlschutter.junixsocket/junixsocket-common {:mvn/version "2.10.1"}
                               com.kohlschutter.junixsocket/junixsocket-native-common {:mvn/version "2.10.1"}}}


### PR DESCRIPTION
Same as https://github.com/clojure-emacs/orchard/pull/420.

Also, raise min Clojure version yet again to 1.10. Long overdue, besides, 1.9 is not compativle with anything post JDK8.