### PR TITLE
Correct nrepl.spec's key types for describe and ls-sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [#466](https://github.com/nrepl/nrepl/pull/466): Serialize namespace loading when resolving client-supplied vars, so concurrent sessions can't race on `require`.
 - [#458](https://github.com/nrepl/nrepl/pull/458): Report descriptive errors for invalid TLS key material (missing, legacy-format or encrypted private keys, missing certificates) instead of NPEs and generic JSSE messages.
 - [#182](https://github.com/nrepl/nrepl/issues/182): The built-in client now sends input to the server as raw text instead of reading it client-side, so reader typos, auto-resolved keywords relying on session aliases (e.g. `::io/foo`) and custom tagged literals no longer crash the REPL.
+- [#468](https://github.com/nrepl/nrepl/pull/468): Fix `nrepl.spec` key types for the `describe` and `ls-sessions` responses, which never matched what the server sends.
 
 ## 1.7.0 (2026-04-14)
 

--- a/src/clojure/nrepl/spec.clj
+++ b/src/clojure/nrepl/spec.clj
@@ -18,12 +18,12 @@
                                     (str/lower-case %))))
 
 (s/def ::session (s/or :single ::uuid-str
-                       :multi  (s/coll-of ::uuid-str :kind? set?)))
+                       :multi  (s/coll-of ::uuid-str :kind set?)))
 
 (s/def ::id string?)
 
 (s/def ::status (s/or :single keyword?
-                      :multi  (s/coll-of keyword? :kind? set?)))
+                      :multi  (s/coll-of keyword? :kind set?)))
 
 ;; Parameters for Clone
 
@@ -52,15 +52,15 @@
 
 (s/def ::doc string?)
 
-(s/def ::requires (s/map-of keyword? string?))
+(s/def ::requires (s/map-of string? string?))
 
-(s/def ::optional (s/map-of keyword? string?))
+(s/def ::optional (s/map-of string? string?))
 
-(s/def ::returns (s/map-of keyword? string?))
+(s/def ::returns (s/map-of string? string?))
 
 (s/def ::description (s/keys :opt-un [::doc ::requires ::optional ::returns]))
 
-(s/def ::ops (s/map-of keyword? ::description))
+(s/def ::ops (s/map-of string? ::description))
 
 (s/def ::major (s/or :integer int?
                      :string  string?))
@@ -158,7 +158,7 @@
 
 ;; `sessions`: Returns sessions in a set
 
-(s/def ::sessions (s/coll-of ::uuid-str :kind? set?))
+(s/def ::sessions (s/coll-of ::uuid-str))
 
 ;; Parameters for Std In
 

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -211,10 +211,11 @@
            combine-responses
            clean-response))
   (let [session-id (new-session timeout-client)
-        session-alive? #(contains? (-> (message timeout-client {:op "ls-sessions"})
-                                       combine-responses
-                                       :sessions
-                                       set)
+        session-alive? #(contains? (->> (message timeout-client {:op "ls-sessions"})
+                                        (map clean-response)
+                                        combine-responses
+                                        :sessions
+                                        set)
                                    session-id)]
     (is session-id)
     (is (session-alive?))

--- a/test/clojure/nrepl/describe_test.clj
+++ b/test/clojure/nrepl/describe_test.clj
@@ -4,7 +4,7 @@
    [clojure.test :refer [is testing use-fixtures]]
    [matcher-combinators.matchers :as mc]
    [nrepl.core :as nrepl]
-   [nrepl.core-test :refer [def-repl-test repl-server-fixture]]
+   [nrepl.core-test :refer [clean-response def-repl-test repl-server-fixture]]
    [nrepl.middleware :as middleware]
    [nrepl.server :as server]
    [nrepl.test-helpers :refer [is+]]
@@ -36,14 +36,16 @@
                      "#'nrepl.middleware.print/wrap-print"
                      "#'nrepl.middleware.session/add-stdin"
                      "#'nrepl.middleware.session/session"]}
-       (nrepl/combine-responses
-        (nrepl/message timeout-client {:op "describe"}))))
+       (->> (nrepl/message timeout-client {:op "describe"})
+            (map clean-response)
+            nrepl/combine-responses)))
 
 (def-repl-test verbose-describe
   (is+ {:ops (mc/all-of
               (mc/via #(set (map name (keys %))) built-in-ops)
               (fn [ops] (every? #(seq (:doc %)) (vals ops))))
         :aux {:current-ns "user"}}
-       (nrepl/combine-responses
-        (nrepl/message timeout-client
-                       {:op "describe" :verbose? "true"}))))
+       (->> (nrepl/message timeout-client
+                           {:op "describe" :verbose? "true"})
+            (map clean-response)
+            nrepl/combine-responses)))


### PR DESCRIPTION
Four specs described a shape the server has never produced, and the response check that should have caught them never ran on either op.

`::ops`, `::requires`, `::optional` and `::returns` declared keyword keys against string-keyed middleware descriptors. For `::ops` that's the pre-#139 world - op names were stringified in April 2019 to settle #138, and the spec landed that September still describing the old shape, having been drafted before the decision. The other three have been string keyed since 2018 and never matched anything.

`::sessions` claimed a set while `ls-sessions` returns the session registry's keys, i.e. a seq. That one hid behind `:kind?`, which isn't an `s/coll-of` option, so it was silently ignored everywhere it appeared - the set constraint on `::session` and `::status` had never applied either. Those two really are sets, so they keep it, spelled `:kind` now.

Rather than change the wire format to satisfy a spec line that has never once executed, the spec now says what the server does.

The reason all four survived is that response validation only runs for messages routed through `clean-response`, and neither `describe` nor `ls-sessions` ever was. Both are now. `describe_test` couldn't have caught it incidentally either - it compares op names with `(map name (keys ops))`, and `name` treats strings and keywords alike.