### PR TITLE
[session] Make adding stdin input to queue atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#458](https://github.com/nrepl/nrepl/pull/458): Report descriptive errors for invalid TLS key material (missing, legacy-format or encrypted private keys, missing certificates) instead of NPEs and generic JSSE messages.
 - [#182](https://github.com/nrepl/nrepl/issues/182): The built-in client now sends input to the server as raw text instead of reading it client-side, so reader typos, auto-resolved keywords relying on session aliases (e.g. `::io/foo`) and custom tagged literals no longer crash the REPL.
 - [#468](https://github.com/nrepl/nrepl/pull/468): Fix `nrepl.spec` key types for the `describe` and `ls-sessions` responses, which never matched what the server sends.
+- [#470](https://github.com/nrepl/nrepl/pull/470): [session] Fix race condition between stdin consumer and producer.
 
 ## 1.7.0 (2026-04-14)
 

--- a/src/clojure/nrepl/middleware/interruptible_eval.clj
+++ b/src/clojure/nrepl/middleware/interruptible_eval.clj
@@ -54,6 +54,18 @@
   (try (.getName (io/file source-path))
        (catch Exception _)))
 
+(defn- skip-stdin-newline []
+  ;; NB: confusing hack. When `(read)` is issued to an input stream, it
+  ;; returns a Lisp form, ending with the last character of the form,
+  ;; naturally (e.g. a closing paren). However, it is expected that any
+  ;; trailing newline after such form is thrown away in order for a
+  ;; subsequent `(read-line)` call to not just return that empty newline but
+  ;; the actual following content. To simulate this behavior, we run
+  ;; this newline-skipping function after every `eval` request.
+  ;; Note that we check if stdin is ready in order not to block if it is empty.
+  (when (.ready ^PushbackReader *in*)
+    (clojure.main/skip-if-eol *in*)))
+
 (defn evaluator
   "Return a closure that evaluates msg's `:code` (either a string or a seq of
   forms to be evaluated) within the dynamic context of its session. `:ns` can be
@@ -155,6 +167,7 @@
           (caught e))
         (finally
           (flush)
+          (skip-stdin-newline)
           (pop-thread-bindings))))))
 
 (defn interruptible-eval

--- a/src/clojure/nrepl/middleware/session.clj
+++ b/src/clojure/nrepl/middleware/session.clj
@@ -2,7 +2,6 @@
   "Support for persistent, cross-connection REPL sessions."
   {:author "Chas Emerick"}
   (:require
-   clojure.main
    [nrepl.config :refer [config]]
    [nrepl.middleware :refer [set-descriptor!]]
    [nrepl.middleware.interruptible-eval :refer [*msg*]]
@@ -37,32 +36,20 @@
 ;; depending upon the expectations of the client/user.  I'm not sure at the moment
 ;; how best to make it configurable though...
 
-(def ^:dynamic ^:private *skipping-eol* false)
-
 (def ephemeral-executor
   "Executor for running eval requests in ephemeral sessions."
   (delay (Executors/newCachedThreadPool
           (threading/thread-factory "nREPL-ephemeral-session-%d"))))
 
 (defn- session-in
-  "Returns a LineNumberingPushbackReader suitable for binding to *in*.
-   When something attempts to read from it, it will (if empty) send a
-   {:status :need-input} message on the provided transport so the client/user
-   can provide content to be read."
+  "Returns a QueuePollingReader (that is suitable for binding to *in* when
+  wrapped into LineNumberingPushbackReader). When something attempts to read
+  from it, it will (if empty) send a {:status :need-input} message on the
+  provided transport so the client/user can provide content to be read."
   [session-id transport]
-  (let [input-queue (LinkedBlockingQueue.)
-        request-input #(or (.poll input-queue)
-                           ;; Skipping newlines shouldn't trigger need-input
-                           ;; from the client if queue is empty.
-                           (when-not *skipping-eol*
-                             (t/send transport
-                                     (response-for *msg* :session session-id
-                                                   :status :need-input))
-                             (.take input-queue)))
-        reader (LineNumberingPushbackReader.
-                (QueuePollingReader. input-queue request-input))]
-    {:input-queue input-queue
-     :stdin-reader reader}))
+  (QueuePollingReader. #(t/send transport
+                                (response-for *msg* :session session-id
+                                              :status :need-input))))
 
 (let [state (atom {})]
   (defn- dynvar-defaults-from-config []
@@ -180,16 +167,15 @@
   `register-session` has to be called next."
   ([{:keys [transport session out-limit] :as msg}]
    (let [id (uuid)
-         {:keys [input-queue stdin-reader]} (session-in id transport)
+         qpr (session-in id transport)
          new-session (atom (assoc (if session
                                     @session
                                     (gather-initial-bindings msg))
-                                  #'*in* stdin-reader
+                                  #'*in* (LineNumberingPushbackReader. qpr)
                                   #'*ns* (create-ns 'user))
                            :meta {:id id
                                   :out-limit (or out-limit (:out-limit (meta session)))
-                                  :stdin-reader stdin-reader
-                                  :input-queue input-queue})]
+                                  ::queue-reader qpr})]
      (alter-meta! new-session assoc :exec (make-ephemeral-exec-fn new-session msg))
      new-session)))
 
