### PR TITLE
Retire nrepl.misc/requiring-resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 - [#462](https://github.com/nrepl/nrepl/pull/462): **(Breaking)** Raise minimal supported Clojure version to 1.10.
+- [#466](https://github.com/nrepl/nrepl/pull/466): **(Breaking)** Remove `nrepl.misc/requiring-resolve` in favour of `clojure.core/requiring-resolve`.
 - [#144](https://github.com/nrepl/nrepl/issues/144): Document more middleware development best practices.
 - [#257](https://github.com/nrepl/nrepl/issues/257): Document the `lookup` op's return values.
 - [#284](https://github.com/nrepl/nrepl/issues/284): Include the `-f`/`--repl-fn` option in the command-line help output.
@@ -20,6 +21,7 @@
 ### Bugs fixed
 
 - [#464](https://github.com/nrepl/nrepl/pull/464): Revert an earlier change that broke use of custom classloaders via `setContextClassLoader`.
+- [#466](https://github.com/nrepl/nrepl/pull/466): Serialize namespace loading when resolving client-supplied vars, so concurrent sessions can't race on `require`.
 - [#458](https://github.com/nrepl/nrepl/pull/458): Report descriptive errors for invalid TLS key material (missing, legacy-format or encrypted private keys, missing certificates) instead of NPEs and generic JSSE messages.
 
 ## 1.7.0 (2026-04-14)

--- a/doc/modules/ROOT/pages/building_middleware.adoc
+++ b/doc/modules/ROOT/pages/building_middleware.adoc
@@ -41,7 +41,7 @@ Optionally you can have some dynamic vars for configuration purposes. Below is a
 (defn completion-reply
   [{:keys [session prefix ns complete-fn options] :as msg}]
   (let [ns (if ns (symbol ns) (symbol (str (@session #'*ns*))))
-        completion-fn (or (and complete-fn (misc/requiring-resolve (symbol complete-fn))) *complete-fn*)]
+        completion-fn (or (and complete-fn (requiring-resolve (symbol complete-fn))) *complete-fn*)]
     (try
       (response-for msg {:status :done :completions (completion-fn prefix ns options)})
       (catch Exception e

--- a/src/clojure/nrepl/middleware/caught.clj
+++ b/src/clojure/nrepl/middleware/caught.clj
@@ -28,7 +28,10 @@
 
 (defn- resolve-caught [msg]
   (when-let [var-sym (some-> (::caught msg) (symbol))]
-    (let [caught-var (misc/requiring-resolve var-sym)]
+    (let [caught-var (try
+                       (requiring-resolve var-sym)
+                       ;; See the note in nrepl.middleware.print/resolve-print.
+                       (catch Exception _ nil))]
       (when-not caught-var
         (transport/respond-to msg {::error (str "Couldn't resolve var " var-sym)
                                    :status ::error}))

--- a/src/clojure/nrepl/middleware/completion.clj
+++ b/src/clojure/nrepl/middleware/completion.clj
@@ -33,7 +33,10 @@
 (defn completion-reply
   [{:keys [prefix ns complete-fn options] :as msg}]
   (let [the-ns (if ns (symbol ns) (symbol (str (misc/resolve-in-session msg *ns*))))
-        completion-fn (or (some-> complete-fn symbol misc/requiring-resolve)
+        completion-fn (or (try
+                            (some-> complete-fn symbol requiring-resolve)
+                            ;; See the note in nrepl.middleware.lookup.
+                            (catch Exception _ nil))
                           (misc/resolve-in-session msg *complete-fn*))]
     {:status :done
      :completions (completion-fn prefix the-ns (parse-options options))}))

--- a/src/clojure/nrepl/middleware/lookup.clj
+++ b/src/clojure/nrepl/middleware/lookup.clj
@@ -28,7 +28,11 @@
   [{:keys [session sym ns lookup-fn] :as msg}]
   (let [the-ns (if ns (symbol ns) (symbol (str (@session #'*ns*))))
         sym (symbol sym)
-        lookup-fn (or (some-> lookup-fn symbol misc/requiring-resolve)
+        lookup-fn (or (try
+                        (some-> lookup-fn symbol requiring-resolve)
+                        ;; An unresolvable client-supplied fn falls back to the
+                        ;; session's, rather than failing the request.
+                        (catch Exception _ nil))
                       (misc/resolve-in-session msg *lookup-fn*))]
     {:status :done, :info (lookup-fn the-ns sym)}))
 

--- a/src/clojure/nrepl/middleware/print.clj
+++ b/src/clojure/nrepl/middleware/print.clj
@@ -130,7 +130,11 @@
 (defn- resolve-print
   [{:keys [::print] :as msg}]
   (when-let [var-sym (some-> print (symbol))]
-    (let [print-var (misc/requiring-resolve var-sym)]
+    (let [print-var (try
+                      (requiring-resolve var-sym)
+                      ;; The symbol comes from the client, so a missing
+                      ;; namespace or an unqualified name is a user error.
+                      (catch Exception _ nil))]
       (when-not print-var
         (transport/respond-to msg {::error (str "Couldn't resolve var " var-sym)
                                    :status ::error}))

--- a/src/clojure/nrepl/misc.clj
+++ b/src/clojure/nrepl/misc.clj
@@ -2,7 +2,6 @@
   "Misc utilities used in nREPL's implementation (potentially also
   useful for anyone extending it)."
   {:author "Chas Emerick"}
-  (:refer-clojure :exclude [requiring-resolve])
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [nrepl.config :refer [config]]))
@@ -89,19 +88,6 @@
   the nREPL server context, not in the user session context."
   [msg dynvar]
   `(get (some-> (:session ~msg) deref) (var ~dynvar) ~dynvar))
-
-(defn requiring-resolve
-  "Resolves namespace-qualified sym per 'resolve'. If initial resolve fails,
-  attempts to require sym's namespace and retries. Returns nil if sym could not
-  be resolved."
-  [sym & [log?]]
-  (or (resolve sym)
-      (try
-        (require (symbol (namespace sym)))
-        (resolve sym)
-        (catch Exception e
-          (when log?
-            (log e))))))
 
 (defmacro with-session-classloader
   "Bind `clojure.lang.Compiler/LOADER` to the context classloader. This is

--- a/src/clojure/nrepl/server.clj
+++ b/src/clojure/nrepl/server.clj
@@ -11,7 +11,7 @@
    nrepl.middleware.lookup
    nrepl.middleware.print
    nrepl.middleware.session
-   [nrepl.misc :as misc :refer [log log-exceptions response-for]]
+   [nrepl.misc :refer [log log-exceptions response-for]]
    [nrepl.socket :as socket :refer [inet-socket unix-server-socket]]
    [nrepl.tls :as tls]
    [nrepl.transport :as t]
@@ -235,5 +235,5 @@
       (log-exceptions
        (accept-connection-loop server consume-exception)))
     (when ack-port
-      ((misc/requiring-resolve 'nrepl.ack/send-ack) (:port server) ack-port transport-fn))
+      ((requiring-resolve 'nrepl.ack/send-ack) (:port server) ack-port transport-fn))
     server))

--- a/src/clojure/nrepl/tls.clj
+++ b/src/clojure/nrepl/tls.clj
@@ -9,7 +9,6 @@
   as a developer. I'm so sorry about all of this."
   {:added "1.1"}
   (:require [clojure.java.io :as io :refer [input-stream]]
-            [clojure.stacktrace]
             [clojure.string :as str])
   (:import (java.net InetSocketAddress)
            (java.security KeyFactory

--- a/src/clojure/nrepl/util/lookup.clj
+++ b/src/clojure/nrepl/util/lookup.clj
@@ -15,7 +15,7 @@
   [sym]
   ;; clojure.repl/special-doc is private, so we need to work a
   ;; bit to be able to invoke it
-  (let [f (misc/requiring-resolve 'clojure.repl/special-doc)]
+  (let [f (requiring-resolve 'clojure.repl/special-doc)]
     (assoc (f sym)
            :ns "clojure.core"
            :file "clojure/core.clj"

--- a/src/clojure/nrepl/util/threading.clj
+++ b/src/clojure/nrepl/util/threading.clj
@@ -57,7 +57,7 @@
     (catch NoSuchMethodException _)))
 
 (defn- jvmti-stop-thread [t]
-  ((misc/requiring-resolve 'nrepl.util.jvmti/stop-thread) t))
+  ((requiring-resolve 'nrepl.util.jvmti/stop-thread) t))
 
 (defn- try-stop-thread [^Thread t]
   (cond

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -1,5 +1,4 @@
 (ns nrepl.core-test
-  (:refer-clojure :exclude [requiring-resolve])
   (:require
    [clojure.java.io :as io]
    [clojure.main]
@@ -23,7 +22,7 @@
    [nrepl.middleware.caught :as middleware.caught]
    [nrepl.middleware.print :as middleware.print]
    [nrepl.middleware.session :as session]
-   [nrepl.misc :refer [uuid requiring-resolve]]
+   [nrepl.misc :refer [uuid]]
    [nrepl.server :as server]
    [nrepl.test-helpers :as th :refer [is+ win?]]
    [nrepl.util.classloader]

--- a/test/clojure/nrepl/middleware/completion_test.clj
+++ b/test/clojure/nrepl/middleware/completion_test.clj
@@ -28,6 +28,15 @@
            nrepl/combine-responses
            clean-response)))
 
+(def-repl-test completions-op-unresolvable-custom-fn
+  ;; An unresolvable :complete-fn falls back to the default rather than failing
+  ;; the request, whether its namespace is missing or it isn't qualified.
+  (doseq [bad ["my.missing.ns/complete" "unqualified"]]
+    (is+ {:status #{:done}, :completions (mc/embeds [{:candidate "map"}])}
+         (-> (nrepl/message session {:op "completions" :prefix "map" :ns "clojure.core" :complete-fn bad})
+             nrepl/combine-responses
+             clean-response))))
+
 (def-repl-test completions-op-custom-fn
   (is+ {:status #{:done}, :completions [{:candidate "map"}]}
        (-> (nrepl/message session {:op "completions" :prefix "map" :ns "clojure.core" :complete-fn "nrepl.middleware.completion-test/dummy-completion"})

--- a/test/clojure/nrepl/middleware/lookup_test.clj
+++ b/test/clojure/nrepl/middleware/lookup_test.clj
@@ -45,3 +45,12 @@
        (-> (nrepl/message session {:op "lookup" :sym "map" :ns "clojure.core" :lookup-fn "nrepl.middleware.lookup-test/dummy-lookup"})
            nrepl/combine-responses
            clean-response)))
+
+(def-repl-test lookup-op-unresolvable-custom-fn
+  ;; An unresolvable :lookup-fn falls back to the default rather than failing
+  ;; the request, whether its namespace is missing or it isn't qualified.
+  (doseq [bad ["my.missing.ns/lookup" "unqualified"]]
+    (is+ {:status #{:done}, :info {:name "map"}}
+         (-> (nrepl/message session {:op "lookup" :sym "map" :ns "clojure.core" :lookup-fn bad})
+             nrepl/combine-responses
+             clean-response))))

--- a/test/clojure/nrepl/util/jvmti_test.clj
+++ b/test/clojure/nrepl/util/jvmti_test.clj
@@ -7,7 +7,7 @@
   (deftest stop-thread-test
     (let [vol (volatile! 0)
           t (doto (Thread. #(while (vswap! vol inc))) .start)]
-      ((misc/requiring-resolve 'nrepl.util.jvmti/stop-thread) t)
+      ((requiring-resolve 'nrepl.util.jvmti/stop-thread) t)
       (Thread/sleep 1000)
       (let [v @vol]
         (Thread/sleep 500)


### PR DESCRIPTION
Ours predates the one Clojure grew in 1.10, and the only thing it added was a `log?` arity nothing ever used - paid for by shadowing core's in every namespace that needed it. Call sites now use core's directly.

Worth knowing they aren't drop-in equivalents: ours returned nil for anything it couldn't resolve, core's throws on a missing namespace or an unqualified symbol. Where the symbol is one of ours a failure is a bug and should surface, so those call it bare. Where it comes from the client (`::print`, `::caught`, `lookup-fn`, `complete-fn`) the existing error and fallback paths depend on nil, so those keep it - `print` and `caught` already had tests pinning that, `lookup-fn`/`complete-fn` didn't and do now.

Side benefit: loading goes through `serialized-require`, so sessions resolving vars concurrently can't race on `require`.

`building_middleware.adoc` used it in an example, so that's updated too. Also drops a `clojure.stacktrace` require in `nrepl.tls` that nothing used.

Based on #465, since the changelog entries belong in the sections that adds.