### PR TITLE
Don't ask for stdin that is already arriving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#458](https://github.com/nrepl/nrepl/pull/458): Report descriptive errors for invalid TLS key material (missing, legacy-format or encrypted private keys, missing certificates) instead of NPEs and generic JSSE messages.
 - [#182](https://github.com/nrepl/nrepl/issues/182): The built-in client now sends input to the server as raw text instead of reading it client-side, so reader typos, auto-resolved keywords relying on session aliases (e.g. `::io/foo`) and custom tagged literals no longer crash the REPL.
 - [#468](https://github.com/nrepl/nrepl/pull/468): Fix `nrepl.spec` key types for the `describe` and `ls-sessions` responses, which never matched what the server sends.
+- [#469](https://github.com/nrepl/nrepl/pull/469): Stop emitting a spurious `need-input` while a `stdin` payload is still being enqueued, which could make a client send input that nothing had asked for.
 
 ## 1.7.0 (2026-04-14)
 

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -51,17 +51,25 @@
    can provide content to be read."
   [session-id transport]
   (let [input-queue (LinkedBlockingQueue.)
+        ;; A "stdin" payload is enqueued one character at a time, so an empty
+        ;; queue may just mean we looked in the middle of a message that is
+        ;; already arriving. `add-stdin` holds this lock for the whole payload,
+        ;; so taking it before asking the client for more input tells us
+        ;; whether the queue is really empty.
+        input-lock (Object.)
         request-input #(or (.poll input-queue)
                            ;; Skipping newlines shouldn't trigger need-input
                            ;; from the client if queue is empty.
                            (when-not *skipping-eol*
-                             (t/send transport
-                                     (response-for *msg* :session session-id
-                                                   :status :need-input))
-                             (.take input-queue)))
+                             (or (locking input-lock (.poll input-queue))
+                                 (do (t/send transport
+                                             (response-for *msg* :session session-id
+                                                           :status :need-input))
+                                     (.take input-queue)))))
         reader (LineNumberingPushbackReader.
                 (QueuePollingReader. input-queue request-input))]
     {:input-queue input-queue
+     :input-lock input-lock
      :stdin-reader reader}))
 
 (let [state (atom {})]
@@ -180,7 +188,7 @@
   `register-session` has to be called next."
   ([{:keys [transport session out-limit] :as msg}]
    (let [id (uuid)
-         {:keys [input-queue stdin-reader]} (session-in id transport)
+         {:keys [input-queue input-lock stdin-reader]} (session-in id transport)
          new-session (atom (assoc (if session
                                     @session
                                     (gather-initial-bindings msg))
@@ -189,7 +197,8 @@
                            :meta {:id id
                                   :out-limit (or out-limit (:out-limit (meta session)))
                                   :stdin-reader stdin-reader
-                                  :input-queue input-queue})]
+                                  :input-queue input-queue
+                                  :input-lock input-lock})]
      (alter-meta! new-session assoc :exec (make-ephemeral-exec-fn new-session msg))
      new-session)))
 
@@ -410,10 +419,15 @@
           (clojure.main/skip-if-eol in))))
 
     (if (= op "stdin")
-      (let [^LinkedBlockingQueue q (:input-queue (meta session))]
+      (let [{:keys [input-queue input-lock]} (meta session)
+            ^LinkedBlockingQueue q input-queue]
         (if (empty? stdin)
           (.put q -1)
-          (.addAll q (seq stdin)))
+          ;; Enqueue the whole payload before a reader can conclude the queue
+          ;; is empty, so it doesn't ask the client for input that is already
+          ;; on its way.
+          (locking input-lock
+            (.addAll q (seq stdin))))
         (t/respond-to msg :status :done))
       (h msg))))
 


### PR DESCRIPTION
Patched twice on the test side (#452, #460), but the bug is in the server.

`add-stdin` enqueues stdin one character at a time via `LinkedBlockingQueue.addAll`, which isn't atomic, so a reader can find the queue empty mid-payload and ask for input it's already been sent. Clients answer that, and the unrequested input gets picked up by the next read - the stray `:ohai` from #452. The enqueue now takes a lock and `request-input` re-checks under it.

Couldn't get it to repro end-to-end on demand; driving the queue and `request-input` directly gives a spurious `need-input` in ~2% of runs, none with the lock. No test changes on purpose - the existing tests assert exactly one `need-input`, which is the invariant that was broken.