@@ -397,23 +383,11 @@
   a :stdin slot to the session's *in* Reader. Requires the session middleware."
   [h]
   (fn [{:keys [op stdin session] :as msg}]
-    ;; NB: confusing hack. When `(read)` is issued to an input stream, it
-    ;; returns a Lisp form, ending with the last character of the form,
-    ;; naturally (e.g. a closing paren). However, it is expected that any
-    ;; trailing newline after such form is thrown away in order for a
-    ;; subsequent `(read-line)` call to not just return that empty newline but
-    ;; the actual following content. To simulate this behavior, we run
-    ;; newline-skipping function before every `eval` request.
-    (when (= op "eval")
-      (let [in (:stdin-reader (meta session))]
-        (binding [*skipping-eol* true]
-          (clojure.main/skip-if-eol in))))
-
     (if (= op "stdin")
-      (let [^LinkedBlockingQueue q (:input-queue (meta session))]
+      (let [^QueuePollingReader qpr (::queue-reader (meta session))]
         (if (empty? stdin)
-          (.put q -1)
-          (.addAll q (seq stdin)))
+          (.addEof qpr)
+          (.addInput qpr stdin))
         (t/respond-to msg :status :done))
       (h msg))))
 

--- a/src/java/nrepl/in/QueuePollingReader.java
+++ b/src/java/nrepl/in/QueuePollingReader.java
@@ -6,16 +6,80 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * An implementation of Reader which, when read is attempted, pulls characters
- * out of a wrapped LinkedBlockingQueue.
+ * out of a wrapped LinkedBlockingQueue. Not fully thread-safe! The producers
+ * should only interact with the thread-safe queue (via addInput() and addEof()
+ * methods), and there should be only one consumer thread.
  */
 public class QueuePollingReader extends Reader {
 
-    private final LinkedBlockingQueue queue;
-    private final IFn requestInput;
+    private static final String EOF_MARKER = new String();
 
-    public QueuePollingReader(LinkedBlockingQueue queue, IFn requestInput) {
-        this.queue = queue;
-        this.requestInput = requestInput;
+    private final IFn sendNeedInputRequest;
+    private final LinkedBlockingQueue<String> queue;
+
+    private String currentInput = null;
+    private int currentInputIndex = 0;
+
+    public QueuePollingReader(IFn sendNeedInputRequest) {
+        this.queue = new LinkedBlockingQueue<>();
+        this.sendNeedInputRequest = sendNeedInputRequest;
+    }
+
+    /** Return the next input char only if it's already present in the buffer or
+     * in the queue. Return -1 if the char is not available, or -2 if the EOF
+     * marker is found.
+     */
+    private int pollInputChar() {
+        while (true) {
+            if (currentInput == EOF_MARKER) {
+                // Intentionally don't clear EOF marker, let the caller do it.
+                return -2;
+            }
+            if (currentInput != null && currentInputIndex < currentInput.length()) {
+                char c = currentInput.charAt(currentInputIndex);
+                return c;
+            }
+            currentInputIndex = 0;
+            currentInput = queue.poll();
+            if (currentInput == null) return -1;
+        }
+    }
+
+    /** Return the next input char. If the buffer and queue is empty, and
+     * blockOnEmpty is true, send the :need-input message to the client and
+     * block on the queue until next input is available. Return -1 if EOF is
+     * reached or if blockOnEmpty is false.
+     */
+    private int readInputChar(boolean blockOnEmpty) {
+        while (true) {
+            int c = pollInputChar();
+            switch (c) {
+            case -2:
+                currentInput = null; // Clear EOF marker
+                return -1;
+            case -1:
+                if (blockOnEmpty) {
+                    sendNeedInputRequest.invoke();
+                    try { currentInput = queue.take(); }
+                    catch (InterruptedException ex) {
+                        Thread.currentThread().interrupt();
+                        return -1;
+                    }
+                    continue;
+                } else return -1;
+            default:
+                currentInputIndex++; // Advance read pointer
+                return c;
+            }
+        }
+    }
+
+    public void addInput(String input) {
+        queue.add(input);
+    }
+
+    public void addEof() {
+        queue.add(EOF_MARKER);
     }
 
     @Override
@@ -24,22 +88,26 @@ public class QueuePollingReader extends Reader {
     }
 
     @Override
+    public boolean ready() throws IOException {
+        return pollInputChar() >= 0;
+    }
+
+    @Override
     public int read(char[] buf, int off, int len) throws IOException {
         if (len == 0) return 0;
 
-        // First char reading will cause `needs-input` message to be sent to the
-        // client (if the queue doesn't contain data already). This logic is
-        // implemented inside requestInput function.
-        Object firstChar = requestInput.invoke();
-        if (firstChar == null || firstChar.equals(-1)) return -1;
+        // First char taken from an empty queue will cause `needs-input` message
+        // to be sent to the client.
+        int firstChar = readInputChar(true);
+        if (firstChar < 0) return -1;
         buf[off] = (char)firstChar;
 
-        // For subsuquent read chars, only poll the queue for data already
+        // For subsequent read chars, only poll the queue for data already
         // there, and when queue becomes empty, return the number of chars read.
         int i = 1;
         while (i < len) {
-            Object c = queue.poll();
-            if (c == null) break;
+            int c = readInputChar(false);
+            if (c < 0) break;
             buf[off + i++] = (char)c;
         }
         return i;

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -649,8 +649,9 @@
     (is+ {:value "(1 2 3)"} (second responses)))
 
   (session {:op "stdin" :stdin (th/newline->sys "a\nb\nc\n")})
-  (doseq [x "abc"]
-    (is (= [(str x)] (repl-values session "(read-line)")))))
+  (is+ ["a"] (repl-values session "(read-line)"))
+  (is+ ["b"] (repl-values session "(read-line)"))
+  (is+ ["c"] (repl-values session "(read-line)")))
 
 (def-repl-test request-*in*-eof
   (let [responses (repl-eval session "(read)")]


### PR DESCRIPTION
Alternative solution to #469.

The issue is indeed with a race between the producer adding characters one-by-one with non-atomic `.addAll` and the consumer that blocks halfway into reading the input.

I don't like using a lock as a solution. Even if it won't deadlock right now, the shape of the code may change sometime in the future where it might. It's also not immediately obvious to me what the scope of the lock should be. Also, it is important to make sure that the consumer holding the lock doesn't block the producer from proceeding.

The proposed solution reverts to using a queue as a single source of truth (and which already handles concurrency correctly). Whole strings are put onto the queue. Then, a string is fed out char-by-char to the consumer. A small added benefit is that we don't copy the string into sequences of chars or even char arrays, very minor, but still.

Spent a lot of time trying to simplify `*skipping-eol*` thing, didn't work the way I wanted because of the damn outer PushbackReader. Tried making QPR extend PushbackReader – bleh, need to override many unrelated methods, not too pretty.

---

- [x] You've updated the [changelog](../CHANGELOG.md) (only applies to user-visible changes)