### PR TITLE
Use contextClassLoader in session middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#284](https://github.com/nrepl/nrepl/issues/284): Include the `-f`/`--repl-fn` option in the command-line help output.
 - [#376](https://github.com/nrepl/nrepl/issues/376): Document the `session-closed` status returned by the `close` op.
+- [#464](https://github.com/nrepl/nrepl/pull/464): Revert an earlier change that broke use of custom classloaders via `setContextClassLoader`
 
 ## 1.7.0 (2026-04-14)
 

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -138,10 +138,11 @@
         ;; TODO: new options: out-quota | err-quota
         opts {::print/buffer-size (or out-limit (get (meta session) :out-limit))}
         out (print/replying-PrintWriter :out msg opts)
-        err (print/replying-PrintWriter :err msg opts)]
+        err (print/replying-PrintWriter :err msg opts)
+        ctxcl (.getContextClassLoader (Thread/currentThread))]
     (-> bindings-map
         (assoc #'*msg* msg
-               Compiler/LOADER (classloader/dynamic-classloader)
+               Compiler/LOADER ctxcl
                #'*out* out
                #'*err* err
                ;; clojure.test captures *out* at load-time, so we need to make


### PR DESCRIPTION
Partially reverts commit d3e1d1a2acafe5423599485f8dd2310a3687bbed "Minor code aesthetics", because it breaks use of custom classloaders like `lambdaisland.classpath/priority-classloader`.

Given the commit message I suspect this semantic change was not intentional. As a result of that change hot reloading of dependencies in lambdaisland.classpath and Launchpad has been broken since nrepl 1.6.0-alpha3.

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your changes.
- [x] You've updated the [changelog](../CHANGELOG.md) (only applies to user-visible changes)

