### PR TITLE
Report stdin EOF that arrives behind buffered input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [#182](https://github.com/nrepl/nrepl/issues/182): The built-in client now sends input to the server as raw text instead of reading it client-side, so reader typos, auto-resolved keywords relying on session aliases (e.g. `::io/foo`) and custom tagged literals no longer crash the REPL.
 - [#468](https://github.com/nrepl/nrepl/pull/468): Fix `nrepl.spec` key types for the `describe` and `ls-sessions` responses, which never matched what the server sends.
 - [#470](https://github.com/nrepl/nrepl/pull/470): [session] Fix race condition between stdin consumer and producer.
+- [#472](https://github.com/nrepl/nrepl/pull/472): Report stdin EOF that arrives behind buffered input, instead of asking the client for more input that will never come.
 
 ## 1.7.0 (2026-04-14)
 

--- a/src/java/nrepl/in/QueuePollingReader.java
+++ b/src/java/nrepl/in/QueuePollingReader.java
@@ -45,12 +45,11 @@ public class QueuePollingReader extends Reader {
         }
     }
 
-    /** Return the next input char. If the buffer and queue is empty, and
-     * blockOnEmpty is true, send the :need-input message to the client and
-     * block on the queue until next input is available. Return -1 if EOF is
-     * reached or if blockOnEmpty is false.
+    /** Return the next input char. If the buffer and the queue are empty, send
+     * the :need-input message to the client and block on the queue until the
+     * next input is available. Return -1 if EOF is reached.
      */
-    private int readInputChar(boolean blockOnEmpty) {
+    private int readInputChar() {
         while (true) {
             int c = pollInputChar();
             switch (c) {
@@ -58,15 +57,13 @@ public class QueuePollingReader extends Reader {
                 currentInput = null; // Clear EOF marker
                 return -1;
             case -1:
-                if (blockOnEmpty) {
-                    sendNeedInputRequest.invoke();
-                    try { currentInput = queue.take(); }
-                    catch (InterruptedException ex) {
-                        Thread.currentThread().interrupt();
-                        return -1;
-                    }
-                    continue;
-                } else return -1;
+                sendNeedInputRequest.invoke();
+                try { currentInput = queue.take(); }
+                catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    return -1;
+                }
+                continue;
             default:
                 currentInputIndex++; // Advance read pointer
                 return c;
@@ -98,7 +95,7 @@ public class QueuePollingReader extends Reader {
 
         // First char taken from an empty queue will cause `needs-input` message
         // to be sent to the client.
-        int firstChar = readInputChar(true);
+        int firstChar = readInputChar();
         if (firstChar < 0) return -1;
         buf[off] = (char)firstChar;
 
@@ -106,8 +103,11 @@ public class QueuePollingReader extends Reader {
         // there, and when queue becomes empty, return the number of chars read.
         int i = 1;
         while (i < len) {
-            int c = readInputChar(false);
+            // Peek, so that an EOF marker stays in place and is reported by the
+            // next read() instead of being swallowed here.
+            int c = pollInputChar();
             if (c < 0) break;
+            currentInputIndex++;
             buf[off + i++] = (char)c;
         }
         return i;

--- a/test/clojure/nrepl/core_test.clj
+++ b/test/clojure/nrepl/core_test.clj
@@ -659,6 +659,13 @@
     (session {:op "stdin" :stdin []})
     (is+ nil? (response-values responses))))
 
+(def-repl-test request-*in*-eof-after-input
+  ;; EOF that arrives behind buffered input must still be reported, and not be
+  ;; swallowed by the read that drains that input.
+  (doall (timeout-session {:op "stdin" :stdin "abc"}))
+  (doall (timeout-session {:op "stdin" :stdin []}))
+  (is+ ["abc"] (repl-values timeout-session "(read-line)")))
+
 (def-repl-test request-multiple-read-newline-*in*
   ;; Verify that when ":ohai\n" is supplied (with a newline), a `(read)`
   ;; consumes :ohai but also consumes a newline, so that when we later give "a\n"


### PR DESCRIPTION
`{:op "stdin" :stdin "abc"}` followed by `{:op "stdin" :stdin []}` left `(read-line)` waiting on `need-input` instead of returning `"abc"`: the read that drained the buffered input took the EOF marker with it, so the end of input was never reported.

Predates #470. On the version before it the same input blew up with `ClassCastException: Long cannot be cast to Character`, so this is longstanding rather than a regression.
