### PR TITLE
Update the docs and changelog for the next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,18 @@
 ### Changes
 
 - [#462](https://github.com/nrepl/nrepl/pull/462): **(Breaking)** Raise minimal supported Clojure version to 1.10.
+- [#144](https://github.com/nrepl/nrepl/issues/144): Document more middleware development best practices.
+- [#257](https://github.com/nrepl/nrepl/issues/257): Document the `lookup` op's return values.
 - [#284](https://github.com/nrepl/nrepl/issues/284): Include the `-f`/`--repl-fn` option in the command-line help output.
 - [#376](https://github.com/nrepl/nrepl/issues/376): Document the `session-closed` status returned by the `close` op.
-- [#464](https://github.com/nrepl/nrepl/pull/464): Revert an earlier change that broke use of custom classloaders via `setContextClassLoader`
 - [#458](https://github.com/nrepl/nrepl/pull/458): Document the TLS security model and include the `--tls-keys-file`/`--tls-keys-str` options in the command-line help output.
-- [#458](https://github.com/nrepl/nrepl/pull/458): Report descriptive errors for invalid TLS key material (missing, legacy-format or encrypted private keys, missing certificates) and preserve the underlying exception causes.
 - [#458](https://github.com/nrepl/nrepl/pull/458): Detect and accept a swapped CA/own certificate order in TLS key material containing exactly two certificates.
 - [#458](https://github.com/nrepl/nrepl/pull/458): Support Ed25519 (PKCS#8) private keys for TLS on Java 15+.
+
+### Bugs fixed
+
+- [#464](https://github.com/nrepl/nrepl/pull/464): Revert an earlier change that broke use of custom classloaders via `setContextClassLoader`.
+- [#458](https://github.com/nrepl/nrepl/pull/458): Report descriptive errors for invalid TLS key material (missing, legacy-format or encrypted private keys, missing certificates) instead of NPEs and generic JSSE messages.
 
 ## 1.7.0 (2026-04-14)
 

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,6 @@
                      nubank/matcher-combinators {:mvn/version "3.9.1"
                                                  :exclusions [org.clojure/clojure]}}}
 
-  :1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
   :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
   :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.5"}}}

--- a/doc/modules/ROOT/pages/about/compatibility.adoc
+++ b/doc/modules/ROOT/pages/about/compatibility.adoc
@@ -13,7 +13,7 @@ This is currently Java 8, 11, 17, 21, and 25.
 
 == Clojure
 
-nREPL targets Clojure 1.9+. As Clojure doesn't have the concept of supported releases
+nREPL targets Clojure 1.10+. As Clojure doesn't have the concept of supported releases
 we have to get a bit creative to determine the minimum version to target.
 
 The minimum required Clojure version is currently derived using data
@@ -49,9 +49,13 @@ Below you can find the official compatibility matrix for nREPL.
 | 8
 | 1.8
 
-| 1.7+
+| 1.7.x
 | 8
 | 1.9
+
+| 1.8+
+| 8
+| 1.10
 
 |===
 

--- a/doc/modules/ROOT/pages/about/compatibility.adoc
+++ b/doc/modules/ROOT/pages/about/compatibility.adoc
@@ -9,7 +9,7 @@ nREPL officially targets LTS releases and the most recent rapid
 release version.  More generally speaking - we aim to support all
 Java releases that are currently officially supported by Oracle.
 
-This is currently Java 8, 11, 17, 21, and 25.
+This is currently Java 8, 11, 17, 21, 25, and 26.
 
 == Clojure
 

--- a/doc/modules/ROOT/pages/faq.adoc
+++ b/doc/modules/ROOT/pages/faq.adoc
@@ -9,7 +9,7 @@ happened during the migration:
 * The artifact id changed from `org.clojure/clojure.tools.nrepl` to `nrepl/nrepl`.
 * The namespace prefix changed from `clojure.tools.nrepl` to `nrepl`.
 * The namespace `clojure.tools.nrepl` was renamed to `nrepl.core`.
-* Minimal requirements changed from Java 6 and Clojure 1.2 to Java 8 and Clojure 1.7 (currently Java 8 and Clojure 1.9).
+* Minimal requirements changed from Java 6 and Clojure 1.2 to Java 8 and Clojure 1.7 (currently Java 8 and Clojure 1.10).
 * All the code which existed for compatibility with nREPL 0.0.x was removed.
 
 == What's the plural form of "middleware"?

--- a/doc/modules/ROOT/pages/installation.adoc
+++ b/doc/modules/ROOT/pages/installation.adoc
@@ -2,7 +2,7 @@
 
 [NOTE]
 ====
-nREPL is compatible with Clojure 1.9+ and Java 8+.
+nREPL is compatible with Clojure 1.10+ and Java 8+.
 ====
 
 nREPL is a library (as opposed to it being an application), so it's

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -106,7 +106,7 @@ See xref:usage/tls.adoc[TLS support] for setup instructions.
 
 If you experience problems running `lein repl`:
 
-* Make sure your project uses Clojure 1.9+ and Java 8+.
+* Make sure your project uses Clojure 1.10+ and Java 8+.
 * Make sure you're using the latest versions of nREPL middleware.
 * If Leiningen bundles an older nREPL version, you can override it by adding
 `nrepl` as an explicit dependency in your `project.clj`.

--- a/doc/modules/ROOT/pages/usage/server.adoc
+++ b/doc/modules/ROOT/pages/usage/server.adoc
@@ -9,7 +9,7 @@ popular options available for you today.
 
 === Using Clojure CLI tools
 
-NOTE: This section assumes you're using Clojure 1.9+.
+NOTE: This section assumes you're using Clojure 1.10+.
 
 If you're into the `clj` command you can take advantage of nREPL's built-in command-line interface
 (`nrepl.cmdline`).

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -968,6 +968,27 @@
       (is good?)))
   (reset! captured-values-atom {}))
 
+(def-repl-test custom-context-classloader-is-used-for-loading
+  ;; Libraries like lambdaisland.classpath install their own classloader as the
+  ;; session thread's context classloader. Loading during eval has to resolve
+  ;; through it - binding Compiler/LOADER to a DynamicClassLoader ancestor
+  ;; instead silently bypasses it (see #464).
+  (testing "a custom context classloader ends up in the chain used for loading"
+    (repl-values session
+                 (code
+                  (let [t (Thread/currentThread)
+                        new-cl (clojure.lang.DynamicClassLoader.
+                                (.getContextClassLoader t))]
+                    (.setContextClassLoader t new-cl)
+                    (nrepl.core-test/capture-value "custom-cl" new-cl))))
+    (let [[in-chain?] (repl-values session
+                                   (code
+                                    (contains? (set (nrepl.core-test/classloader-hierarchy
+                                                     (clojure.lang.RT/baseLoader)))
+                                               (@nrepl.core-test/captured-values-atom "custom-cl"))))]
+      (is in-chain?)))
+  (reset! captured-values-atom {}))
+
 (def-repl-test sanity-tests
   (testing "eval"
     (are [expr result] (= result (first (repl-values session (code expr))))


### PR DESCRIPTION
The Clojure 1.10 minimum landed as part of a CI matrix change (see https://github.com/nrepl/nrepl/pull/462), so nothing outside the changelog knew about it - the docs still said 1.9 everywhere and deps.edn kept an alias nothing used. This catches the rest up, adds Java 26 to the compatibility page (it's been in CI since the JDK26 refactor), and sorts the unreleased changelog entries into Changes and Bugs fixed like the released sections do.

Also adds a regression test for #464. That break slipped in unnoticed inside a commit about code aesthetics, and reverting the fix today still leaves the whole suite green. Worth noting for anyone touching this later: reading `Compiler/LOADER` from evaluated code doesn't work as a probe, because `Compiler.eval` pushes a fresh loader of its own every time. The test asserts on the parent chain `RT/baseLoader` hands to loading instead.